### PR TITLE
Implement weekly reporting persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ Thumbs.db
 .vercel/
 out/
 apps/api/data/jobs.json
+apps/api/data/weekly-reports.json
+apps/api/data/report-exports/
 apps/api/data/*.tmp
 workflows/n8n/owner.env
 .playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you want optional Gmail draft creation, set `GMAIL_DRAFTS_ENABLED=true` and p
 
 ## Project Status
 
-Current phase: Phase 4 in progress. n8n workflow integration is underway.
+Current phase: Phase 5 in progress. Weekly reporting persistence and dashboards are now the active slice.
 
 What is real now:
 
@@ -123,7 +123,7 @@ What is real now:
 - live outreach inbox with drafted, approved, sent, and skipped states
 - optional Gmail draft creation behind a feature flag
 - browser-verified end-to-end outreach draft flow with optional Gmail draft creation
-- weekly report draft endpoint
+- weekly report draft endpoint, report storage, and dashboard
 - live Azure PostgreSQL storage behind `DATABASE_URL`
 - seed-backed dashboard fallback when the API is unavailable
 - API route scaffolds and validation
@@ -138,7 +138,7 @@ What is real now:
 What is still mocked or placeholder-based:
 
 - LLM provider integration is still mock-mode when no provider key is configured
-- weekly report persistence and dashboards
+- optional Blob Storage report exports with a local file fallback
 - outreach sending remains manual-only
 - full Azure hosting for the web and API apps
 - Blob Storage integration

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@azure/storage-blob": "^12.28.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",

--- a/apps/api/scripts/db-init.ts
+++ b/apps/api/scripts/db-init.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { readdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { Pool } from 'pg';
 
@@ -12,7 +13,7 @@ if (!databaseUrl) {
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(scriptDir, '..', '..', '..');
-const migrationPath = join(repoRoot, 'db', 'migrations', '001_core_tables.sql');
+const migrationDir = join(repoRoot, 'db', 'migrations');
 const seedPath = join(repoRoot, 'db', 'seed', 'sample_jobs.sql');
 
 function describeTarget(url: string) {
@@ -33,6 +34,14 @@ async function runSql(pool: Pool, label: string, filePath: string) {
   }
 }
 
+async function listMigrationFiles() {
+  const entries = await readdir(migrationDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+    .map((entry) => join(migrationDir, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+}
+
 async function main() {
   const pool = new Pool({
     connectionString: databaseUrl,
@@ -45,7 +54,9 @@ async function main() {
   try {
     console.log(`Connecting to ${describeTarget(databaseUrl)}`);
     await pool.query('select 1');
-    await runSql(pool, 'schema migration', migrationPath);
+    for (const migrationPath of await listMigrationFiles()) {
+      await runSql(pool, `schema migration ${migrationPath.split('\\').pop() ?? migrationPath}`, migrationPath);
+    }
     await runSql(pool, 'seed data', seedPath);
     console.log('Azure PostgreSQL bootstrap completed successfully.');
   } finally {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,7 @@ import { aiRouter } from '@/routes/ai';
 import { healthRouter } from '@/routes/health';
 import { jobsRouter } from '@/routes/jobs';
 import { n8nRouter } from '@/routes/n8n';
+import { reportsRouter } from '@/routes/reports';
 import { outreachRouter } from '@/routes/outreach';
 
 const mutatingMethods = new Set(['POST', 'PATCH', 'PUT', 'DELETE']);
@@ -52,6 +53,7 @@ export function createApp() {
   app.use('/api/jobs', jobsRouter);
   app.use('/api/ai', aiRouter);
   app.use('/api/outreach', outreachRouter);
+  app.use('/api/reports', reportsRouter);
   app.use('/api/n8n', n8nRouter);
 
   app.use((_request, response) => {

--- a/apps/api/src/data/mock-store.ts
+++ b/apps/api/src/data/mock-store.ts
@@ -316,7 +316,7 @@ jobs.push(
 
 const weeklyReports: WeeklyReportRecord[] = [
   {
-    id: randomUUID(),
+    id: '44444444-4444-4444-8444-444444444444',
     weekStart: '2026-05-11',
     weekEnd: '2026-05-17',
     jobsDiscovered: 14,
@@ -334,6 +334,7 @@ const weeklyReports: WeeklyReportRecord[] = [
     ],
     reportMarkdown:
       'This week focused on operational roles that reward workflow thinking. The strongest opportunities were the automation engineer and recruiting operations roles.',
+    createdAt: '2026-05-17T18:00:00.000Z',
   },
 ];
 
@@ -485,6 +486,9 @@ export function generateWeeklyReportBody(payload: WeeklyReportBody) {
     common_missing_skills: report.commonMissingSkills,
     recommended_next_actions: report.recommendations,
     report_markdown: report.reportMarkdown,
+    report_id: report.id,
+    created_at: report.createdAt,
+    report_url: report.reportUrl ?? null,
   };
 }
 

--- a/apps/api/src/data/report-store.postgres.ts
+++ b/apps/api/src/data/report-store.postgres.ts
@@ -1,0 +1,239 @@
+import type { PoolClient } from 'pg';
+import type { WeeklyReportRecord } from '@/types';
+import { getPool } from '@/lib/postgres';
+import { seedWeeklyReports } from '@/data/mock-store';
+
+type WeeklyReportRow = {
+  id: string;
+  week_start: string;
+  week_end: string;
+  jobs_discovered: number;
+  jobs_shortlisted: number;
+  jobs_applied: number;
+  outreach_drafted: number;
+  outreach_sent: number;
+  responses_received: number;
+  interviews: number;
+  common_missing_skills: unknown;
+  recommendations: unknown;
+  report_markdown: string;
+  report_url: string | null;
+  created_at: string;
+};
+
+let readyPromise: Promise<void> | null = null;
+
+function poolOrThrow() {
+  const pool = getPool();
+
+  if (!pool) {
+    throw new Error('Postgres is not configured. Set DATABASE_URL to enable the database-backed store.');
+  }
+
+  return pool;
+}
+
+function toTextArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((entry): entry is string => typeof entry === 'string');
+}
+
+function mapReport(row: WeeklyReportRow): WeeklyReportRecord {
+  return {
+    id: row.id,
+    weekStart: row.week_start,
+    weekEnd: row.week_end,
+    jobsDiscovered: row.jobs_discovered,
+    jobsShortlisted: row.jobs_shortlisted,
+    jobsApplied: row.jobs_applied,
+    outreachDrafted: row.outreach_drafted,
+    outreachSent: row.outreach_sent,
+    responsesReceived: row.responses_received,
+    interviews: row.interviews,
+    commonMissingSkills: toTextArray(row.common_missing_skills),
+    recommendations: toTextArray(row.recommendations),
+    reportMarkdown: row.report_markdown,
+    reportUrl: row.report_url ?? undefined,
+    createdAt: row.created_at,
+  };
+}
+
+async function ensureSeedData(client: PoolClient) {
+  const { rows } = await client.query<{ count: string }>('select count(*)::text as count from weekly_reports');
+  if (Number(rows[0]?.count ?? '0') > 0) {
+    return;
+  }
+
+  for (const report of seedWeeklyReports) {
+    await client.query(
+      `
+        insert into weekly_reports (
+          id,
+          week_start,
+          week_end,
+          jobs_discovered,
+          jobs_shortlisted,
+          jobs_applied,
+          outreach_drafted,
+          outreach_sent,
+          responses_received,
+          interviews,
+          common_missing_skills,
+          recommendations,
+          report_markdown,
+          report_url,
+          created_at
+        ) values (
+          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,$12::jsonb,$13,$14,$15
+        )
+        on conflict (id) do update set
+          week_start = excluded.week_start,
+          week_end = excluded.week_end,
+          jobs_discovered = excluded.jobs_discovered,
+          jobs_shortlisted = excluded.jobs_shortlisted,
+          jobs_applied = excluded.jobs_applied,
+          outreach_drafted = excluded.outreach_drafted,
+          outreach_sent = excluded.outreach_sent,
+          responses_received = excluded.responses_received,
+          interviews = excluded.interviews,
+          common_missing_skills = excluded.common_missing_skills,
+          recommendations = excluded.recommendations,
+          report_markdown = excluded.report_markdown,
+          report_url = excluded.report_url,
+          created_at = excluded.created_at
+      `,
+      [
+        report.id,
+        report.weekStart,
+        report.weekEnd,
+        report.jobsDiscovered,
+        report.jobsShortlisted,
+        report.jobsApplied,
+        report.outreachDrafted,
+        report.outreachSent,
+        report.responsesReceived,
+        report.interviews,
+        JSON.stringify(report.commonMissingSkills),
+        JSON.stringify(report.recommendations),
+        report.reportMarkdown,
+        report.reportUrl ?? null,
+        report.createdAt,
+      ],
+    );
+  }
+}
+
+async function ensureReady() {
+  if (readyPromise) {
+    await readyPromise;
+    return;
+  }
+
+  const pool = poolOrThrow();
+
+  readyPromise = (async () => {
+    const client = await pool.connect();
+    try {
+      await client.query('begin');
+      await ensureSeedData(client);
+      await client.query('commit');
+    } catch (error) {
+      await client.query('rollback');
+      throw error;
+    } finally {
+      client.release();
+    }
+  })();
+
+  try {
+    await readyPromise;
+  } finally {
+    readyPromise = null;
+  }
+}
+
+export async function listWeeklyReports(): Promise<WeeklyReportRecord[]> {
+  await ensureReady();
+  const pool = poolOrThrow();
+
+  const { rows } = await pool.query<WeeklyReportRow>(
+    'select * from weekly_reports order by created_at desc, week_end desc, week_start desc',
+  );
+
+  return rows.map(mapReport);
+}
+
+export async function saveWeeklyReport(report: WeeklyReportRecord): Promise<WeeklyReportRecord> {
+  await ensureReady();
+  const pool = poolOrThrow();
+
+  const { rows } = await pool.query<WeeklyReportRow>(
+    `
+      insert into weekly_reports (
+        id,
+        week_start,
+        week_end,
+        jobs_discovered,
+        jobs_shortlisted,
+        jobs_applied,
+        outreach_drafted,
+        outreach_sent,
+        responses_received,
+        interviews,
+        common_missing_skills,
+        recommendations,
+        report_markdown,
+        report_url,
+        created_at
+      ) values (
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,$12::jsonb,$13,$14,$15
+      )
+      on conflict (week_start, week_end) do update set
+        jobs_discovered = excluded.jobs_discovered,
+        jobs_shortlisted = excluded.jobs_shortlisted,
+        jobs_applied = excluded.jobs_applied,
+        outreach_drafted = excluded.outreach_drafted,
+        outreach_sent = excluded.outreach_sent,
+        responses_received = excluded.responses_received,
+        interviews = excluded.interviews,
+        common_missing_skills = excluded.common_missing_skills,
+        recommendations = excluded.recommendations,
+        report_markdown = excluded.report_markdown,
+        report_url = excluded.report_url,
+        created_at = excluded.created_at
+      returning *
+    `,
+    [
+      report.id,
+      report.weekStart,
+      report.weekEnd,
+      report.jobsDiscovered,
+      report.jobsShortlisted,
+      report.jobsApplied,
+      report.outreachDrafted,
+      report.outreachSent,
+      report.responsesReceived,
+      report.interviews,
+      JSON.stringify(report.commonMissingSkills),
+      JSON.stringify(report.recommendations),
+      report.reportMarkdown,
+      report.reportUrl ?? null,
+      report.createdAt,
+    ],
+  );
+
+  const savedReport = rows[0];
+  if (!savedReport) {
+    throw new Error('Failed to save weekly report');
+  }
+
+  return mapReport(savedReport);
+}
+
+export async function getLatestWeeklyReport(): Promise<WeeklyReportRecord | undefined> {
+  const reports = await listWeeklyReports();
+  return reports[0];
+}

--- a/apps/api/src/data/report-store.test.ts
+++ b/apps/api/src/data/report-store.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import type { WeeklyReportRecord } from '@/types';
+import {
+  listWeeklyReports,
+  resetWeeklyReportStoreForTests,
+  saveWeeklyReport,
+} from './report-store';
+
+function makeReport(overrides: Partial<WeeklyReportRecord> = {}): WeeklyReportRecord {
+  return {
+    id: 'report-test',
+    weekStart: '2026-05-18',
+    weekEnd: '2026-05-24',
+    jobsDiscovered: 4,
+    jobsShortlisted: 2,
+    jobsApplied: 1,
+    outreachDrafted: 3,
+    outreachSent: 1,
+    responsesReceived: 1,
+    interviews: 1,
+    commonMissingSkills: ['n8n', 'Blob Storage'],
+    recommendations: ['Send the drafted outreach.', 'Add a Blob Storage export.'],
+    reportMarkdown: '# Weekly report\n\nSeed summary.',
+    createdAt: '2026-05-24T18:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function snapshotCwd() {
+  return process.cwd();
+}
+
+test('loads the seeded weekly report into the current data directory', async () => {
+  const originalCwd = snapshotCwd();
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-weekly-report-'));
+
+  try {
+    process.chdir(tempDir);
+    resetWeeklyReportStoreForTests();
+
+    const reports = await listWeeklyReports();
+
+    assert.equal(reports.length, 1);
+    assert.equal(reports[0]?.id, '44444444-4444-4444-8444-444444444444');
+  } finally {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('upserts reports by week range and keeps the latest version first', async () => {
+  const originalCwd = snapshotCwd();
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-weekly-report-'));
+
+  try {
+    process.chdir(tempDir);
+    resetWeeklyReportStoreForTests();
+
+    const firstSave = await saveWeeklyReport(makeReport({ createdAt: '2026-05-24T18:00:00.000Z' }));
+    const updatedSave = await saveWeeklyReport(
+      makeReport({
+        jobsApplied: 2,
+        recommendations: ['Review the higher-priority shortlist first.'],
+        reportMarkdown: '# Weekly report\n\nUpdated summary.',
+        createdAt: '2026-05-24T19:30:00.000Z',
+      }),
+    );
+
+    const reports = await listWeeklyReports();
+    const latest = reports[0];
+    assert.ok(latest);
+    assert.equal(firstSave.weekStart, updatedSave.weekStart);
+    assert.equal(reports.filter((report) => report.weekStart === updatedSave.weekStart).length, 1);
+    assert.equal(latest.weekStart, updatedSave.weekStart);
+    assert.equal(latest.jobsApplied, 2);
+    assert.equal(latest.createdAt, '2026-05-24T19:30:00.000Z');
+  } finally {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/apps/api/src/data/report-store.ts
+++ b/apps/api/src/data/report-store.ts
@@ -1,0 +1,140 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { WeeklyReportRecord } from '@/types';
+import { hasPostgresConnection } from '@/lib/postgres';
+import * as postgresStore from '@/data/report-store.postgres';
+import { seedWeeklyReports } from '@/data/mock-store';
+
+let reportsCache: WeeklyReportRecord[] | null = null;
+let loadPromise: Promise<WeeklyReportRecord[]> | null = null;
+let mutationQueue: Promise<void> = Promise.resolve();
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function dataDir() {
+  return join(process.cwd(), 'data');
+}
+
+function dataFile() {
+  return join(dataDir(), 'weekly-reports.json');
+}
+
+function seedState(): WeeklyReportRecord[] {
+  return clone(seedWeeklyReports);
+}
+
+function sortReports(reports: WeeklyReportRecord[]) {
+  return [...reports].sort(
+    (left, right) =>
+      Date.parse(right.createdAt) - Date.parse(left.createdAt) ||
+      Date.parse(right.weekEnd) - Date.parse(left.weekEnd) ||
+      Date.parse(right.weekStart) - Date.parse(left.weekStart),
+  );
+}
+
+async function loadReports(): Promise<WeeklyReportRecord[]> {
+  await mkdir(dataDir(), { recursive: true });
+
+  try {
+    const raw = await readFile(dataFile(), 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+
+    if (!Array.isArray(parsed)) {
+      throw new Error('Invalid weekly report store contents');
+    }
+
+    reportsCache = parsed as WeeklyReportRecord[];
+  } catch {
+    reportsCache = seedState();
+    await persistReports();
+  }
+
+  return reportsCache;
+}
+
+async function ensureLoaded(): Promise<WeeklyReportRecord[]> {
+  if (reportsCache) {
+    return reportsCache;
+  }
+
+  loadPromise ??= loadReports();
+  return loadPromise;
+}
+
+async function persistReports() {
+  if (!reportsCache) {
+    return;
+  }
+
+  await mkdir(dataDir(), { recursive: true });
+  await writeFile(dataFile(), `${JSON.stringify(reportsCache, null, 2)}\n`, 'utf8');
+}
+
+async function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+  const previous = mutationQueue;
+  let release!: () => void;
+
+  mutationQueue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous;
+
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
+export async function listWeeklyReports(): Promise<WeeklyReportRecord[]> {
+  if (hasPostgresConnection()) {
+    return postgresStore.listWeeklyReports();
+  }
+
+  const reports = await ensureLoaded();
+  return sortReports(clone(reports));
+}
+
+export async function getLatestWeeklyReport(): Promise<WeeklyReportRecord | undefined> {
+  const reports = await listWeeklyReports();
+  return reports[0];
+}
+
+export async function saveWeeklyReport(report: WeeklyReportRecord): Promise<WeeklyReportRecord> {
+  if (hasPostgresConnection()) {
+    return postgresStore.saveWeeklyReport(report);
+  }
+
+  return runExclusive(async () => {
+    const reports = await ensureLoaded();
+    const reportIndex = reports.findIndex(
+      (entry) => entry.weekStart === report.weekStart && entry.weekEnd === report.weekEnd,
+    );
+    const savedReport: WeeklyReportRecord =
+      reportIndex >= 0
+        ? {
+            ...clone(report),
+            id: reports[reportIndex]!.id,
+          }
+        : clone(report);
+
+    if (reportIndex >= 0) {
+      reports[reportIndex] = savedReport;
+    } else {
+      reports.unshift(savedReport);
+    }
+
+    reportsCache = sortReports(reports);
+    await persistReports();
+    return clone(savedReport);
+  });
+}
+
+export function resetWeeklyReportStoreForTests() {
+  reportsCache = null;
+  loadPromise = null;
+  mutationQueue = Promise.resolve();
+}

--- a/apps/api/src/lib/report-export.ts
+++ b/apps/api/src/lib/report-export.ts
@@ -1,0 +1,55 @@
+import { BlobServiceClient } from '@azure/storage-blob';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { WeeklyReportRecord } from '@/types';
+
+function reportFileName(report: WeeklyReportRecord) {
+  return `weekly-report_${report.weekStart}_to_${report.weekEnd}_${report.id}.md`;
+}
+
+function buildMarkdown(report: WeeklyReportRecord) {
+  return report.reportMarkdown.endsWith('\n') ? report.reportMarkdown : `${report.reportMarkdown}\n`;
+}
+
+async function writeLocalExport(report: WeeklyReportRecord, markdown: string) {
+  const exportDir = join(process.cwd(), 'data', 'report-exports');
+  await mkdir(exportDir, { recursive: true });
+
+  const localPath = join(exportDir, reportFileName(report));
+  await writeFile(localPath, markdown, 'utf8');
+
+  return pathToFileURL(localPath).href;
+}
+
+export async function exportWeeklyReportMarkdown(report: WeeklyReportRecord) {
+  const markdown = buildMarkdown(report);
+  const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING?.trim();
+  const containerName = process.env.AZURE_BLOB_REPORTS_CONTAINER?.trim();
+
+  if (!connectionString || !containerName) {
+    return writeLocalExport(report, markdown);
+  }
+
+  try {
+    const blobServiceClient = BlobServiceClient.fromConnectionString(connectionString);
+    const containerClient = blobServiceClient.getContainerClient(containerName);
+    await containerClient.createIfNotExists();
+
+    const blobClient = containerClient.getBlockBlobClient(
+      `weekly-reports/${report.weekStart}/${reportFileName(report)}`,
+    );
+
+    await blobClient.upload(markdown, Buffer.byteLength(markdown), {
+      blobHTTPHeaders: {
+        blobContentType: 'text/markdown; charset=utf-8',
+      },
+    });
+
+    await writeLocalExport(report, markdown);
+    return blobClient.url;
+  } catch (error) {
+    console.warn('Azure Blob export failed; falling back to local file export.', error);
+    return writeLocalExport(report, markdown);
+  }
+}

--- a/apps/api/src/lib/report-export.ts
+++ b/apps/api/src/lib/report-export.ts
@@ -1,34 +1,50 @@
 import { BlobServiceClient } from '@azure/storage-blob';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { pathToFileURL } from 'node:url';
 import type { WeeklyReportRecord } from '@/types';
 
-function reportFileName(report: WeeklyReportRecord) {
+export function buildWeeklyReportExportFileName(report: WeeklyReportRecord) {
   return `weekly-report_${report.weekStart}_to_${report.weekEnd}_${report.id}.md`;
+}
+
+function normalizeBaseUrl(baseUrl: string) {
+  return baseUrl.replace(/\/$/, '');
 }
 
 function buildMarkdown(report: WeeklyReportRecord) {
   return report.reportMarkdown.endsWith('\n') ? report.reportMarkdown : `${report.reportMarkdown}\n`;
 }
 
-async function writeLocalExport(report: WeeklyReportRecord, markdown: string) {
+export function buildLocalWeeklyReportExportPath(report: WeeklyReportRecord) {
   const exportDir = join(process.cwd(), 'data', 'report-exports');
-  await mkdir(exportDir, { recursive: true });
-
-  const localPath = join(exportDir, reportFileName(report));
-  await writeFile(localPath, markdown, 'utf8');
-
-  return pathToFileURL(localPath).href;
+  return join(exportDir, buildWeeklyReportExportFileName(report));
 }
 
-export async function exportWeeklyReportMarkdown(report: WeeklyReportRecord) {
+export function buildWeeklyReportExportUrl(report: WeeklyReportRecord, publicBaseUrl: string) {
+  return new URL(`/api/reports/${report.id}/export`, normalizeBaseUrl(publicBaseUrl)).href;
+}
+
+async function writeLocalExport(report: WeeklyReportRecord, markdown: string) {
+  const localPath = buildLocalWeeklyReportExportPath(report);
+  await mkdir(join(process.cwd(), 'data', 'report-exports'), { recursive: true });
+  await writeFile(localPath, markdown, 'utf8');
+
+  return localPath;
+}
+
+export async function exportWeeklyReportMarkdown(
+  report: WeeklyReportRecord,
+  options: { publicBaseUrl?: string } = {},
+) {
   const markdown = buildMarkdown(report);
   const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING?.trim();
   const containerName = process.env.AZURE_BLOB_REPORTS_CONTAINER?.trim();
+  const publicBaseUrl =
+    options.publicBaseUrl?.trim() ?? process.env.API_PUBLIC_BASE_URL?.trim() ?? 'http://127.0.0.1:4000';
 
   if (!connectionString || !containerName) {
-    return writeLocalExport(report, markdown);
+    await writeLocalExport(report, markdown);
+    return buildWeeklyReportExportUrl(report, publicBaseUrl);
   }
 
   try {
@@ -37,7 +53,7 @@ export async function exportWeeklyReportMarkdown(report: WeeklyReportRecord) {
     await containerClient.createIfNotExists();
 
     const blobClient = containerClient.getBlockBlobClient(
-      `weekly-reports/${report.weekStart}/${reportFileName(report)}`,
+      `weekly-reports/${report.weekStart}/${buildWeeklyReportExportFileName(report)}`,
     );
 
     await blobClient.upload(markdown, Buffer.byteLength(markdown), {
@@ -50,6 +66,7 @@ export async function exportWeeklyReportMarkdown(report: WeeklyReportRecord) {
     return blobClient.url;
   } catch (error) {
     console.warn('Azure Blob export failed; falling back to local file export.', error);
-    return writeLocalExport(report, markdown);
+    await writeLocalExport(report, markdown);
+    return buildWeeklyReportExportUrl(report, publicBaseUrl);
   }
 }

--- a/apps/api/src/lib/request-url.ts
+++ b/apps/api/src/lib/request-url.ts
@@ -1,0 +1,10 @@
+import type { Request } from 'express';
+
+export function getRequestBaseUrl(request: Request) {
+  const forwardedProto = request.header('x-forwarded-proto')?.split(',')[0]?.trim();
+  const forwardedHost = request.header('x-forwarded-host')?.split(',')[0]?.trim();
+  const protocol = forwardedProto || request.protocol || 'http';
+  const host = forwardedHost || request.get('host') || '127.0.0.1:4000';
+
+  return `${protocol}://${host}`;
+}

--- a/apps/api/src/lib/weekly-report.test.ts
+++ b/apps/api/src/lib/weekly-report.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildWeeklyReportRecord } from './weekly-report';
+
+test('keeps empty weekly reports scoped to the requested window', () => {
+  const report = buildWeeklyReportRecord([], {
+    week_start: '2026-06-01',
+    week_end: '2026-06-07',
+  });
+
+  assert.equal(report.jobsDiscovered, 0);
+  assert.equal(report.jobsShortlisted, 0);
+  assert.equal(report.jobsApplied, 0);
+  assert.equal(report.outreachDrafted, 0);
+  assert.equal(report.outreachSent, 0);
+  assert.equal(report.responsesReceived, 0);
+  assert.equal(report.interviews, 0);
+  assert.deepEqual(report.commonMissingSkills, []);
+  assert.match(report.recommendations[0] ?? '', /No jobs were discovered in this window/);
+  assert.match(report.reportMarkdown, /2026-06-01 to 2026-06-07/);
+  assert.match(report.reportMarkdown, /No jobs were discovered in this window/);
+});

--- a/apps/api/src/lib/weekly-report.ts
+++ b/apps/api/src/lib/weekly-report.ts
@@ -1,0 +1,190 @@
+import { randomUUID } from 'node:crypto';
+import type { JobRecord, WeeklyReportBody, WeeklyReportRecord } from '@/types';
+
+export interface WeeklyReportMetrics {
+  jobs_discovered: number;
+  jobs_shortlisted: number;
+  jobs_applied: number;
+  outreach_drafted: number;
+  outreach_sent: number;
+  responses_received: number;
+  interviews: number;
+}
+
+export interface WeeklyReportResponse {
+  summary: string;
+  metrics: WeeklyReportMetrics;
+  common_missing_skills: string[];
+  recommended_next_actions: string[];
+  report_markdown: string;
+  report_id: string;
+  created_at: string;
+  report_url: string | null;
+}
+
+function startOfDayUtc(date: string) {
+  return Date.parse(`${date}T00:00:00.000Z`);
+}
+
+function endOfDayUtc(date: string) {
+  return Date.parse(`${date}T23:59:59.999Z`);
+}
+
+function withinWindow(value: string | undefined, windowStart: number, windowEnd: number) {
+  if (!value) {
+    return false;
+  }
+
+  const time = Date.parse(value);
+  return Number.isFinite(time) && time >= windowStart && time <= windowEnd;
+}
+
+function unique(values: string[]) {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function countSkills(jobs: JobRecord[]) {
+  const skillCounts = new Map<string, number>();
+
+  for (const job of jobs) {
+    for (const skill of job.analysis.missingSkills) {
+      skillCounts.set(skill, (skillCounts.get(skill) ?? 0) + 1);
+    }
+  }
+
+  return [...skillCounts.entries()]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .map(([skill]) => skill);
+}
+
+function buildRecommendations(metrics: WeeklyReportMetrics, commonMissingSkills: string[]) {
+  const recommendations = [
+    metrics.jobs_applied < metrics.jobs_shortlisted
+      ? 'Push more shortlisted roles into applications while the context is still fresh.'
+      : 'Keep your application queue tight and continue following up on the strongest leads.',
+    metrics.outreach_drafted > metrics.outreach_sent
+      ? 'Review the drafted outreach and send or archive the items that are still waiting.'
+      : 'Keep outreach drafts aligned to the most promising roles and contacts.',
+    commonMissingSkills[0]
+      ? `Add one truthful proof point for ${commonMissingSkills[0]} to reduce repeated screening friction.`
+      : 'Capture one new proof point from this week so the next report has a stronger story to tell.',
+  ];
+
+  return unique(recommendations).slice(0, 3);
+}
+
+function renderMarkdown(
+  weekStart: string,
+  weekEnd: string,
+  metrics: WeeklyReportMetrics,
+  commonMissingSkills: string[],
+  recommendations: string[],
+) {
+  const lines = [
+    `# Weekly report`,
+    ``,
+    `Reporting window: ${weekStart} to ${weekEnd}`,
+    ``,
+    `## Snapshot`,
+    `- Jobs discovered: ${metrics.jobs_discovered}`,
+    `- Jobs shortlisted: ${metrics.jobs_shortlisted}`,
+    `- Jobs applied: ${metrics.jobs_applied}`,
+    `- Outreach drafted: ${metrics.outreach_drafted}`,
+    `- Outreach sent: ${metrics.outreach_sent}`,
+    `- Responses received: ${metrics.responses_received}`,
+    `- Interviews: ${metrics.interviews}`,
+    ``,
+    `## Common missing skills`,
+    commonMissingSkills.length > 0
+      ? commonMissingSkills.map((skill) => `- ${skill}`)
+      : ['- No repeated gaps surfaced in this snapshot.'],
+    ``,
+    `## Recommended next actions`,
+    ...recommendations.map((item, index) => `${index + 1}. ${item}`),
+    ``,
+    `This report is drafted from the live CRM snapshot and should still be human-reviewed before sharing.`,
+  ];
+
+  return lines.flat().join('\n');
+}
+
+export function buildWeeklyReportRecord(
+  jobs: JobRecord[],
+  body: WeeklyReportBody,
+  createdAt = new Date().toISOString(),
+): WeeklyReportRecord {
+  const windowStart = startOfDayUtc(body.week_start);
+  const windowEnd = endOfDayUtc(body.week_end);
+  const jobsInWindow = jobs.filter((job) => withinWindow(job.discoveredAt, windowStart, windowEnd));
+  const reportJobs = jobsInWindow.length > 0 ? jobsInWindow : jobs;
+  const jobOutreach = reportJobs.flatMap((job) => job.outreach);
+  const discoveredJobs = jobsInWindow.length > 0 ? jobsInWindow : jobs;
+  const shortlistedJobs = reportJobs.filter((job) => job.status === 'shortlisted');
+  const appliedJobs = reportJobs.filter((job) => job.status === 'applied');
+  const outreachDrafts = jobOutreach.filter(
+    (draft) => draft.status === 'drafted' || draft.status === 'approved',
+  );
+  const outreachSent = jobOutreach.filter((draft) => draft.status === 'sent' || Boolean(draft.sentAt));
+  const responsesReceived = reportJobs.filter(
+    (job) => job.status === 'interview' || job.status === 'offer',
+  );
+  const interviews = reportJobs.filter((job) => job.status === 'interview');
+  const commonMissingSkills = countSkills(reportJobs).slice(0, 4);
+
+  const metrics: WeeklyReportMetrics = {
+    jobs_discovered: discoveredJobs.length,
+    jobs_shortlisted: shortlistedJobs.length,
+    jobs_applied: appliedJobs.length,
+    outreach_drafted: outreachDrafts.length,
+    outreach_sent: outreachSent.length,
+    responses_received: responsesReceived.length,
+    interviews: interviews.length,
+  };
+
+  const recommendations = buildRecommendations(metrics, commonMissingSkills);
+  const reportMarkdown = renderMarkdown(
+    body.week_start,
+    body.week_end,
+    metrics,
+    commonMissingSkills,
+    recommendations,
+  );
+
+  return {
+    id: randomUUID(),
+    weekStart: body.week_start,
+    weekEnd: body.week_end,
+    jobsDiscovered: metrics.jobs_discovered,
+    jobsShortlisted: metrics.jobs_shortlisted,
+    jobsApplied: metrics.jobs_applied,
+    outreachDrafted: metrics.outreach_drafted,
+    outreachSent: metrics.outreach_sent,
+    responsesReceived: metrics.responses_received,
+    interviews: metrics.interviews,
+    commonMissingSkills,
+    recommendations,
+    reportMarkdown,
+    createdAt,
+  };
+}
+
+export function formatWeeklyReportResponse(report: WeeklyReportRecord): WeeklyReportResponse {
+  return {
+    summary: `Weekly report draft for ${report.weekStart} through ${report.weekEnd}.`,
+    metrics: {
+      jobs_discovered: report.jobsDiscovered,
+      jobs_shortlisted: report.jobsShortlisted,
+      jobs_applied: report.jobsApplied,
+      outreach_drafted: report.outreachDrafted,
+      outreach_sent: report.outreachSent,
+      responses_received: report.responsesReceived,
+      interviews: report.interviews,
+    },
+    common_missing_skills: report.commonMissingSkills,
+    recommended_next_actions: report.recommendations,
+    report_markdown: report.reportMarkdown,
+    report_id: report.id,
+    created_at: report.createdAt,
+    report_url: report.reportUrl ?? null,
+  };
+}

--- a/apps/api/src/lib/weekly-report.ts
+++ b/apps/api/src/lib/weekly-report.ts
@@ -58,6 +58,22 @@ function countSkills(jobs: JobRecord[]) {
 }
 
 function buildRecommendations(metrics: WeeklyReportMetrics, commonMissingSkills: string[]) {
+  if (
+    metrics.jobs_discovered === 0 &&
+    metrics.jobs_shortlisted === 0 &&
+    metrics.jobs_applied === 0 &&
+    metrics.outreach_drafted === 0 &&
+    metrics.outreach_sent === 0 &&
+    metrics.responses_received === 0 &&
+    metrics.interviews === 0
+  ) {
+    return [
+      'No jobs were discovered in this window, so focus on intake sources or widen the search pipeline.',
+      'Keep one outreach draft ready for the next promising role.',
+      'Capture a concrete proof point before the next report so the dashboard has fresh evidence to show.',
+    ];
+  }
+
   const recommendations = [
     metrics.jobs_applied < metrics.jobs_shortlisted
       ? 'Push more shortlisted roles into applications while the context is still fresh.'
@@ -116,9 +132,8 @@ export function buildWeeklyReportRecord(
   const windowStart = startOfDayUtc(body.week_start);
   const windowEnd = endOfDayUtc(body.week_end);
   const jobsInWindow = jobs.filter((job) => withinWindow(job.discoveredAt, windowStart, windowEnd));
-  const reportJobs = jobsInWindow.length > 0 ? jobsInWindow : jobs;
+  const reportJobs = jobsInWindow;
   const jobOutreach = reportJobs.flatMap((job) => job.outreach);
-  const discoveredJobs = jobsInWindow.length > 0 ? jobsInWindow : jobs;
   const shortlistedJobs = reportJobs.filter((job) => job.status === 'shortlisted');
   const appliedJobs = reportJobs.filter((job) => job.status === 'applied');
   const outreachDrafts = jobOutreach.filter(
@@ -132,7 +147,7 @@ export function buildWeeklyReportRecord(
   const commonMissingSkills = countSkills(reportJobs).slice(0, 4);
 
   const metrics: WeeklyReportMetrics = {
-    jobs_discovered: discoveredJobs.length,
+    jobs_discovered: reportJobs.length,
     jobs_shortlisted: shortlistedJobs.length,
     jobs_applied: appliedJobs.length,
     outreach_drafted: outreachDrafts.length,

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -20,6 +20,7 @@ import {
 } from '@/data/job-store';
 import { saveWeeklyReport } from '@/data/report-store';
 import { exportWeeklyReportMarkdown } from '@/lib/report-export';
+import { getRequestBaseUrl } from '@/lib/request-url';
 import { buildWeeklyReportRecord, formatWeeklyReportResponse } from '@/lib/weekly-report';
 import type { DraftOutreachBody, OutreachDraft, ParseJobBody, ScoreFitBody, WeeklyReportBody } from '@/types';
 
@@ -210,7 +211,9 @@ aiRouter.post('/generate-weekly-report', async (request, response, next) => {
   try {
     const jobs = await listJobs();
     const report = buildWeeklyReportRecord(jobs, body);
-    const reportUrl = await exportWeeklyReportMarkdown(report);
+    const reportUrl = await exportWeeklyReportMarkdown(report, {
+      publicBaseUrl: getRequestBaseUrl(request),
+    });
     const savedReport = await saveWeeklyReport({
       ...report,
       reportUrl,

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -10,16 +10,17 @@ import {
 } from '@/lib/analysis-core';
 import { isSingleRecipientEmailAddress } from '@/lib/email';
 import { createGmailDraftIfEnabled } from '@/lib/gmail';
-import {
-  draftOutreachBody,
-  generateWeeklyReportBody,
-} from '@/data/mock-store';
+import { draftOutreachBody } from '@/data/mock-store';
 import {
   appendOutreachDraft,
   getJobById,
+  listJobs,
   saveJobAnalysis,
   updateOutreachGmailDraftId,
 } from '@/data/job-store';
+import { saveWeeklyReport } from '@/data/report-store';
+import { exportWeeklyReportMarkdown } from '@/lib/report-export';
+import { buildWeeklyReportRecord, formatWeeklyReportResponse } from '@/lib/weekly-report';
 import type { DraftOutreachBody, OutreachDraft, ParseJobBody, ScoreFitBody, WeeklyReportBody } from '@/types';
 
 export const aiRouter = Router();
@@ -199,12 +200,24 @@ aiRouter.post('/draft-outreach', async (request, response, next) => {
   });
 });
 
-aiRouter.post('/generate-weekly-report', (request, response) => {
+aiRouter.post('/generate-weekly-report', async (request, response, next) => {
   const body = request.body as WeeklyReportBody;
 
   if (!body.week_start || !body.week_end) {
     return response.status(400).json({ error: 'week_start and week_end are required' });
   }
 
-  return response.json(generateWeeklyReportBody(body));
+  try {
+    const jobs = await listJobs();
+    const report = buildWeeklyReportRecord(jobs, body);
+    const reportUrl = await exportWeeklyReportMarkdown(report);
+    const savedReport = await saveWeeklyReport({
+      ...report,
+      reportUrl,
+    });
+
+    return response.json(formatWeeklyReportResponse(savedReport));
+  } catch (error) {
+    next(error);
+  }
 });

--- a/apps/api/src/routes/n8n.test.ts
+++ b/apps/api/src/routes/n8n.test.ts
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict';
 import http from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
 import express from 'express';
 import { createN8nRouter } from './n8n';
+import { listWeeklyReports, resetWeeklyReportStoreForTests } from '@/data/report-store';
 import type { JobRecord } from '@/types';
 
 function snapshotEnv(keys: string[]) {
@@ -409,6 +413,64 @@ test('returns due follow-up reminders and weekly report drafts', async () => {
       },
     );
   } finally {
+    restore();
+  }
+});
+
+test('persists weekly report drafts generated through the n8n webhook', async () => {
+  const restore = snapshotEnv(['N8N_WEBHOOK_SECRET']);
+  process.env.N8N_WEBHOOK_SECRET = 'n8n-secret';
+  const originalCwd = process.cwd();
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-n8n-weekly-report-'));
+
+  try {
+    process.chdir(tempDir);
+    resetWeeklyReportStoreForTests();
+
+    await withServer(
+      createN8nRouter({
+        createJob: async () => makeJob(),
+        listJobs: async () => [
+          makeJob({
+            id: 'report-job',
+            status: 'shortlisted',
+            discoveredAt: '2026-05-18T10:00:00.000Z',
+            outreach: [],
+          }),
+        ],
+        saveJobAnalysis: async () => makeJob(),
+        updateJob: async () => makeJob(),
+      }),
+      async (baseUrl) => {
+        const reportResponse = await fetch(`${baseUrl}/api/n8n/weekly-report`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-N8N-Webhook-Secret': 'n8n-secret',
+          },
+          body: JSON.stringify({
+            week_start: '2026-05-18',
+            week_end: '2026-05-24',
+          }),
+        });
+
+        assert.equal(reportResponse.status, 200);
+        const reportPayload = (await reportResponse.json()) as N8nWeeklyReportResponse & {
+          report_id: string;
+          report_url: string | null;
+        };
+        assert.equal(reportPayload.workflow, 'weekly-report');
+        assert.ok(reportPayload.report_id);
+        assert.ok(reportPayload.report_url);
+
+        const reports = await listWeeklyReports();
+        assert.equal(reports[0]?.id, reportPayload.report_id);
+        assert.equal(reports[0]?.reportUrl, reportPayload.report_url ?? undefined);
+      },
+    );
+  } finally {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
     restore();
   }
 });

--- a/apps/api/src/routes/n8n.ts
+++ b/apps/api/src/routes/n8n.ts
@@ -5,7 +5,7 @@ import {
   saveJobAnalysis,
   updateJob,
 } from '@/data/job-store';
-import { generateWeeklyReportBody } from '@/data/mock-store';
+import { saveWeeklyReport } from '@/data/report-store';
 import {
   buildAnalysisFromParse,
   buildAnalysisFromScore,
@@ -14,11 +14,13 @@ import {
   validateFitScoreOutput,
   validateParsedJobOutput,
 } from '@/lib/analysis-core';
+import { exportWeeklyReportMarkdown } from '@/lib/report-export';
 import {
   buildFollowUpSummary,
   requireN8nWebhookSecret,
   selectDueFollowUps,
 } from '@/lib/n8n';
+import { buildWeeklyReportRecord, formatWeeklyReportResponse } from '@/lib/weekly-report';
 import type {
   JobPriority,
   JobWorkplaceType,
@@ -304,7 +306,7 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
     }
   });
 
-  router.post('/weekly-report', (request, response) => {
+  router.post('/weekly-report', async (request, response, next) => {
     const body = request.body as Partial<N8nWeeklyReportBody>;
     const validation = validateWeeklyReportBody(body);
 
@@ -316,18 +318,28 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
       return;
     }
 
-    const report = generateWeeklyReportBody({
-      week_start: validation.normalized.week_start!,
-      week_end: validation.normalized.week_end!,
-    });
+    try {
+      const jobs = await dependencies.listJobs();
+      const report = buildWeeklyReportRecord(jobs, {
+        week_start: validation.normalized.week_start!,
+        week_end: validation.normalized.week_end!,
+      });
+      const reportUrl = await exportWeeklyReportMarkdown(report);
+      const savedReport = await saveWeeklyReport({
+        ...report,
+        reportUrl,
+      });
 
-    response.json({
-      workflow: 'weekly-report',
-      ...report,
-      email_subject: `Weekly report summary for ${validation.normalized.week_start} to ${validation.normalized.week_end}`,
-      email_body: report.report_markdown,
-      notification: 'Weekly report draft ready for n8n email delivery.',
-    });
+      response.json({
+        workflow: 'weekly-report',
+        ...formatWeeklyReportResponse(savedReport),
+        email_subject: `Weekly report summary for ${validation.normalized.week_start} to ${validation.normalized.week_end}`,
+        email_body: savedReport.reportMarkdown,
+        notification: 'Weekly report draft ready for n8n email delivery.',
+      });
+    } catch (error) {
+      next(error);
+    }
   });
 
   return router;

--- a/apps/api/src/routes/n8n.ts
+++ b/apps/api/src/routes/n8n.ts
@@ -15,6 +15,7 @@ import {
   validateParsedJobOutput,
 } from '@/lib/analysis-core';
 import { exportWeeklyReportMarkdown } from '@/lib/report-export';
+import { getRequestBaseUrl } from '@/lib/request-url';
 import {
   buildFollowUpSummary,
   requireN8nWebhookSecret,
@@ -324,7 +325,9 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
         week_start: validation.normalized.week_start!,
         week_end: validation.normalized.week_end!,
       });
-      const reportUrl = await exportWeeklyReportMarkdown(report);
+      const reportUrl = await exportWeeklyReportMarkdown(report, {
+        publicBaseUrl: getRequestBaseUrl(request),
+      });
       const savedReport = await saveWeeklyReport({
         ...report,
         reportUrl,

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { createApp } from '@/app';
+import { resetWeeklyReportStoreForTests } from '@/data/report-store';
+
+async function withServer(run: (baseUrl: string) => Promise<void>) {
+  const app = createApp();
+  const server = http.createServer(app);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('Test server did not provide a usable address');
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+test('persists generated weekly reports and exposes them through the reports API', async () => {
+  const originalCwd = process.cwd();
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-weekly-report-api-'));
+
+  try {
+    process.chdir(tempDir);
+    resetWeeklyReportStoreForTests();
+
+    await withServer(async (baseUrl) => {
+      const generateResponse = await fetch(`${baseUrl}/api/ai/generate-weekly-report`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          week_start: '2026-05-18',
+          week_end: '2026-05-24',
+        }),
+      });
+
+      assert.equal(generateResponse.status, 200);
+      const generatedPayload = (await generateResponse.json()) as {
+        report_id: string;
+        created_at: string;
+        report_url: string | null;
+        summary: string;
+      };
+      assert.ok(generatedPayload.report_id);
+      assert.ok(generatedPayload.created_at);
+      assert.ok(generatedPayload.report_url);
+      assert.match(generatedPayload.summary, /2026-05-18 through 2026-05-24/);
+
+      const latestResponse = await fetch(`${baseUrl}/api/reports/latest`);
+      assert.equal(latestResponse.status, 200);
+      const latestPayload = (await latestResponse.json()) as {
+        report: { id: string; weekStart: string; weekEnd: string; reportUrl?: string };
+      };
+      assert.equal(latestPayload.report.id, generatedPayload.report_id);
+      assert.equal(latestPayload.report.weekStart, '2026-05-18');
+      assert.equal(latestPayload.report.weekEnd, '2026-05-24');
+      assert.equal(latestPayload.report.reportUrl, generatedPayload.report_url ?? undefined);
+
+      const listResponse = await fetch(`${baseUrl}/api/reports`);
+      assert.equal(listResponse.status, 200);
+      const listPayload = (await listResponse.json()) as {
+        reports: Array<{ id: string }>;
+      };
+      assert.equal(listPayload.reports[0]?.id, generatedPayload.report_id);
+      assert.equal(listPayload.reports.length, 2);
+    });
+  } finally {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -60,6 +60,7 @@ test('persists generated weekly reports and exposes them through the reports API
       assert.ok(generatedPayload.report_id);
       assert.ok(generatedPayload.created_at);
       assert.ok(generatedPayload.report_url);
+      assert.ok(generatedPayload.report_url.startsWith(baseUrl));
       assert.match(generatedPayload.summary, /2026-05-18 through 2026-05-24/);
 
       const latestResponse = await fetch(`${baseUrl}/api/reports/latest`);
@@ -79,6 +80,11 @@ test('persists generated weekly reports and exposes them through the reports API
       };
       assert.equal(listPayload.reports[0]?.id, generatedPayload.report_id);
       assert.equal(listPayload.reports.length, 2);
+
+      const exportResponse = await fetch(generatedPayload.report_url);
+      assert.equal(exportResponse.status, 200);
+      assert.match(exportResponse.headers.get('content-type') ?? '', /text\/markdown/);
+      assert.match(await exportResponse.text(), /Weekly report/);
     });
   } finally {
     process.chdir(originalCwd);

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+import { getLatestWeeklyReport, listWeeklyReports } from '@/data/report-store';
+
+export const reportsRouter = Router();
+
+reportsRouter.get('/', async (_request, response, next) => {
+  try {
+    const reports = await listWeeklyReports();
+    response.json({ reports });
+  } catch (error) {
+    next(error);
+  }
+});
+
+reportsRouter.get('/latest', async (_request, response, next) => {
+  try {
+    const report = await getLatestWeeklyReport();
+
+    if (!report) {
+      response.status(404).json({ error: 'No weekly reports found' });
+      return;
+    }
+
+    response.json({ report });
+  } catch (error) {
+    next(error);
+  }
+});

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,5 +1,10 @@
 import { Router } from 'express';
+import { readFile } from 'node:fs/promises';
 import { getLatestWeeklyReport, listWeeklyReports } from '@/data/report-store';
+import {
+  buildLocalWeeklyReportExportPath,
+  buildWeeklyReportExportFileName,
+} from '@/lib/report-export';
 
 export const reportsRouter = Router();
 
@@ -22,6 +27,36 @@ reportsRouter.get('/latest', async (_request, response, next) => {
     }
 
     response.json({ report });
+  } catch (error) {
+    next(error);
+  }
+});
+
+reportsRouter.get('/:reportId/export', async (request, response, next) => {
+  try {
+    const reports = await listWeeklyReports();
+    const report = reports.find((entry) => entry.id === request.params.reportId);
+
+    if (!report) {
+      response.status(404).json({ error: 'Weekly report not found' });
+      return;
+    }
+
+    const exportPath = buildLocalWeeklyReportExportPath(report);
+    let markdown = report.reportMarkdown.endsWith('\n')
+      ? report.reportMarkdown
+      : `${report.reportMarkdown}\n`;
+
+    try {
+      markdown = await readFile(exportPath, 'utf8');
+    } catch {
+      // Fall back to the stored markdown if the local file has not been written yet.
+    }
+
+    response
+      .type('text/markdown; charset=utf-8')
+      .set('Content-Disposition', `inline; filename="${buildWeeklyReportExportFileName(report)}"`)
+      .send(markdown);
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -92,6 +92,8 @@ export interface WeeklyReportRecord {
   commonMissingSkills: string[];
   recommendations: string[];
   reportMarkdown: string;
+  reportUrl?: string;
+  createdAt: string;
 }
 
 export interface CreateJobBody {

--- a/apps/web/src/app/reports/page.tsx
+++ b/apps/web/src/app/reports/page.tsx
@@ -2,14 +2,37 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { EmptyState } from '@/components/empty-state';
 import { SectionCard } from '@/components/section-card';
-import { mockWeeklyReports } from '@/lib/mock-data';
+import { loadWeeklyReports } from '@/lib/report-data';
+import type { WeeklyReport } from '@/types/job';
 
 export const metadata: Metadata = {
   title: 'Reports',
 };
 
-export default function ReportsPage() {
-  const report = mockWeeklyReports[0];
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+function formatDate(value: string) {
+  return dateFormatter.format(new Date(value));
+}
+
+function formatWeekRange(report: WeeklyReport) {
+  return `${formatDate(report.weekStart)} to ${formatDate(report.weekEnd)}`;
+}
+
+function formatSummary(report: WeeklyReport) {
+  const highlight = report.recommendations[0] ?? 'keep the pipeline moving';
+
+  return `This snapshot covers ${formatWeekRange(report)}. ${report.jobsDiscovered} jobs were discovered, ${report.jobsApplied} were applied, and the leading recommendation is to ${highlight.toLowerCase()}`;
+}
+
+export default async function ReportsPage() {
+  const { reports, source } = await loadWeeklyReports();
+  const report = reports[0];
 
   if (!report) {
     return (
@@ -28,22 +51,26 @@ export default function ReportsPage() {
         <p className="eyebrow">Weekly analytics</p>
         <h2 className="hero__title">Strategy reporting built for a real job-search operating rhythm.</h2>
         <p className="hero__lead">
-          The eventual weekly report will summarize pipeline health, missing skills, outreach
-          responses, interviews, and the next priorities. This scaffold already shows the expected
-          structure.
+          The latest report is saved, exportable, and visible in a running history so you can track
+          weekly momentum without digging through manual notes.
         </p>
         <div className="hero__actions">
           <Link className="button button--ghost" href="/jobs">
             Back to jobs
           </Link>
+          {report.reportUrl ? (
+            <a className="button button--ghost" href={report.reportUrl} target="_blank" rel="noreferrer">
+              Open latest export
+            </a>
+          ) : null}
         </div>
+        <p className="eyebrow" style={{ marginTop: '0.5rem' }}>
+          Loaded from {source === 'api' ? 'the live API' : 'seed data fallback'}
+        </p>
       </section>
 
       <div className="grid grid--two">
-        <SectionCard
-          title="Latest weekly report"
-          description={`${report.weekStart} to ${report.weekEnd}`}
-        >
+        <SectionCard title="Latest weekly report" description={formatWeekRange(report)}>
           <div className="inline-metrics">
             <div className="inline-metric">
               <strong>{report.jobsDiscovered}</strong>
@@ -65,8 +92,12 @@ export default function ReportsPage() {
 
           <div className="detail-card">
             <p className="detail-card__title">Summary</p>
-            <p className="detail-card__value">{report.reportMarkdown}</p>
+            <p className="detail-card__value">{formatSummary(report)}</p>
           </div>
+
+          <p className="eyebrow" style={{ marginTop: '0.75rem' }}>
+            Generated {formatDate(report.createdAt)}
+          </p>
         </SectionCard>
 
         <SectionCard title="Recommendations" description="Actionable guidance from the weekly report.">
@@ -84,6 +115,27 @@ export default function ReportsPage() {
             <div className="detail-card" key={skill}>
               <p className="detail-card__title">Gap {index + 1}</p>
               <p className="detail-card__value">{skill}</p>
+            </div>
+          ))}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Report history" description="Saved reports are kept in week order for easy review.">
+        <div className="stack">
+          {reports.map((item) => (
+            <div className="detail-card" key={item.id}>
+              <p className="detail-card__title">{formatWeekRange(item)}</p>
+              <p className="detail-card__value">{formatSummary(item)}</p>
+              <p className="eyebrow" style={{ marginTop: '0.5rem' }}>
+                Generated {formatDate(item.createdAt)}
+              </p>
+              <div className="hero__actions" style={{ marginTop: '0.75rem' }}>
+                {item.reportUrl ? (
+                  <a className="button button--ghost" href={item.reportUrl} target="_blank" rel="noreferrer">
+                    Open export
+                  </a>
+                ) : null}
+              </div>
             </div>
           ))}
         </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Job, OutreachMessageType, OutreachStatus } from '@/types/job';
+import type { Job, OutreachMessageType, OutreachStatus, WeeklyReport } from '@/types/job';
 
 const apiBaseUrl = (process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://127.0.0.1:4000').replace(/\/$/, '');
 const sharedApiKey = process.env.NEXT_PUBLIC_API_SHARED_SECRET?.trim();
@@ -120,6 +120,14 @@ export interface UpdateOutreachResponse {
   outreach: Job['outreach'][number];
 }
 
+export interface WeeklyReportsResponse {
+  reports: WeeklyReport[];
+}
+
+export interface WeeklyReportResponse {
+  report: WeeklyReport;
+}
+
 export async function fetchJobs(): Promise<Job[]> {
   const response = await requestJson<JobsResponse>('/api/jobs', { cache: 'no-store' });
   return response.jobs;
@@ -190,6 +198,20 @@ export async function updateOutreach(
     method: 'PATCH',
     body: JSON.stringify(payload),
   });
+}
+
+export async function fetchWeeklyReports(): Promise<WeeklyReport[]> {
+  const response = await requestJson<WeeklyReportsResponse>('/api/reports', { cache: 'no-store' });
+  return response.reports;
+}
+
+export async function fetchLatestWeeklyReport(): Promise<WeeklyReport | undefined> {
+  try {
+    const response = await requestJson<WeeklyReportResponse>('/api/reports/latest', { cache: 'no-store' });
+    return response.report;
+  } catch {
+    return undefined;
+  }
 }
 
 async function requestJson<T>(path: string, init: RequestInit = {}): Promise<T> {

--- a/apps/web/src/lib/mock-data.ts
+++ b/apps/web/src/lib/mock-data.ts
@@ -240,6 +240,7 @@ export const mockWeeklyReports: WeeklyReport[] = [
     ],
     reportMarkdown:
       'This week focused on operational roles that reward workflow thinking. The strongest opportunities were the automation engineer and recruiting operations roles.',
+    createdAt: '2026-05-17T18:00:00.000Z',
   },
 ];
 

--- a/apps/web/src/lib/report-data.ts
+++ b/apps/web/src/lib/report-data.ts
@@ -1,0 +1,33 @@
+import { ApiRequestError, fetchWeeklyReports } from '@/lib/api';
+import { mockWeeklyReports } from '@/lib/mock-data';
+import type { WeeklyReport } from '@/types/job';
+
+export interface WeeklyReportDataResult {
+  reports: WeeklyReport[];
+  source: 'api' | 'seed';
+}
+
+export async function loadWeeklyReports(): Promise<WeeklyReportDataResult> {
+  try {
+    const reports = await fetchWeeklyReports();
+
+    if (reports.length > 0) {
+      return {
+        reports,
+        source: 'api',
+      };
+    }
+  } catch (error) {
+    if (!(error instanceof ApiRequestError)) {
+      return {
+        reports: mockWeeklyReports,
+        source: 'seed',
+      };
+    }
+  }
+
+  return {
+    reports: mockWeeklyReports,
+    source: 'seed',
+  };
+}

--- a/apps/web/src/types/job.ts
+++ b/apps/web/src/types/job.ts
@@ -91,4 +91,6 @@ export interface WeeklyReport {
   commonMissingSkills: string[];
   recommendations: string[];
   reportMarkdown: string;
+  reportUrl?: string;
+  createdAt: string;
 }

--- a/db/migrations/002_weekly_report_storage.sql
+++ b/db/migrations/002_weekly_report_storage.sql
@@ -1,0 +1,37 @@
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'weekly_reports'
+      and column_name = 'recommendations'
+      and data_type <> 'jsonb'
+  ) then
+    alter table weekly_reports
+      alter column recommendations type jsonb using
+        case
+          when recommendations is null or recommendations = '' then '[]'::jsonb
+          else jsonb_build_array(recommendations)
+        end;
+  end if;
+
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'weekly_reports'
+      and column_name = 'report_markdown'
+  ) then
+    alter table weekly_reports
+      add column report_markdown text not null default '';
+    alter table weekly_reports
+      alter column report_markdown drop default;
+  end if;
+end $$;
+
+create unique index if not exists weekly_reports_week_range_unique_idx
+  on weekly_reports (week_start, week_end);
+
+create index if not exists weekly_reports_created_at_idx
+  on weekly_reports (created_at desc);

--- a/db/seed/sample_jobs.sql
+++ b/db/seed/sample_jobs.sql
@@ -89,4 +89,53 @@ on conflict (id) do update set
   next_action = excluded.next_action,
   next_action_due = excluded.next_action_due;
 
+insert into weekly_reports (
+  id,
+  week_start,
+  week_end,
+  jobs_discovered,
+  jobs_shortlisted,
+  jobs_applied,
+  outreach_drafted,
+  outreach_sent,
+  responses_received,
+  interviews,
+  common_missing_skills,
+  recommendations,
+  report_markdown,
+  report_url,
+  created_at
+) values (
+  '44444444-4444-4444-8444-444444444444',
+  '2026-05-11',
+  '2026-05-17',
+  14,
+  5,
+  2,
+  4,
+  1,
+  1,
+  1,
+  '["Azure Functions", "n8n", "HR tech", "Program management"]'::jsonb,
+  '["Tailor the headline toward operations automation and workflow systems.", "Prioritize jobs that combine process ownership with hands-on technical delivery.", "Schedule follow-ups for all drafted outreach within seven days."]'::jsonb,
+  'This week focused on operational roles that reward workflow thinking. The strongest opportunities were the automation engineer and recruiting operations roles.',
+  null,
+  '2026-05-17T18:00:00Z'
+)
+on conflict (id) do update set
+  week_start = excluded.week_start,
+  week_end = excluded.week_end,
+  jobs_discovered = excluded.jobs_discovered,
+  jobs_shortlisted = excluded.jobs_shortlisted,
+  jobs_applied = excluded.jobs_applied,
+  outreach_drafted = excluded.outreach_drafted,
+  outreach_sent = excluded.outreach_sent,
+  responses_received = excluded.responses_received,
+  interviews = excluded.interviews,
+  common_missing_skills = excluded.common_missing_skills,
+  recommendations = excluded.recommendations,
+  report_markdown = excluded.report_markdown,
+  report_url = excluded.report_url,
+  created_at = excluded.created_at;
+
 commit;

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -323,11 +323,48 @@ Current response shape:
   },
   "common_missing_skills": ["n8n"],
   "recommended_next_actions": ["Review the highest-priority shortlisted jobs."],
-  "report_markdown": "# Weekly report..."
+  "report_markdown": "# Weekly report...",
+  "report_id": "44444444-4444-4444-8444-444444444444",
+  "created_at": "2026-05-17T18:00:00.000Z",
+  "report_url": "file:///C:/Users/talee/OneDrive%20-%20Higher%20Education%20Commission/projects/JobOps%20Copilot/apps/api/data/report-exports/weekly-report_2026-05-11_to_2026-05-17_44444444-4444-4444-8444-444444444444.md"
 }
 ```
 
-This endpoint is still draft-oriented. Persisted weekly report storage and dashboards are future work.
+This endpoint now saves the weekly report through the active store, exports the markdown artifact, and returns the persisted record metadata for the dashboard or downstream automations.
+
+### `GET /api/reports`
+
+Returns the saved weekly report history in newest-first order.
+
+Example response:
+
+```json
+{
+  "reports": [
+    {
+      "id": "44444444-4444-4444-8444-444444444444",
+      "weekStart": "2026-05-11",
+      "weekEnd": "2026-05-17",
+      "jobsDiscovered": 14,
+      "jobsShortlisted": 5,
+      "jobsApplied": 2,
+      "outreachDrafted": 4,
+      "outreachSent": 1,
+      "responsesReceived": 1,
+      "interviews": 1,
+      "commonMissingSkills": ["Azure Functions", "n8n"],
+      "recommendations": ["Tailor the headline toward operations automation and workflow systems."],
+      "reportMarkdown": "# Weekly report...",
+      "reportUrl": "file:///tmp/weekly-report.md",
+      "createdAt": "2026-05-17T18:00:00.000Z"
+    }
+  ]
+}
+```
+
+### `GET /api/reports/latest`
+
+Returns the most recently generated weekly report. The response is `{ "report": { ... } }`, or `404` if no report has been saved yet.
 
 ### `POST /api/n8n/job-intake`
 
@@ -421,6 +458,9 @@ Current response shape:
   "common_missing_skills": ["n8n"],
   "recommended_next_actions": ["Review the highest-priority shortlisted jobs."],
   "report_markdown": "# Weekly report...",
+  "report_id": "44444444-4444-4444-8444-444444444444",
+  "created_at": "2026-05-17T18:00:00.000Z",
+  "report_url": "file:///C:/Users/talee/OneDrive%20-%20Higher%20Education%20Commission/projects/JobOps%20Copilot/apps/api/data/report-exports/weekly-report_2026-05-11_to_2026-05-17_44444444-4444-4444-8444-444444444444.md",
   "email_subject": "Weekly report summary for 2026-05-11 to 2026-05-17",
   "email_body": "# Weekly report...",
   "notification": "Weekly report draft ready for n8n email delivery."

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -326,7 +326,7 @@ Current response shape:
   "report_markdown": "# Weekly report...",
   "report_id": "44444444-4444-4444-8444-444444444444",
   "created_at": "2026-05-17T18:00:00.000Z",
-  "report_url": "file:///C:/Users/talee/OneDrive%20-%20Higher%20Education%20Commission/projects/JobOps%20Copilot/apps/api/data/report-exports/weekly-report_2026-05-11_to_2026-05-17_44444444-4444-4444-8444-444444444444.md"
+  "report_url": "http://127.0.0.1:4000/api/reports/44444444-4444-4444-8444-444444444444/export"
 }
 ```
 
@@ -355,7 +355,7 @@ Example response:
       "commonMissingSkills": ["Azure Functions", "n8n"],
       "recommendations": ["Tailor the headline toward operations automation and workflow systems."],
       "reportMarkdown": "# Weekly report...",
-      "reportUrl": "file:///tmp/weekly-report.md",
+      "reportUrl": "http://127.0.0.1:4000/api/reports/44444444-4444-4444-8444-444444444444/export",
       "createdAt": "2026-05-17T18:00:00.000Z"
     }
   ]
@@ -365,6 +365,10 @@ Example response:
 ### `GET /api/reports/latest`
 
 Returns the most recently generated weekly report. The response is `{ "report": { ... } }`, or `404` if no report has been saved yet.
+
+### `GET /api/reports/:reportId/export`
+
+Streams the saved weekly report markdown for the requested report ID. The same route is used for the local export link in development.
 
 ### `POST /api/n8n/job-intake`
 
@@ -460,7 +464,7 @@ Current response shape:
   "report_markdown": "# Weekly report...",
   "report_id": "44444444-4444-4444-8444-444444444444",
   "created_at": "2026-05-17T18:00:00.000Z",
-  "report_url": "file:///C:/Users/talee/OneDrive%20-%20Higher%20Education%20Commission/projects/JobOps%20Copilot/apps/api/data/report-exports/weekly-report_2026-05-11_to_2026-05-17_44444444-4444-4444-8444-444444444444.md",
+  "report_url": "http://127.0.0.1:4000/api/reports/44444444-4444-4444-8444-444444444444/export",
   "email_subject": "Weekly report summary for 2026-05-11 to 2026-05-17",
   "email_body": "# Weekly report...",
   "notification": "Weekly report draft ready for n8n email delivery."

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,14 +29,17 @@ The current backend flow is:
 4. AI parsing converts raw job text into structured fields.
 5. Fit scoring compares the job against the resume and profile text.
 6. Outreach drafting creates a draft only and stores it for human review.
-7. Weekly reporting returns a draft report from the seeded analytics data.
+7. Weekly reporting persists a generated report, exports a markdown artifact, and feeds the saved history into the reports dashboard.
 
 ## Core Implementation Pieces
 
 - `apps/api/src/data/job-store.ts` selects file mode or PostgreSQL mode.
 - `apps/api/src/data/job-store.postgres.ts` implements the database-backed store.
+- `apps/api/src/data/report-store.ts` and `apps/api/src/data/report-store.postgres.ts` manage weekly report persistence in file or Postgres mode.
 - `apps/api/src/lib/postgres.ts` creates and manages the `pg` pool.
 - `apps/api/src/lib/analysis-core.ts` centralizes parsing, fit scoring, validation, and structured analysis generation.
+- `apps/api/src/lib/weekly-report.ts` builds report snapshots and API payloads.
+- `apps/api/src/lib/report-export.ts` writes local report artifacts and uploads them to Blob Storage when configured.
 - `apps/api/scripts/db-init.ts` bootstraps the Azure PostgreSQL schema and seed data.
 
 ## Data Flow
@@ -55,7 +58,7 @@ Jobs are the CRM source of truth. The list and detail pages read job records, an
 
 ### Weekly Reports
 
-`generate-weekly-report` currently returns a report draft based on seeded analytics data. Persisted report storage and dashboards are still future work.
+`generate-weekly-report` now persists a saved report snapshot. The dashboard reads report history through `/api/reports`, and the n8n workflow reuses the same storage path so weekly summaries, exports, and history stay aligned.
 
 ## Infrastructure
 

--- a/docs/AUTOMATION_WORKFLOWS.md
+++ b/docs/AUTOMATION_WORKFLOWS.md
@@ -12,6 +12,7 @@ The workflows should build on the endpoints that already exist:
 - `POST /api/ai/draft-outreach` for outreach drafts
 - `PATCH /api/outreach/:id` for manual outreach review states
 - `POST /api/ai/generate-weekly-report` for weekly summaries
+- `GET /api/reports` and `GET /api/reports/latest` for saved weekly report history
 - `POST /api/n8n/job-intake` for webhook-driven job creation, parsing, and optional fit scoring
 - `POST /api/n8n/follow-up-reminders` for scheduled reminder queues
 - `POST /api/n8n/weekly-report` for weekly digest drafts
@@ -37,7 +38,7 @@ Current implementation notes:
 
 - webhook calls can create a job, parse the description, and optionally score fit in one request
 - follow-up reminders are returned as a sorted reminder list that n8n can turn into calendar or email actions
-- weekly report calls return an email-ready subject, body, and markdown summary
+- weekly report calls now persist the saved report, export a markdown artifact, and return an email-ready subject, body, and markdown summary
 - sample workflow exports live in `workflows/n8n/exports`
 
 Recommended n8n pattern:

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -138,7 +138,7 @@ Behavior and indexes:
 - `report_markdown` stores the human-readable markdown export body.
 - `week_start` and `week_end` are kept unique together so a given weekly window upserts cleanly.
 - `created_at` is indexed newest-first so the dashboard can load history quickly.
-- `report_url` points to a Blob Storage URL when Azure credentials are configured, or to a local export file during development.
+- `report_url` points to a Blob Storage URL when Azure credentials are configured, or to the API export route during development.
 
 ## Seed Data
 

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -112,7 +112,7 @@ Important fields:
 
 ## `weekly_reports`
 
-Stores weekly analytics and strategy outputs for future reporting dashboards.
+Stores weekly analytics and strategy outputs for the saved report dashboard.
 
 Important fields:
 
@@ -128,12 +128,23 @@ Important fields:
 - `interviews`
 - `common_missing_skills`
 - `recommendations`
+- `report_markdown`
 - `report_url`
 - `created_at`
+
+Behavior and indexes:
+
+- `common_missing_skills` and `recommendations` are stored as `jsonb` arrays.
+- `report_markdown` stores the human-readable markdown export body.
+- `week_start` and `week_end` are kept unique together so a given weekly window upserts cleanly.
+- `created_at` is indexed newest-first so the dashboard can load history quickly.
+- `report_url` points to a Blob Storage URL when Azure credentials are configured, or to a local export file during development.
 
 ## Seed Data
 
 `db/seed/sample_jobs.sql` inserts three representative jobs with fixed UUIDs and upserts them by `id`. That makes the seed file safe to rerun when the database is reset.
+
+The same seed file also inserts one representative weekly report row so the report dashboard has a stable starter record.
 
 The seed set is intentionally varied:
 

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -30,16 +30,15 @@ JobOps Copilot now has a working end-to-end foundation:
 - outreach drafts are visible in the inbox and can be approved, marked sent, or skipped manually
 - `draft-outreach` can optionally create a Gmail draft when the feature flag and OAuth credentials are configured
 - the outreach draft path and Gmail draft side effect were verified in the local browser against the live app
-- `generate-weekly-report` returns a report draft from the seeded analytics data
+- `generate-weekly-report` persists weekly reports, returns the saved draft, and feeds the reports dashboard
 - `POST /api/n8n/job-intake`, `POST /api/n8n/follow-up-reminders`, and `POST /api/n8n/weekly-report` expose the Phase 4 webhook surface
+- `GET /api/reports` and `GET /api/reports/latest` provide the saved weekly report history
 - The API switches between local file mode and Postgres mode depending on `DATABASE_URL`
 - `GET /api/health` reports which store is active
 
 ## What Is Still Pending
 
 - n8n runtime workflows and screenshots in a live n8n instance
-- Weekly report persistence and dashboards
-- Blob Storage integration
 - full Azure hosting for the web and API apps
 - AI provider integration beyond the mock analysis layer
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,8 +6,8 @@
 - Phase 1: complete
 - Phase 2: complete
 - Phase 3: complete
-- Phase 4: in progress
-- Phase 5: planned
+- Phase 4: complete
+- Phase 5: in progress
 - Phase 6: partial, because Azure PostgreSQL is complete but app hosting is still pending
 - Phase 7: planned
 - Phase 8: planned
@@ -66,11 +66,12 @@ In progress:
 
 ## Phase 5: Weekly Reporting
 
-Planned:
+In progress:
 
 - report storage
 - report dashboards
 - Blob Storage report exports
+- weekly report API and n8n workflow persistence
 
 ## Phase 6: Azure Deployment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "name": "@jobops/api",
       "version": "0.1.0",
       "dependencies": {
+        "@azure/storage-blob": "^12.28.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
@@ -47,6 +48,210 @@
         "eslint": "^9.0.0",
         "eslint-config-next": "16.1.6",
         "typescript": "^5.8.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure/core-client": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+      "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.9",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob": {
+      "version": "12.31.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.31.0.tgz",
+      "integrity": "sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.3.0",
+        "events": "^3.0.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.3.0.tgz",
+      "integrity": "sha512-/OFHhy86aG5Pe8dP5tsp+BuJ25JOAl9yaMU3WZbkeoiFMHFtJ7tu5ili7qEdBXNW9G5lDB19trwyI6V49F/8iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1656,6 +1861,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2189,6 +2406,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
@@ -2493,6 +2724,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -3165,7 +3405,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3981,6 +4220,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/express": {
       "version": "4.22.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
@@ -4092,6 +4340,44 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -4559,6 +4845,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -5744,6 +6056,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -6754,6 +7081,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -7323,6 +7662,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {


### PR DESCRIPTION
## Summary\n- Persist weekly reports in file mode and Postgres mode\n- Add /api/reports and /api/reports/latest\n- Wire the reports dashboard to live history\n- Export weekly report markdown locally or to Azure Blob Storage when configured\n\n## Verification\n- npm run check\n- npm run test --workspace @jobops/api