### PR TITLE
Add Azure App Service deployment scaffold

### DIFF
--- a/.github/workflows/azure-app-service.yml
+++ b/.github/workflows/azure-app-service.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           app-name: ${{ vars.AZURE_WEBAPP_NAME_WEB }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_WEB }}
-          package: apps/web
+          package: apps/web # workspace package root; tsconfig is self-contained
 
       - name: Deploy API
         if: ${{ inputs.target == 'both' || inputs.target == 'api' }}
@@ -59,4 +59,4 @@ jobs:
         with:
           app-name: ${{ vars.AZURE_WEBAPP_NAME_API }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}
-          package: apps/api
+          package: apps/api # workspace package root; tsconfig is self-contained

--- a/.github/workflows/azure-app-service.yml
+++ b/.github/workflows/azure-app-service.yml
@@ -1,0 +1,62 @@
+name: Deploy Azure App Service
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Choose which app service(s) to deploy
+        required: true
+        type: choice
+        default: both
+        options:
+          - both
+          - web
+          - api
+
+permissions:
+  contents: read
+
+concurrency:
+  group: azure-app-service-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web app
+        if: ${{ inputs.target == 'both' || inputs.target == 'web' }}
+        run: npm run build:web
+
+      - name: Build API
+        if: ${{ inputs.target == 'both' || inputs.target == 'api' }}
+        run: npm run build:api
+
+      - name: Deploy web app
+        if: ${{ inputs.target == 'both' || inputs.target == 'web' }}
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ vars.AZURE_WEBAPP_NAME_WEB }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_WEB }}
+          package: apps/web
+
+      - name: Deploy API
+        if: ${{ inputs.target == 'both' || inputs.target == 'api' }}
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ vars.AZURE_WEBAPP_NAME_API }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}
+          package: apps/api

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JobOps Copilot is a cloud-ready job search operations CRM that helps you track o
 
 ## Overview
 
-The project is intentionally designed as a responsible AI operations system rather than an auto-apply bot. Phases 0 through 2 are implemented and verified:
+The project is intentionally designed as a responsible AI operations system rather than an auto-apply bot. Phases 0 through 5 are implemented and verified:
 
 - a polished Next.js dashboard;
 - an Express API with persistent job CRUD, AI parsing, fit scoring, and outreach draft endpoints;
@@ -25,6 +25,7 @@ See [docs/IMPLEMENTATION_STATUS.md](docs/IMPLEMENTATION_STATUS.md) for the full 
 - Phase 1 CRM MVP complete
 - Phase 2 AI parsing and fit scoring complete
 - Phase 3 outreach drafting, inbox review, and optional Gmail draft creation are browser-verified locally
+- Phase 5 weekly reporting persistence, dashboard history, and report export flow are complete
 - Azure PostgreSQL bootstrap and live database verification complete
 - CI runs on push and pull request
 - `main` is protected and requires the CI checks to pass
@@ -112,7 +113,7 @@ If you want optional Gmail draft creation, set `GMAIL_DRAFTS_ENABLED=true` and p
 
 ## Project Status
 
-Current phase: Phase 5 in progress. Weekly reporting persistence and dashboards are now the active slice.
+Current phase: Phase 6 partial. Azure deployment is now the active slice.
 
 What is real now:
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
     "dev": "tsx watch src/server.ts",
     "db:init": "tsx scripts/db-init.ts",
     "test": "node scripts/run-tests.mjs",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && tsc-alias -p tsconfig.json",
     "start": "node dist/server.js",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
@@ -27,6 +27,7 @@
     "eslint": "^9.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.8.0",
+    "tsc-alias": "^1.8.17",
     "typescript-eslint": "^8.0.0"
   }
 }

--- a/apps/api/src/lib/report-export.ts
+++ b/apps/api/src/lib/report-export.ts
@@ -38,7 +38,9 @@ export async function exportWeeklyReportMarkdown(
 ) {
   const markdown = buildMarkdown(report);
   const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING?.trim();
-  const containerName = process.env.AZURE_BLOB_REPORTS_CONTAINER?.trim();
+  const containerName =
+    process.env.AZURE_STORAGE_CONTAINER_NAME?.trim() ??
+    process.env.AZURE_BLOB_REPORTS_CONTAINER?.trim();
   const publicBaseUrl =
     options.publicBaseUrl?.trim() ?? process.env.API_PUBLIC_BASE_URL?.trim() ?? 'http://127.0.0.1:4000';
 

--- a/apps/api/src/lib/report-export.ts
+++ b/apps/api/src/lib/report-export.ts
@@ -39,7 +39,7 @@ export async function exportWeeklyReportMarkdown(
   const markdown = buildMarkdown(report);
   const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING?.trim();
   const containerName =
-    process.env.AZURE_STORAGE_CONTAINER_NAME?.trim() ??
+    process.env.AZURE_STORAGE_CONTAINER_NAME?.trim() ||
     process.env.AZURE_BLOB_REPORTS_CONTAINER?.trim();
   const publicBaseUrl =
     options.publicBaseUrl?.trim() ?? process.env.API_PUBLIC_BASE_URL?.trim() ?? 'http://127.0.0.1:4000';

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,16 +1,20 @@
 {
-  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src",
-    "module": "commonjs",
     "target": "ES2022",
     "lib": ["ES2022"],
-    "types": ["node"],
+    "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
     "moduleResolution": "node",
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
     "resolveJsonModule": true,
+    "rootDir": "src",
+    "skipLibCheck": true,
     "sourceMap": true,
+    "strict": true,
+    "types": ["node"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,22 +1,30 @@
 {
-  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowSyntheticDefaultImports": true,
     "allowJs": false,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
     "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
     "module": "esnext",
     "moduleResolution": "bundler",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
+    "skipLibCheck": true,
+    "strict": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": [
+        "src/*"
+      ]
     },
     "plugins": [
       {
@@ -28,7 +36,10 @@
     "next-env.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -75,13 +75,14 @@ For the first Azure hosting pass, use two Linux App Service web apps:
 Why this route:
 
 - each app already has a production `start` script
+- each workspace tsconfig is self-contained, so App Service can build the app folder directly without relying on repo-root files
 - the monorepo stays intact, so we do not need to rewrite the runtime for Functions yet
 - GitHub Actions can build the workspace packages and deploy them with `azure/webapps-deploy@v3`
 - the API build rewrites TypeScript path aliases after compilation, so `node dist/server.js` starts cleanly in App Service
 
 Required app settings:
 
-- `SCM_DO_BUILD_DURING_DEPLOYMENT=true` on both apps so App Service installs dependencies during deployment
+- `SCM_DO_BUILD_DURING_DEPLOYMENT=true` on both apps so App Service installs dependencies and runs the workspace build during deployment
 - `NEXT_PUBLIC_API_BASE_URL=https://<api-app>.azurewebsites.net` on the web app
 - `DATABASE_URL=...` on the API app
 - `API_PUBLIC_BASE_URL=https://<api-app>.azurewebsites.net` on the API app

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -12,6 +12,8 @@ The remaining Azure hosting work is still future scope:
 - Azure Application Insights for monitoring and tracing
 - Azure Key Vault for secrets
 
+Phase 6 now focuses on turning those hosted pieces into a repeatable deployment path.
+
 ## Azure PostgreSQL Setup
 
 When creating the Flexible Server, keep the configuration small and inexpensive:
@@ -62,6 +64,24 @@ npm run dev:api
 - Use `.env.example` locally and Azure application settings in hosted environments.
 - Prefer structured JSON logs for API and workflow observability.
 - Use the same database schema and seed files for local verification and cloud setup.
+
+## Recommended Phase 6 Order
+
+1. Deploy the Next.js dashboard to Azure Static Web Apps or another Azure web host.
+2. Deploy the Express API to Azure Functions or another Azure API host.
+3. Connect Azure Blob Storage for report exports and any future uploaded artifacts.
+4. Copy the required environment variables into Azure application settings or Key Vault.
+5. Add Azure Application Insights so the hosted stack has basic tracing and error visibility.
+6. Capture deployment screenshots once the public or semi-public stack is live.
+
+## Recommendation
+
+For the first pass, keep the deployment small and auditable:
+
+- deploy the dashboard first so the UI has a stable public URL
+- keep the API and database as the next cut so the live data path stays consistent
+- wire Blob Storage only after the app and API URLs are stable
+- avoid adding extra Azure services until the core hosting path is verified
 
 ## Progress Notes
 

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -65,6 +65,52 @@ npm run dev:api
 - Prefer structured JSON logs for API and workflow observability.
 - Use the same database schema and seed files for local verification and cloud setup.
 
+## App Service First Pass
+
+For the first Azure hosting pass, use two Linux App Service web apps:
+
+- one app for `apps/web`
+- one app for `apps/api`
+
+Why this route:
+
+- each app already has a production `start` script
+- the monorepo stays intact, so we do not need to rewrite the runtime for Functions yet
+- GitHub Actions can build the workspace packages and deploy them with `azure/webapps-deploy@v3`
+- the API build rewrites TypeScript path aliases after compilation, so `node dist/server.js` starts cleanly in App Service
+
+Required app settings:
+
+- `SCM_DO_BUILD_DURING_DEPLOYMENT=true` on both apps so App Service installs dependencies during deployment
+- `NEXT_PUBLIC_API_BASE_URL=https://<api-app>.azurewebsites.net` on the web app
+- `DATABASE_URL=...` on the API app
+- `API_PUBLIC_BASE_URL=https://<api-app>.azurewebsites.net` on the API app
+- `AZURE_STORAGE_CONNECTION_STRING=...` on the API app
+- `AZURE_STORAGE_CONTAINER_NAME=...` on the API app
+- `N8N_WEBHOOK_SECRET=...` on the API app
+
+Startup command:
+
+- `npm start` on both apps so App Service launches the production script from each workspace package
+
+Optional settings:
+
+- `API_SHARED_SECRET=...` if you want to require a shared key for non-n8n mutating API calls
+- `NEXT_PUBLIC_API_SHARED_SECRET=...` only if the browser client is intentionally configured to send that shared key
+
+GitHub Actions inputs and secrets:
+
+- `vars.AZURE_WEBAPP_NAME_WEB`
+- `vars.AZURE_WEBAPP_NAME_API`
+- `secrets.AZURE_WEBAPP_PUBLISH_PROFILE_WEB`
+- `secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API`
+
+Recommended workflow:
+
+- run the manual Azure deployment workflow from the Actions tab
+- deploy the web app and API together after `npm run build:web` and `npm run build:api` pass
+- switch to push-based deployment later only after the App Service settings are stable
+
 ## Recommended Phase 6 Order
 
 1. Deploy the Next.js dashboard to Azure Static Web Apps or another Azure web host.

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Snapshot
 
-JobOps Copilot now has a working end-to-end foundation:
+JobOps Copilot now has a working end-to-end foundation through weekly reporting:
 
 - Next.js dashboard for jobs, outreach, reports, and settings
 - Express API with persistent job CRUD and AI analysis endpoints
@@ -18,6 +18,7 @@ JobOps Copilot now has a working end-to-end foundation:
 - Phase 2: AI parsing and fit scoring complete
 - Phase 3: outreach drafting and human review complete
 - Phase 3: outreach draft flow and optional Gmail draft creation browser-verified locally
+- Phase 5: weekly reporting complete, including persisted reports, dashboard history, and markdown export
 - Azure PostgreSQL bootstrap complete
 - repo CI complete
 - `main` branch protected
@@ -31,6 +32,7 @@ JobOps Copilot now has a working end-to-end foundation:
 - `draft-outreach` can optionally create a Gmail draft when the feature flag and OAuth credentials are configured
 - the outreach draft path and Gmail draft side effect were verified in the local browser against the live app
 - `generate-weekly-report` persists weekly reports, returns the saved draft, and feeds the reports dashboard
+- weekly reporting is persisted and surfaced through the dashboard and reports API
 - `POST /api/n8n/job-intake`, `POST /api/n8n/follow-up-reminders`, and `POST /api/n8n/weekly-report` expose the Phase 4 webhook surface
 - `GET /api/reports` and `GET /api/reports/latest` provide the saved weekly report history
 - The API switches between local file mode and Postgres mode depending on `DATABASE_URL`

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -40,6 +40,7 @@ JobOps Copilot now has a working end-to-end foundation through weekly reporting:
 
 ## What Is Still Pending
 
+- Azure App Service deployment scaffold exists, but the live web and API App Service resources still need to be provisioned and wired up
 - n8n runtime workflows and screenshots in a live n8n instance
 - full Azure hosting for the web and API apps
 - AI provider integration beyond the mock analysis layer

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -78,6 +78,7 @@ Complete:
 Partial:
 
 - Azure PostgreSQL is in place and verified
+- App Service deployment workflow scaffold is now in the repo
 - full static web app or app hosting still needs to be deployed
 - API hosting still needs to be deployed
 - Blob Storage, monitoring, and secrets management still need to be wired in

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,7 +7,7 @@
 - Phase 2: complete
 - Phase 3: complete
 - Phase 4: complete
-- Phase 5: in progress
+- Phase 5: complete
 - Phase 6: partial, because Azure PostgreSQL is complete but app hosting is still pending
 - Phase 7: planned
 - Phase 8: planned
@@ -66,7 +66,7 @@ In progress:
 
 ## Phase 5: Weekly Reporting
 
-In progress:
+Complete:
 
 - report storage
 - report dashboards

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/node": "^22.0.0",
         "@types/pg": "^8.20.0",
         "eslint": "^9.0.0",
+        "tsc-alias": "^1.8.17",
         "tsx": "^4.19.2",
         "typescript": "^5.8.0",
         "typescript-eslint": "^8.0.0"
@@ -2768,6 +2769,20 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2829,6 +2844,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -3021,6 +3046,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/body-parser": {
@@ -3225,6 +3263,44 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3250,6 +3326,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3486,6 +3572,19 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -4706,6 +4805,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5004,6 +5124,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -5694,6 +5827,20 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mylas": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.14.tgz",
+      "integrity": "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -5822,6 +5969,16 @@
       "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6094,6 +6251,16 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -6201,6 +6368,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -6340,6 +6520,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6414,6 +6604,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -6897,6 +7100,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7224,6 +7437,28 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsc-alias": {
+      "version": "1.8.17",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.17.tgz",
+      "integrity": "sha512-EIduCZHqbNwPm8BZYfq1aD7BQ697A4h6uSGMOFQfYGoQwfrYFTKwYfy9Bv42YxHkduVBcn9Zx0DkX111DKskyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "get-tsconfig": "^4.10.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=16.20.2"
       }
     },
     "node_modules/tsconfig-paths": {


### PR DESCRIPTION
## Summary
- add an Azure App Service deployment workflow scaffold for the web app and API
- make the API build rewrite TypeScript path aliases so the compiled server starts under plain Node/App Service
- document the required App Service settings, startup command, and deployment variables

## Verification
- npm run check
- node apps/api/dist/server.js + GET /api/health smoke test
