### PR TITLE
feat: Python AI agent service with real multi-provider LLM (Phase 9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,15 @@
 DATABASE_URL=
 AZURE_STORAGE_CONNECTION_STRING=
 AZURE_STORAGE_CONTAINER_NAME=
+# When set, the Node API delegates AI analysis to the Python agent service
+# (services/agent). Leave blank to use the built-in deterministic mock.
+AGENT_SERVICE_URL=http://127.0.0.1:8000
+AGENT_TIMEOUT_MS=60000
+# LLM configuration is consumed by the Python agent service. Supported
+# providers: anthropic | azure_openai | openai | google_genai. Leave
+# LLM_PROVIDER blank to auto-select the first one with credentials.
 LLM_PROVIDER=
+ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 AZURE_OPENAI_ENDPOINT=
 AZURE_OPENAI_API_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,29 @@ jobs:
         env:
           CI: true
         run: npm run check
+
+  agent:
+    name: Agent service (Python)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/agent
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: services/agent/requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Lint (ruff)
+        run: ruff check app tests
+
+      - name: Test (pytest)
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,11 @@ workflows/n8n/owner.env
 .playwright-mcp/
 .serena/
 tmp/
+
+# Python (services/agent)
+.venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+*.egg-info/

--- a/apps/api/src/lib/agent-client.ts
+++ b/apps/api/src/lib/agent-client.ts
@@ -1,0 +1,126 @@
+/**
+ * Client for the Python AI agent service (services/agent).
+ *
+ * When AGENT_SERVICE_URL is set, analysis is delegated to the real-LLM agent
+ * service. On any failure (unset URL, network error, non-2xx, invalid payload),
+ * we transparently fall back to the deterministic mock in analysis-core /
+ * mock-store. This preserves the project's offline/demo resilience: the app
+ * always returns a valid, validated result.
+ */
+
+import {
+  parseJobDescription,
+  scoreJobFit,
+  validateFitScoreOutput,
+  validateParsedJobOutput,
+  type FitScoreOutput,
+  type ParsedJobOutput,
+} from '@/lib/analysis-core';
+import { draftOutreachBody } from '@/data/mock-store';
+import type { DraftOutreachBody } from '@/types';
+
+const AGENT_URL = process.env.AGENT_SERVICE_URL?.trim().replace(/\/$/, '');
+const AGENT_TIMEOUT_MS = Number(process.env.AGENT_TIMEOUT_MS ?? 60_000);
+
+export function isAgentEnabled(): boolean {
+  return Boolean(AGENT_URL);
+}
+
+async function callAgent<T>(path: string, payload: unknown): Promise<T> {
+  const response = await fetch(`${AGENT_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(AGENT_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`agent ${path} responded with ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export interface ScoreFitInput {
+  descriptionText: string;
+  resumeText: string;
+  profileText: string;
+  requiredSkills?: string[];
+  preferredSkills?: string[];
+  atsKeywords?: string[];
+  retrievedContext?: string[];
+}
+
+export interface OutreachDraftResult {
+  subject: string;
+  draft_text: string;
+  safety_notes?: string;
+}
+
+/** Parse a job description via the agent, falling back to the mock parser. */
+export async function resolveParsedJob(descriptionText: string): Promise<ParsedJobOutput> {
+  if (isAgentEnabled()) {
+    try {
+      const parsed = await callAgent<ParsedJobOutput>('/parse-job', {
+        description_text: descriptionText,
+      });
+      if (validateParsedJobOutput(parsed)) {
+        return parsed;
+      }
+      console.warn('agent /parse-job returned an invalid payload; falling back to mock');
+    } catch (error) {
+      console.warn('agent /parse-job failed; falling back to mock', error);
+    }
+  }
+  return parseJobDescription(descriptionText);
+}
+
+/** Score job fit via the agent, falling back to the mock scorer. */
+export async function resolveFitScore(input: ScoreFitInput): Promise<FitScoreOutput> {
+  if (isAgentEnabled()) {
+    try {
+      const scored = await callAgent<FitScoreOutput>('/score-fit', {
+        description_text: input.descriptionText,
+        resume_text: input.resumeText,
+        profile_text: input.profileText,
+        required_skills: input.requiredSkills,
+        preferred_skills: input.preferredSkills,
+        ats_keywords: input.atsKeywords,
+        retrieved_context: input.retrievedContext,
+      });
+      if (validateFitScoreOutput(scored)) {
+        return scored;
+      }
+      console.warn('agent /score-fit returned an invalid payload; falling back to mock');
+    } catch (error) {
+      console.warn('agent /score-fit failed; falling back to mock', error);
+    }
+  }
+  return scoreJobFit(input);
+}
+
+/** Draft outreach via the agent, falling back to the mock drafter. */
+export async function resolveOutreachDraft(
+  payload: DraftOutreachBody & { company?: string; retrieved_context?: string[] },
+): Promise<OutreachDraftResult> {
+  if (isAgentEnabled()) {
+    try {
+      const draft = await callAgent<OutreachDraftResult>('/draft-outreach', {
+        message_type: payload.message_type,
+        contact_name: payload.contact_name,
+        contact_role: payload.contact_role,
+        company: payload.company,
+        job_context: payload.job_context,
+        resume_summary: payload.resume_summary,
+        retrieved_context: payload.retrieved_context,
+      });
+      if (draft && typeof draft.draft_text === 'string' && draft.draft_text.trim()) {
+        return draft;
+      }
+      console.warn('agent /draft-outreach returned an invalid payload; falling back to mock');
+    } catch (error) {
+      console.warn('agent /draft-outreach failed; falling back to mock', error);
+    }
+  }
+  return draftOutreachBody(payload);
+}

--- a/apps/api/src/lib/analysis-core.ts
+++ b/apps/api/src/lib/analysis-core.ts
@@ -105,9 +105,11 @@ function buildResponsibilities(keywords: string[]) {
   return keywords.slice(0, 4).map((keyword) => `Contribute to ${keyword.toLowerCase()} initiatives.`);
 }
 
-function baseAnalysis(descriptionText: string): JobAnalysis {
-  const parsed = parseJobDescription(descriptionText);
-
+/**
+ * Map a parsed job description (from the mock parser OR the real LLM agent)
+ * into a persisted JobAnalysis record. Pure function so both paths agree.
+ */
+export function analysisFromParsed(parsed: ParsedJobOutput): JobAnalysis {
   return {
     requiredSkills: parsed.required_skills,
     preferredSkills: parsed.preferred_skills,
@@ -120,6 +122,37 @@ function baseAnalysis(descriptionText: string): JobAnalysis {
     confidenceScore: 48,
     modelUsed: 'mock-analysis-v1',
   };
+}
+
+/**
+ * Map a fit-score result (mock OR real LLM agent) into a persisted JobAnalysis.
+ * Pure function: keeps the score route and n8n route in agreement.
+ */
+export function analysisFromFit(
+  fit: FitScoreOutput,
+  context: { requiredSkills: string[]; preferredSkills: string[] },
+): JobAnalysis {
+  return {
+    requiredSkills: unique(context.requiredSkills),
+    preferredSkills: unique(context.preferredSkills),
+    matchedSkills: fit.matched_skills,
+    missingSkills: fit.missing_skills,
+    atsKeywords: fit.ats_keywords,
+    fitSummary: fit.fit_summary,
+    recommendedResumeAngle: fit.recommended_resume_angle,
+    applyRecommendation:
+      fit.apply_recommendation === 'apply'
+        ? 'Apply with a customized resume and a short human-reviewed outreach message.'
+        : fit.apply_recommendation === 'review'
+          ? 'Review manually before deciding whether to apply.'
+          : 'Hold off unless you can make a stronger truthful case.',
+    confidenceScore: fit.confidence_score,
+    modelUsed: fit.model_used,
+  };
+}
+
+function baseAnalysis(descriptionText: string): JobAnalysis {
+  return analysisFromParsed(parseJobDescription(descriptionText));
 }
 
 export function parseJobDescription(descriptionText: string): ParsedJobOutput {
@@ -196,24 +229,12 @@ export function buildAnalysisFromScore(input: {
   atsKeywords?: string[];
 }): JobAnalysis {
   const fit = scoreJobFit(input);
+  const parsed = parseJobDescription(input.descriptionText);
 
-  return {
-    requiredSkills: unique(input.requiredSkills ?? parseJobDescription(input.descriptionText).required_skills),
-    preferredSkills: unique(input.preferredSkills ?? parseJobDescription(input.descriptionText).preferred_skills),
-    matchedSkills: fit.matched_skills,
-    missingSkills: fit.missing_skills,
-    atsKeywords: fit.ats_keywords,
-    fitSummary: fit.fit_summary,
-    recommendedResumeAngle: fit.recommended_resume_angle,
-    applyRecommendation:
-      fit.apply_recommendation === 'apply'
-        ? 'Apply with a customized resume and a short human-reviewed outreach message.'
-        : fit.apply_recommendation === 'review'
-          ? 'Review manually before deciding whether to apply.'
-          : 'Hold off unless you can make a stronger truthful case.',
-    confidenceScore: fit.confidence_score,
-    modelUsed: fit.model_used,
-  };
+  return analysisFromFit(fit, {
+    requiredSkills: input.requiredSkills ?? parsed.required_skills,
+    preferredSkills: input.preferredSkills ?? parsed.preferred_skills,
+  });
 }
 
 export function validateParsedJobOutput(value: unknown): value is ParsedJobOutput {

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -1,16 +1,14 @@
 import { randomUUID } from 'node:crypto';
 import { Router } from 'express';
 import {
-  buildAnalysisFromParse,
-  buildAnalysisFromScore,
-  parseJobDescription,
-  scoreJobFit,
+  analysisFromFit,
+  analysisFromParsed,
   validateFitScoreOutput,
   validateParsedJobOutput,
 } from '@/lib/analysis-core';
+import { resolveFitScore, resolveOutreachDraft, resolveParsedJob } from '@/lib/agent-client';
 import { isSingleRecipientEmailAddress } from '@/lib/email';
 import { createGmailDraftIfEnabled } from '@/lib/gmail';
-import { draftOutreachBody } from '@/data/mock-store';
 import {
   appendOutreachDraft,
   getJobById,
@@ -34,7 +32,7 @@ aiRouter.post('/parse-job', async (request, response, next) => {
       return response.status(400).json({ error: 'description_text is required' });
     }
 
-    const parsed = parseJobDescription(body.description_text);
+    const parsed = await resolveParsedJob(body.description_text);
 
     if (!validateParsedJobOutput(parsed)) {
       return response.status(500).json({ error: 'AI parser returned an invalid payload' });
@@ -46,7 +44,7 @@ aiRouter.post('/parse-job', async (request, response, next) => {
         return response.status(404).json({ error: 'Job not found' });
       }
 
-      await saveJobAnalysis(body.job_id, buildAnalysisFromParse(body.description_text));
+      await saveJobAnalysis(body.job_id, analysisFromParsed(parsed));
     }
 
     return response.json({
@@ -75,7 +73,7 @@ aiRouter.post('/score-fit', async (request, response, next) => {
       return response.status(404).json({ error: 'Job not found' });
     }
 
-    const scored = scoreJobFit({
+    const scored = await resolveFitScore({
       descriptionText: job.descriptionText,
       resumeText: body.resume_text,
       profileText: body.profile_text,
@@ -88,13 +86,9 @@ aiRouter.post('/score-fit', async (request, response, next) => {
       return response.status(500).json({ error: 'AI scorer returned an invalid payload' });
     }
 
-    const analysis = buildAnalysisFromScore({
-      descriptionText: job.descriptionText,
-      resumeText: body.resume_text,
-      profileText: body.profile_text,
+    const analysis = analysisFromFit(scored, {
       requiredSkills: job.analysis.requiredSkills,
       preferredSkills: job.analysis.preferredSkills,
-      atsKeywords: job.analysis.atsKeywords,
     });
 
     await saveJobAnalysis(body.job_id, analysis, scored.fit_score);
@@ -129,9 +123,10 @@ aiRouter.post('/draft-outreach', async (request, response, next) => {
     }
   }
 
-  const payload = draftOutreachBody({
+  const payload = await resolveOutreachDraft({
     ...body,
     contact_email: contactEmail,
+    company: job?.company,
     job_context: body.job_context ?? job?.descriptionText,
     resume_summary: body.resume_summary,
   });

--- a/apps/api/src/routes/n8n.ts
+++ b/apps/api/src/routes/n8n.ts
@@ -7,13 +7,12 @@ import {
 } from '@/data/job-store';
 import { saveWeeklyReport } from '@/data/report-store';
 import {
-  buildAnalysisFromParse,
-  buildAnalysisFromScore,
-  parseJobDescription,
-  scoreJobFit,
+  analysisFromFit,
+  analysisFromParsed,
   validateFitScoreOutput,
   validateParsedJobOutput,
 } from '@/lib/analysis-core';
+import { resolveFitScore, resolveParsedJob } from '@/lib/agent-client';
 import { exportWeeklyReportMarkdown } from '@/lib/report-export';
 import { getRequestBaseUrl } from '@/lib/request-url';
 import {
@@ -207,20 +206,20 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
         descriptionText: validation.normalized.descriptionText!,
       });
 
-      const parsed = parseJobDescription(createdJob.descriptionText);
+      const parsed = await resolveParsedJob(createdJob.descriptionText);
 
       if (!validateParsedJobOutput(parsed)) {
         response.status(500).json({ error: 'n8n parser returned an invalid payload' });
         return;
       }
 
-      let analysis = buildAnalysisFromParse(createdJob.descriptionText);
+      let analysis = analysisFromParsed(parsed);
       let fitStatus: 'skipped' | 'scored' = 'skipped';
       let fitMessage = 'Fit scoring was skipped because resume/profile context was not supplied.';
       let fitScore: number | null | undefined;
 
       if (validation.normalized.resumeText && validation.normalized.profileText) {
-        const fit = scoreJobFit({
+        const fit = await resolveFitScore({
           descriptionText: createdJob.descriptionText,
           resumeText: validation.normalized.resumeText,
           profileText: validation.normalized.profileText,
@@ -234,13 +233,9 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
           return;
         }
 
-        analysis = buildAnalysisFromScore({
-          descriptionText: createdJob.descriptionText,
-          resumeText: validation.normalized.resumeText,
-          profileText: validation.normalized.profileText,
+        analysis = analysisFromFit(fit, {
           requiredSkills: parsed.required_skills,
           preferredSkills: parsed.preferred_skills,
-          atsKeywords: [...parsed.required_skills, ...parsed.preferred_skills],
         });
         fitStatus = 'scored';
         fitMessage = `Fit scoring completed with a score of ${fit.fit_score}.`;

--- a/services/agent/.env.example
+++ b/services/agent/.env.example
@@ -1,0 +1,30 @@
+# Pick a provider explicitly, or leave LLM_PROVIDER blank to auto-select the
+# first one with credentials. Supported: anthropic | azure_openai | openai | google_genai
+LLM_PROVIDER=
+
+# Anthropic Claude
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-sonnet-4-6
+
+# OpenAI
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+
+# Azure OpenAI
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_API_VERSION=2024-10-21
+AZURE_OPENAI_DEPLOYMENT=
+
+# Google Gemini
+GOOGLE_GEMINI_API_KEY=
+GEMINI_MODEL=gemini-2.0-flash
+
+# RAG (Phase 10) — reuse the same Postgres as the Node API
+DATABASE_URL=
+
+# Research agent web search (Phase 8, optional)
+TAVILY_API_KEY=
+
+LLM_TEMPERATURE=0.2
+REQUEST_TIMEOUT=60

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+COPY app ./app
+
+EXPOSE 8000
+
+# Azure App Service / Container Apps inject PORT; default to 8000 locally.
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -1,0 +1,67 @@
+# JobOps Copilot — AI Agent Service
+
+A Python **FastAPI** microservice that provides the real, LLM-powered AI layer
+for JobOps Copilot. The Node API (`apps/api`) delegates analysis to this service
+when `AGENT_SERVICE_URL` is set, and transparently falls back to its
+deterministic mock when the service is unavailable or unconfigured.
+
+Built with **LangChain** on a **provider-agnostic** model router: Anthropic
+Claude, Azure OpenAI, OpenAI, or Google Gemini — selected by `LLM_PROVIDER` or
+auto-detected from whichever credentials are present.
+
+## Endpoints (Phase 9)
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/health` | Liveness + whether an LLM provider is configured. |
+| `POST` | `/parse-job` | Structured job-description parsing. |
+| `POST` | `/score-fit` | Honest, evidence-grounded resume/job fit scoring. |
+| `POST` | `/draft-outreach` | Human-review outreach drafting. |
+| `POST` | `/weekly-recommendations` | LLM-narrated weekly strategy recommendations. |
+
+Later phases add `/rag/*` (Phase 10), `/agents/*` (Phase 8), and
+`/telemetry/*` (Phase 11).
+
+Each endpoint returns **structured, validated JSON** whose shape mirrors the
+TypeScript contracts in `apps/api/src/lib/analysis-core.ts`, so the Node API
+consumes responses without translation. When no provider is configured the
+endpoints return `503` and the Node API uses its mock.
+
+## Local development
+
+```bash
+cd services/agent
+python -m venv .venv
+.venv/Scripts/activate        # Windows
+# source .venv/bin/activate   # macOS/Linux
+pip install -r requirements-dev.txt
+
+cp .env.example .env          # set a provider key, e.g. ANTHROPIC_API_KEY
+uvicorn app.main:app --reload --port 8000
+```
+
+Point the Node API at it:
+
+```bash
+# in the repo root .env
+AGENT_SERVICE_URL=http://127.0.0.1:8000
+```
+
+## Tests & lint
+
+```bash
+pytest          # CI-safe: runs without any provider credentials
+ruff check app tests
+```
+
+## Configuration
+
+See `.env.example`. Key variables: `LLM_PROVIDER`, `ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, `AZURE_OPENAI_*`, `GOOGLE_GEMINI_API_KEY`, `DATABASE_URL`
+(Phase 10 RAG), `TAVILY_API_KEY` (Phase 8 research agent).
+
+## Safety
+
+The prompts enforce JobOps Copilot's rules: stay grounded in the source text,
+never fabricate resume experience, keep recommendations honest and
+conservative, and never imply auto-sending. Outreach is always human-reviewed.

--- a/services/agent/app/__init__.py
+++ b/services/agent/app/__init__.py
@@ -1,0 +1,1 @@
+"""JobOps Copilot AI agent service."""

--- a/services/agent/app/chains/draft_outreach.py
+++ b/services/agent/app/chains/draft_outreach.py
@@ -1,0 +1,31 @@
+"""Draft an outreach message for human review with a real LLM."""
+
+from __future__ import annotations
+
+from app.llm.provider import get_model
+from app.prompts import OUTREACH_DRAFTER_SYSTEM
+from app.schemas import DraftOutreachRequest, OutreachDraftLLM, OutreachDraftResponse
+
+
+def draft_outreach(req: DraftOutreachRequest) -> OutreachDraftResponse:
+    model, label = get_model()
+    structured = model.with_structured_output(OutreachDraftLLM)
+
+    parts = [f"Message type: {req.message_type}"]
+    if req.contact_name:
+        parts.append(f"Contact name: {req.contact_name}")
+    if req.contact_role:
+        parts.append(f"Contact role: {req.contact_role}")
+    if req.company:
+        parts.append(f"Company: {req.company}")
+    if req.job_context:
+        parts.append(f"Job context:\n{req.job_context}")
+    if req.resume_summary:
+        parts.append(f"Resume summary (only truthful claims allowed):\n{req.resume_summary}")
+    if req.retrieved_context:
+        evidence = "\n".join(f"- {chunk}" for chunk in req.retrieved_context)
+        parts.append("Relevant resume evidence to draw from:\n" + evidence)
+
+    messages = [("system", OUTREACH_DRAFTER_SYSTEM), ("human", "\n\n".join(parts))]
+    result = structured.invoke(messages)
+    return OutreachDraftResponse(**result.model_dump(), model_used=label)

--- a/services/agent/app/chains/parse_job.py
+++ b/services/agent/app/chains/parse_job.py
@@ -1,0 +1,17 @@
+"""Parse a raw job description into structured fields with a real LLM."""
+
+from __future__ import annotations
+
+from app.llm.provider import get_model
+from app.prompts import JOB_PARSER_SYSTEM
+from app.schemas import ParsedJob
+
+
+def parse_job(description_text: str) -> ParsedJob:
+    model, _ = get_model()
+    structured = model.with_structured_output(ParsedJob)
+    messages = [
+        ("system", JOB_PARSER_SYSTEM),
+        ("human", f"Job description:\n\n{description_text}"),
+    ]
+    return structured.invoke(messages)

--- a/services/agent/app/chains/score_fit.py
+++ b/services/agent/app/chains/score_fit.py
@@ -1,0 +1,36 @@
+"""Score a job against the user's resume/profile with a real LLM.
+
+Supports optional retrieved resume evidence (Phase 10 RAG): when present, the
+model is told to ground its matched skills and summary in those snippets.
+"""
+
+from __future__ import annotations
+
+from app.llm.provider import get_model
+from app.prompts import FIT_SCORER_SYSTEM
+from app.schemas import FitScoreLLM, FitScoreResponse, ScoreFitRequest
+
+
+def score_fit(req: ScoreFitRequest) -> FitScoreResponse:
+    model, label = get_model()
+    structured = model.with_structured_output(FitScoreLLM)
+
+    parts = [
+        f"Job description:\n{req.description_text}",
+        f"Resume:\n{req.resume_text}",
+        f"Profile / extra context:\n{req.profile_text}",
+    ]
+    if req.required_skills:
+        parts.append("Known required skills: " + ", ".join(req.required_skills))
+    if req.preferred_skills:
+        parts.append("Known preferred skills: " + ", ".join(req.preferred_skills))
+    if req.retrieved_context:
+        evidence = "\n".join(f"- {chunk}" for chunk in req.retrieved_context)
+        parts.append(
+            "Retrieved resume evidence (ground matched_skills and the summary in these):\n"
+            + evidence
+        )
+
+    messages = [("system", FIT_SCORER_SYSTEM), ("human", "\n\n".join(parts))]
+    result = structured.invoke(messages)
+    return FitScoreResponse(**result.model_dump(), model_used=label)

--- a/services/agent/app/chains/weekly.py
+++ b/services/agent/app/chains/weekly.py
@@ -1,0 +1,21 @@
+"""Generate LLM-narrated weekly recommendations from pipeline metrics."""
+
+from __future__ import annotations
+
+from app.llm.provider import get_model
+from app.prompts import WEEKLY_RECOMMENDATIONS_SYSTEM
+from app.schemas import WeeklyRecommendationsLLM, WeeklyRecommendationsRequest
+
+
+def weekly_recommendations(req: WeeklyRecommendationsRequest) -> WeeklyRecommendationsLLM:
+    model, _ = get_model()
+    structured = model.with_structured_output(WeeklyRecommendationsLLM)
+
+    metrics_lines = "\n".join(f"- {key}: {value}" for key, value in req.metrics.items())
+    missing = ", ".join(req.common_missing_skills) or "none reported"
+    human = (
+        f"Weekly pipeline metrics:\n{metrics_lines}\n\n"
+        f"Most common missing skills: {missing}"
+    )
+    messages = [("system", WEEKLY_RECOMMENDATIONS_SYSTEM), ("human", human)]
+    return structured.invoke(messages)

--- a/services/agent/app/config.py
+++ b/services/agent/app/config.py
@@ -1,0 +1,46 @@
+"""Runtime configuration loaded from environment variables.
+
+Field names map to upper-case env vars (case-insensitive), e.g. ``llm_provider``
+reads ``LLM_PROVIDER``. Mirrors the names already used in the repo root
+``.env.example`` so the Python service and the Node API share one config story.
+"""
+
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    # Provider selection. When unset, the first provider with credentials wins.
+    llm_provider: str | None = None
+
+    # Anthropic Claude
+    anthropic_api_key: str | None = None
+    anthropic_model: str = "claude-sonnet-4-6"
+
+    # OpenAI
+    openai_api_key: str | None = None
+    openai_model: str = "gpt-4o-mini"
+
+    # Azure OpenAI
+    azure_openai_endpoint: str | None = None
+    azure_openai_api_key: str | None = None
+    azure_openai_api_version: str = "2024-10-21"
+    azure_openai_deployment: str | None = None
+
+    # Google Gemini
+    google_gemini_api_key: str | None = None
+    gemini_model: str = "gemini-2.0-flash"
+
+    # Shared
+    database_url: str | None = None
+    request_timeout: int = 60
+    llm_temperature: float = 0.2
+
+    # Optional web-search tool for the research agent (Phase 8)
+    tavily_api_key: str | None = None
+
+
+settings = Settings()

--- a/services/agent/app/llm/provider.py
+++ b/services/agent/app/llm/provider.py
@@ -1,0 +1,82 @@
+"""Provider-agnostic LLM router.
+
+Selects between Anthropic Claude, Azure OpenAI, OpenAI, and Google Gemini based
+on ``LLM_PROVIDER`` (explicit) or whichever credentials are present (implicit).
+Built on LangChain's ``init_chat_model`` so the rest of the service is provider
+independent.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from langchain.chat_models import init_chat_model
+
+from app.config import settings
+
+
+class LLMNotConfigured(RuntimeError):
+    """Raised when no provider credentials are available."""
+
+
+def resolve_provider() -> str | None:
+    """Return the active provider id, or None when nothing is configured."""
+    if settings.llm_provider:
+        return settings.llm_provider.strip().lower()
+    if settings.anthropic_api_key:
+        return "anthropic"
+    if settings.azure_openai_api_key and settings.azure_openai_endpoint:
+        return "azure_openai"
+    if settings.openai_api_key:
+        return "openai"
+    if settings.google_gemini_api_key:
+        return "google_genai"
+    return None
+
+
+def llm_available() -> bool:
+    return resolve_provider() is not None
+
+
+@lru_cache(maxsize=1)
+def get_model():
+    """Return ``(chat_model, model_label)`` for the active provider.
+
+    ``model_label`` is recorded as ``model_used`` on responses for auditability.
+    """
+    provider = resolve_provider()
+    if provider is None:
+        raise LLMNotConfigured(
+            "No LLM provider configured. Set LLM_PROVIDER and the matching API key "
+            "(ANTHROPIC_API_KEY, AZURE_OPENAI_*, OPENAI_API_KEY, or GOOGLE_GEMINI_API_KEY)."
+        )
+
+    common = {"temperature": settings.llm_temperature, "timeout": settings.request_timeout}
+
+    if provider == "anthropic":
+        model = settings.anthropic_model
+        chat = init_chat_model(
+            f"anthropic:{model}", api_key=settings.anthropic_api_key, **common
+        )
+    elif provider == "openai":
+        model = settings.openai_model
+        chat = init_chat_model(f"openai:{model}", api_key=settings.openai_api_key, **common)
+    elif provider == "azure_openai":
+        model = settings.azure_openai_deployment or "gpt-4o-mini"
+        chat = init_chat_model(
+            model,
+            model_provider="azure_openai",
+            azure_endpoint=settings.azure_openai_endpoint,
+            api_key=settings.azure_openai_api_key,
+            api_version=settings.azure_openai_api_version,
+            **common,
+        )
+    elif provider == "google_genai":
+        model = settings.gemini_model
+        chat = init_chat_model(
+            f"google_genai:{model}", api_key=settings.google_gemini_api_key, **common
+        )
+    else:
+        raise LLMNotConfigured(f"Unsupported LLM_PROVIDER: {provider!r}")
+
+    return chat, f"{provider}:{model}"

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -1,0 +1,90 @@
+"""JobOps Copilot AI agent service (FastAPI).
+
+Exposes real-LLM analysis endpoints that the Node API delegates to when
+``AGENT_SERVICE_URL`` is set. Returns 503 when no provider is configured so the
+Node API can transparently fall back to its deterministic mock.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, HTTPException
+
+from app.chains.draft_outreach import draft_outreach
+from app.chains.parse_job import parse_job
+from app.chains.score_fit import score_fit
+from app.chains.weekly import weekly_recommendations
+from app.llm.provider import LLMNotConfigured, llm_available, resolve_provider
+from app.schemas import (
+    DraftOutreachRequest,
+    FitScoreResponse,
+    OutreachDraftResponse,
+    ParsedJob,
+    ParseJobRequest,
+    ScoreFitRequest,
+    WeeklyRecommendationsLLM,
+    WeeklyRecommendationsRequest,
+)
+
+logger = logging.getLogger("jobops.agent")
+
+app = FastAPI(
+    title="JobOps Copilot Agent Service",
+    version="0.1.0",
+    summary="Real-LLM analysis and agent orchestration for JobOps Copilot.",
+)
+
+
+def _require_llm() -> None:
+    if not llm_available():
+        raise HTTPException(
+            status_code=503,
+            detail="LLM provider not configured; the API will use its mock fallback.",
+        )
+
+
+def _run(fn, *args):
+    """Execute a chain, translating provider errors into clean HTTP errors."""
+    try:
+        return fn(*args)
+    except LLMNotConfigured as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 - surface upstream model/network failures
+        logger.exception("agent chain failed")
+        raise HTTPException(status_code=502, detail=f"Agent chain failed: {exc}") from exc
+
+
+@app.get("/health")
+def health() -> dict:
+    return {
+        "status": "ok",
+        "llm_configured": llm_available(),
+        "provider": resolve_provider(),
+    }
+
+
+@app.post("/parse-job", response_model=ParsedJob)
+def parse_job_endpoint(req: ParseJobRequest) -> ParsedJob:
+    _require_llm()
+    return _run(parse_job, req.description_text)
+
+
+@app.post("/score-fit", response_model=FitScoreResponse)
+def score_fit_endpoint(req: ScoreFitRequest) -> FitScoreResponse:
+    _require_llm()
+    return _run(score_fit, req)
+
+
+@app.post("/draft-outreach", response_model=OutreachDraftResponse)
+def draft_outreach_endpoint(req: DraftOutreachRequest) -> OutreachDraftResponse:
+    _require_llm()
+    return _run(draft_outreach, req)
+
+
+@app.post("/weekly-recommendations", response_model=WeeklyRecommendationsLLM)
+def weekly_recommendations_endpoint(
+    req: WeeklyRecommendationsRequest,
+) -> WeeklyRecommendationsLLM:
+    _require_llm()
+    return _run(weekly_recommendations, req)

--- a/services/agent/app/prompts.py
+++ b/services/agent/app/prompts.py
@@ -1,0 +1,50 @@
+"""System prompts for the analysis chains.
+
+These are the deployable, inlined versions of the canonical templates in the
+repo-root ``prompts/`` directory. Keeping them in code makes the container
+self-contained; the markdown files remain the human-facing source of truth.
+Every prompt enforces the project's safety rules: stay grounded in the source
+text, never fabricate resume experience, never auto-send.
+"""
+
+JOB_PARSER_SYSTEM = """You convert a raw job description into structured, auditable data.
+
+Rules:
+- Stay grounded in the source text; do not infer aggressively.
+- Use null for company/title when they are genuinely unknown.
+- Separate cloud tools, automation tools, programming languages, and soft skills where possible.
+- seniority must be one of: junior, mid, senior, lead, unknown.
+- Keep the summary to 1-2 plain sentences describing the role.
+"""
+
+FIT_SCORER_SYSTEM = """You compare a job against the user's resume and profile and produce a transparent, honest fit assessment.
+
+Rules:
+- Never fabricate or assume resume experience that is not present in the provided text.
+- matched_skills must be supported by the resume/profile; missing_skills are required skills not evidenced.
+- fit_score (0-100) and confidence_score (0-100) must reflect the real overlap, not optimism.
+- apply_recommendation: "apply" only for strong, well-evidenced fits; "review" for partial; "pass" for weak.
+- recommended_resume_angle must only suggest truthful reordering/emphasis of existing experience.
+- When retrieved resume evidence is provided, ground matched_skills and the summary in those snippets.
+- Explain the score in plain language in fit_summary.
+"""
+
+OUTREACH_DRAFTER_SYSTEM = """You draft concise, human-sounding outreach messages for the user to review before sending.
+
+Rules:
+- Keep it concise, specific, and professional; no filler.
+- Never claim the user has applied unless explicitly told the CRM status confirms it.
+- Never imply the message will be auto-sent; it is always human-reviewed.
+- Keep all claims truthful and grounded in the provided job context and resume summary.
+- Put any claim that needs manual verification into safety_notes.
+- Tailor tone to message_type (recruiter_email, linkedin_connection, referral_request, follow_up, thank_you).
+"""
+
+WEEKLY_RECOMMENDATIONS_SYSTEM = """You are a job-search operations strategist. Given weekly pipeline metrics and the
+most common missing skills, write 2-4 short, concrete, prioritized recommendations for the coming week.
+
+Rules:
+- Be specific and actionable; reference the actual numbers.
+- Keep it honest and encouraging without hype.
+- Focus on the highest-leverage next actions (e.g., converting shortlisted roles, closing skill gaps).
+"""

--- a/services/agent/app/schemas.py
+++ b/services/agent/app/schemas.py
@@ -1,0 +1,111 @@
+"""Pydantic schemas.
+
+The output schemas intentionally mirror the TypeScript contracts in
+``apps/api/src/lib/analysis-core.ts`` (``ParsedJobOutput``, ``FitScoreOutput``)
+and ``prompts/*.md`` so the Node API can consume agent responses without any
+shape translation and fall back to its deterministic mock when this service is
+unavailable.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+Seniority = Literal["junior", "mid", "senior", "lead", "unknown"]
+ApplyRecommendation = Literal["apply", "review", "pass"]
+MessageType = Literal[
+    "recruiter_email",
+    "linkedin_connection",
+    "referral_request",
+    "follow_up",
+    "thank_you",
+]
+
+
+# --- LLM structured outputs ------------------------------------------------
+
+
+class ParsedJob(BaseModel):
+    """Structured job description. Matches ParsedJobOutput in the Node API."""
+
+    company: str | None = Field(default=None, description="Hiring company, or null if unknown.")
+    title: str | None = Field(default=None, description="Role title, or null if unknown.")
+    required_skills: list[str] = Field(default_factory=list)
+    preferred_skills: list[str] = Field(default_factory=list)
+    responsibilities: list[str] = Field(default_factory=list)
+    seniority: Seniority = "unknown"
+    cloud_tools: list[str] = Field(default_factory=list)
+    automation_tools: list[str] = Field(default_factory=list)
+    summary: str = ""
+
+
+class FitScoreLLM(BaseModel):
+    """Fields the model produces for a fit assessment."""
+
+    fit_score: int = Field(ge=0, le=100, description="Overall fit, 0-100.")
+    matched_skills: list[str] = Field(default_factory=list)
+    missing_skills: list[str] = Field(default_factory=list)
+    ats_keywords: list[str] = Field(default_factory=list)
+    fit_summary: str = ""
+    recommended_resume_angle: str = ""
+    apply_recommendation: ApplyRecommendation = "review"
+    confidence_score: int = Field(default=50, ge=0, le=100)
+
+
+class OutreachDraftLLM(BaseModel):
+    """Fields the model produces for an outreach message."""
+
+    subject: str = ""
+    draft_text: str = ""
+    safety_notes: str = ""
+
+
+class WeeklyRecommendationsLLM(BaseModel):
+    recommendations: str = ""
+
+
+# --- API request bodies ----------------------------------------------------
+
+
+class ParseJobRequest(BaseModel):
+    description_text: str
+
+
+class ScoreFitRequest(BaseModel):
+    description_text: str
+    resume_text: str
+    profile_text: str
+    required_skills: list[str] | None = None
+    preferred_skills: list[str] | None = None
+    ats_keywords: list[str] | None = None
+    # Optional retrieved resume evidence (Phase 10 RAG). When present the model
+    # is instructed to ground its assessment in these snippets.
+    retrieved_context: list[str] | None = None
+
+
+class DraftOutreachRequest(BaseModel):
+    message_type: MessageType
+    contact_name: str | None = None
+    contact_role: str | None = None
+    company: str | None = None
+    job_context: str | None = None
+    resume_summary: str | None = None
+    retrieved_context: list[str] | None = None
+
+
+class WeeklyRecommendationsRequest(BaseModel):
+    metrics: dict[str, int] = Field(default_factory=dict)
+    common_missing_skills: list[str] = Field(default_factory=list)
+
+
+# --- API responses (add server-controlled fields) --------------------------
+
+
+class FitScoreResponse(FitScoreLLM):
+    model_used: str
+
+
+class OutreachDraftResponse(OutreachDraftLLM):
+    model_used: str

--- a/services/agent/pyproject.toml
+++ b/services/agent/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "jobops-agent"
+version = "0.1.0"
+description = "JobOps Copilot AI agent service (FastAPI + LangChain)."
+requires-python = ">=3.11"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.ruff.lint.per-file-ignores]
+# Prose system prompts read better as natural sentences than hard-wrapped.
+"app/prompts.py" = ["E501"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]

--- a/services/agent/requirements-dev.txt
+++ b/services/agent/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest>=8.0,<9
+ruff>=0.6,<1
+httpx>=0.27,<1

--- a/services/agent/requirements.txt
+++ b/services/agent/requirements.txt
@@ -1,0 +1,14 @@
+# Core service + LLM providers (Phase 9).
+# RAG deps (psycopg, pgvector, sentence-transformers) are added in Phase 10,
+# telemetry deps (pandas) in Phase 11.
+fastapi>=0.115,<0.120
+uvicorn[standard]>=0.30,<0.40
+pydantic>=2.7,<3
+pydantic-settings>=2.3,<3
+python-dotenv>=1.0,<2
+
+# LangChain provider-agnostic layer
+langchain>=1.0,<2
+langchain-anthropic>=1.0,<2
+langchain-openai>=1.0,<2
+langchain-google-genai>=3.0,<4

--- a/services/agent/tests/conftest.py
+++ b/services/agent/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Test fixtures. Tests run without provider credentials so they are CI-safe."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_llm_env(monkeypatch):
+    for var in (
+        "LLM_PROVIDER",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT",
+        "GOOGLE_GEMINI_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield

--- a/services/agent/tests/test_endpoints.py
+++ b/services/agent/tests/test_endpoints.py
@@ -1,0 +1,94 @@
+"""API wiring tests using a fake LLM layer (no network, CI-safe)."""
+
+from fastapi.testclient import TestClient
+
+import app.main as main
+from app.schemas import FitScoreResponse, OutreachDraftResponse, ParsedJob
+
+client = TestClient(main.app)
+
+
+def test_health_reports_llm_state(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: False)
+    monkeypatch.setattr(main, "resolve_provider", lambda: None)
+    body = client.get("/health").json()
+    assert body["status"] == "ok"
+    assert body["llm_configured"] is False
+
+
+def test_parse_job_returns_503_without_provider(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: False)
+    res = client.post("/parse-job", json={"description_text": "Build AI agents in Python."})
+    assert res.status_code == 503
+
+
+def test_parse_job_happy_path(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+    monkeypatch.setattr(
+        main,
+        "parse_job",
+        lambda text: ParsedJob(
+            title="AI Software Engineer",
+            required_skills=["Python", "LangChain"],
+            seniority="junior",
+            summary="Entry-level AI role.",
+        ),
+    )
+    res = client.post("/parse-job", json={"description_text": "anything"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["title"] == "AI Software Engineer"
+    assert "Python" in data["required_skills"]
+
+
+def test_score_fit_happy_path(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+    monkeypatch.setattr(
+        main,
+        "score_fit",
+        lambda req: FitScoreResponse(
+            fit_score=88,
+            matched_skills=["Python"],
+            missing_skills=[],
+            ats_keywords=["Python"],
+            fit_summary="Strong fit.",
+            recommended_resume_angle="Lead with Python.",
+            apply_recommendation="apply",
+            confidence_score=80,
+            model_used="anthropic:claude-sonnet-4-6",
+        ),
+    )
+    res = client.post(
+        "/score-fit",
+        json={
+            "description_text": "Python AI role",
+            "resume_text": "Built Python AI agents",
+            "profile_text": "CS new grad",
+        },
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["fit_score"] == 88
+    assert data["model_used"].startswith("anthropic:")
+
+
+def test_draft_outreach_happy_path(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+    monkeypatch.setattr(
+        main,
+        "draft_outreach",
+        lambda req: OutreachDraftResponse(
+            subject="Excited about the AI Software Engineer role",
+            draft_text="Hi, ...",
+            safety_notes="Verify the team name before sending.",
+            model_used="anthropic:claude-sonnet-4-6",
+        ),
+    )
+    res = client.post("/draft-outreach", json={"message_type": "recruiter_email"})
+    assert res.status_code == 200
+    assert res.json()["subject"].startswith("Excited")
+
+
+def test_draft_outreach_rejects_bad_message_type():
+    res = client.post("/draft-outreach", json={"message_type": "carrier_pigeon"})
+    assert res.status_code == 422

--- a/services/agent/tests/test_provider.py
+++ b/services/agent/tests/test_provider.py
@@ -1,0 +1,32 @@
+"""Provider-resolution precedence tests."""
+
+from app.config import Settings
+from app.llm import provider as provider_module
+
+
+def _resolve_with(monkeypatch, **overrides):
+    monkeypatch.setattr(provider_module, "settings", Settings(**overrides))
+    return provider_module.resolve_provider()
+
+
+def test_no_credentials_returns_none(monkeypatch):
+    assert _resolve_with(monkeypatch) is None
+    monkeypatch.setattr(provider_module, "settings", Settings())
+    assert provider_module.llm_available() is False
+
+
+def test_explicit_provider_wins(monkeypatch):
+    assert _resolve_with(monkeypatch, llm_provider="openai", anthropic_api_key="x") == "openai"
+
+
+def test_implicit_anthropic_first(monkeypatch):
+    assert _resolve_with(monkeypatch, anthropic_api_key="x", openai_api_key="y") == "anthropic"
+
+
+def test_implicit_azure_requires_endpoint_and_key(monkeypatch):
+    assert (
+        _resolve_with(monkeypatch, azure_openai_api_key="k", azure_openai_endpoint="https://e")
+        == "azure_openai"
+    )
+    # Key without endpoint should not select azure.
+    assert _resolve_with(monkeypatch, azure_openai_api_key="k", openai_api_key="o") == "openai"

--- a/services/agent/tests/test_schemas.py
+++ b/services/agent/tests/test_schemas.py
@@ -1,0 +1,41 @@
+"""Schema contract tests — these must stay in lock-step with the TS API."""
+
+from app.schemas import FitScoreLLM, FitScoreResponse, ParsedJob
+
+
+def test_parsed_job_defaults_are_safe():
+    parsed = ParsedJob()
+    assert parsed.company is None
+    assert parsed.title is None
+    assert parsed.seniority == "unknown"
+    assert parsed.required_skills == []
+    assert parsed.summary == ""
+
+
+def test_fit_score_clamps_range():
+    score = FitScoreLLM(
+        fit_score=82,
+        matched_skills=["Python"],
+        missing_skills=["Rust"],
+        ats_keywords=["Python", "LLM"],
+        fit_summary="Strong overlap.",
+        recommended_resume_angle="Lead with Python.",
+        apply_recommendation="apply",
+        confidence_score=77,
+    )
+    assert 0 <= score.fit_score <= 100
+    assert score.apply_recommendation in {"apply", "review", "pass"}
+
+
+def test_fit_score_response_carries_model_used():
+    base = FitScoreLLM(
+        fit_score=50,
+        fit_summary="x",
+        recommended_resume_angle="y",
+        apply_recommendation="review",
+        confidence_score=50,
+    )
+    resp = FitScoreResponse(**base.model_dump(), model_used="anthropic:claude-sonnet-4-6")
+    assert resp.model_used == "anthropic:claude-sonnet-4-6"
+    # Response must remain a superset of the LLM output contract.
+    assert resp.fit_score == 50


### PR DESCRIPTION
## Summary
Introduces `services/agent`, a Python **FastAPI** microservice that replaces the project's deterministic mock "AI" with a **real, LLM-powered** layer — while keeping the mock as an offline/demo fallback so the app never breaks without credentials.

This is the foundation for the AI-agent push aligned to the AI Software Engineer role (real LLMs, LangChain, provider-agnostic, structured output).

## What's new
- **Provider-agnostic LLM router** (LangChain `init_chat_model`): Anthropic Claude / Azure OpenAI / OpenAI / Google Gemini, selected by `LLM_PROVIDER` or auto-detected from available credentials.
- **Real structured-output chains**: `parse-job`, `score-fit`, `draft-outreach`, `weekly-recommendations`. Pydantic schemas mirror the TS contracts (`ParsedJobOutput`, `FitScoreOutput`) exactly.
- **Safety-preserving prompts**: grounded in source text, no fabricated experience, honest/conservative scoring, never auto-send.
- **Graceful degradation**: service returns `503` with no provider configured; the Node API falls back to the mock.

## Node API integration
- New `apps/api/src/lib/agent-client.ts` delegates to the service when `AGENT_SERVICE_URL` is set, falling back to the mock on any error/invalid payload.
- `analysis-core.ts` gains pure mappers (`analysisFromParsed`/`analysisFromFit`) so mock and agent paths produce identical `JobAnalysis` records.
- `ai.ts` and `n8n.ts` use the async resolvers — behavior-identical when the agent is unset, so existing tests stay green.

## CI
- New **Python job** (ruff + pytest) added to `ci.yml`.

## Verification
- ✅ 20 Node API tests pass; ✅ 13 agent tests pass; ✅ `npm run check` green.
- ✅ Live end-to-end smoke: `POST /api/ai/parse-job` → Express → Python agent → OpenAI returned real structured analysis (LLM-generated responsibilities + skill separation, not the keyword mock).

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)