### PR TITLE
feat: advanced LangChain agents with tool use + dashboard UI (Phase 8)

### DIFF
--- a/apps/api/src/lib/agent-client.ts
+++ b/apps/api/src/lib/agent-client.ts
@@ -21,17 +21,27 @@ import type { DraftOutreachBody } from '@/types';
 
 const AGENT_URL = process.env.AGENT_SERVICE_URL?.trim().replace(/\/$/, '');
 const AGENT_TIMEOUT_MS = Number(process.env.AGENT_TIMEOUT_MS ?? 60_000);
+// Tool-using agents (Phase 8) can take longer than the single-shot chains.
+const AGENT_TASK_TIMEOUT_MS = Number(process.env.AGENT_TASK_TIMEOUT_MS ?? 120_000);
+
+/** Thrown when an agent task is requested but the service is not configured. */
+export class AgentDisabledError extends Error {
+  constructor() {
+    super('The AI agent service is not configured.');
+    this.name = 'AgentDisabledError';
+  }
+}
 
 export function isAgentEnabled(): boolean {
   return Boolean(AGENT_URL);
 }
 
-async function callAgent<T>(path: string, payload: unknown): Promise<T> {
+async function callAgent<T>(path: string, payload: unknown, timeoutMs = AGENT_TIMEOUT_MS): Promise<T> {
   const response = await fetch(`${AGENT_URL}${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(AGENT_TIMEOUT_MS),
+    signal: AbortSignal.timeout(timeoutMs),
   });
 
   if (!response.ok) {
@@ -39,6 +49,18 @@ async function callAgent<T>(path: string, payload: unknown): Promise<T> {
   }
 
   return (await response.json()) as T;
+}
+
+/**
+ * Run a Phase 8 agent task (interview-prep, research, skill-gap). Unlike the
+ * analysis resolvers, these have no mock fallback — they are net-new
+ * capabilities — so this throws AgentDisabledError when the service is unset.
+ */
+export async function runAgentTask<T>(path: string, payload: unknown): Promise<T> {
+  if (!isAgentEnabled()) {
+    throw new AgentDisabledError();
+  }
+  return callAgent<T>(path, payload, AGENT_TASK_TIMEOUT_MS);
 }
 
 export interface ScoreFitInput {

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -6,7 +6,13 @@ import {
   validateFitScoreOutput,
   validateParsedJobOutput,
 } from '@/lib/analysis-core';
-import { resolveFitScore, resolveOutreachDraft, resolveParsedJob } from '@/lib/agent-client';
+import {
+  AgentDisabledError,
+  resolveFitScore,
+  resolveOutreachDraft,
+  resolveParsedJob,
+  runAgentTask,
+} from '@/lib/agent-client';
 import { isSingleRecipientEmailAddress } from '@/lib/email';
 import { createGmailDraftIfEnabled } from '@/lib/gmail';
 import {
@@ -194,6 +200,94 @@ aiRouter.post('/draft-outreach', async (request, response, next) => {
     gmail_draft_id: draft.gmailDraftId ?? null,
     gmail_draft_message: gmailDraftMessage,
   });
+});
+
+const AGENT_DISABLED_MESSAGE =
+  'The AI agent service is not configured. Set AGENT_SERVICE_URL and a provider key to enable the agents.';
+
+aiRouter.post('/agents/interview-prep', async (request, response, next) => {
+  const body = request.body as { job_id?: string; resume_text?: string };
+
+  if (!body.job_id) {
+    return response.status(400).json({ error: 'job_id is required' });
+  }
+
+  try {
+    const job = await getJobById(body.job_id);
+    if (!job) {
+      return response.status(404).json({ error: 'Job not found' });
+    }
+
+    const result = await runAgentTask('/agents/interview-prep', {
+      job_description: job.descriptionText,
+      resume_text: body.resume_text,
+      company: job.company,
+      role: job.title,
+    });
+
+    return response.json(result);
+  } catch (error) {
+    if (error instanceof AgentDisabledError) {
+      return response.status(503).json({ error: AGENT_DISABLED_MESSAGE });
+    }
+    next(error);
+  }
+});
+
+aiRouter.post('/agents/research', async (request, response, next) => {
+  const body = request.body as { job_id?: string };
+
+  if (!body.job_id) {
+    return response.status(400).json({ error: 'job_id is required' });
+  }
+
+  try {
+    const job = await getJobById(body.job_id);
+    if (!job) {
+      return response.status(404).json({ error: 'Job not found' });
+    }
+
+    const result = await runAgentTask('/agents/research', {
+      company: job.company,
+      role: job.title,
+      context: job.descriptionText,
+    });
+
+    return response.json(result);
+  } catch (error) {
+    if (error instanceof AgentDisabledError) {
+      return response.status(503).json({ error: AGENT_DISABLED_MESSAGE });
+    }
+    next(error);
+  }
+});
+
+aiRouter.post('/agents/skill-gap', async (request, response, next) => {
+  const body = request.body as { job_id?: string; resume_text?: string };
+
+  if (!body.job_id) {
+    return response.status(400).json({ error: 'job_id is required' });
+  }
+
+  try {
+    const job = await getJobById(body.job_id);
+    if (!job) {
+      return response.status(404).json({ error: 'Job not found' });
+    }
+
+    const result = await runAgentTask('/agents/skill-gap', {
+      missing_skills: job.analysis.missingSkills,
+      job_description: job.descriptionText,
+      resume_text: body.resume_text,
+    });
+
+    return response.json(result);
+  } catch (error) {
+    if (error instanceof AgentDisabledError) {
+      return response.status(503).json({ error: AGENT_DISABLED_MESSAGE });
+    }
+    next(error);
+  }
 });
 
 aiRouter.post('/generate-weekly-report', async (request, response, next) => {

--- a/apps/web/src/app/jobs/[jobId]/page.tsx
+++ b/apps/web/src/app/jobs/[jobId]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { JobAgentsPanel } from '@/components/job-agents-panel';
 import { JobAnalysisActions } from '@/components/job-analysis-actions';
 import { JobEditPanel } from '@/components/job-edit-panel';
 import { JobOutreachActions } from '@/components/job-outreach-actions';
@@ -169,6 +170,14 @@ export default async function JobDetailPage({ params }: JobDetailParams) {
                 <p className="detail-card__value">{job.analysis.applyRecommendation}</p>
               </div>
             </div>
+          </SectionCard>
+
+          <SectionCard
+            id="agents"
+            title="AI agents"
+            description="Multi-step LangChain agents for interview prep, company research, and skill-gap planning."
+          >
+            <JobAgentsPanel jobId={job.id} resumeText={demoResumeText} />
           </SectionCard>
 
           <SectionCard

--- a/apps/web/src/components/job-agents-panel.tsx
+++ b/apps/web/src/components/job-agents-panel.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  ApiRequestError,
+  runInterviewPrep,
+  runResearch,
+  runSkillGap,
+  type InterviewPrepResponse,
+  type ResearchBriefResponse,
+  type SkillGapPlanResponse,
+} from '@/lib/api';
+
+type JobAgentsPanelProps = {
+  jobId: string;
+  resumeText: string;
+};
+
+type AgentKind = 'interview' | 'research' | 'skillGap';
+
+function DetailList({ title, items }: { title: string; items: string[] }) {
+  if (!items?.length) {
+    return null;
+  }
+  return (
+    <div className="detail-card">
+      <p className="detail-card__title">{title}</p>
+      <ul className="list">
+        {items.map((item, index) => (
+          <li key={`${title}-${index}`}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function JobAgentsPanel({ jobId, resumeText }: JobAgentsPanelProps) {
+  const [running, setRunning] = useState<AgentKind | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [interview, setInterview] = useState<InterviewPrepResponse | null>(null);
+  const [research, setResearch] = useState<ResearchBriefResponse | null>(null);
+  const [skillGap, setSkillGap] = useState<SkillGapPlanResponse | null>(null);
+
+  async function run<T>(kind: AgentKind, task: () => Promise<T>, onDone: (result: T) => void) {
+    setError(null);
+    setRunning(kind);
+    try {
+      onDone(await task());
+    } catch (requestError) {
+      if (requestError instanceof ApiRequestError) {
+        setError(requestError.message);
+      } else {
+        setError(requestError instanceof Error ? requestError.message : 'The agent run failed.');
+      }
+    } finally {
+      setRunning(null);
+    }
+  }
+
+  const busy = running !== null;
+
+  return (
+    <div className="stack">
+      <p className="callout__text">
+        These are real LangChain agents running in the Python service. The research agent uses a web
+        search tool; all three return structured, auditable output.
+      </p>
+
+      {error ? (
+        <div className="callout callout--accent">
+          <p className="callout__title">Agent run failed</p>
+          <p className="callout__text">{error}</p>
+        </div>
+      ) : null}
+
+      <div className="hero__actions">
+        <button
+          className="button button--primary"
+          type="button"
+          disabled={busy}
+          onClick={() => run('interview', () => runInterviewPrep({ jobId, resumeText }), setInterview)}
+        >
+          {running === 'interview' ? 'Preparing…' : 'Interview prep'}
+        </button>
+        <button
+          className="button button--ghost"
+          type="button"
+          disabled={busy}
+          onClick={() => run('research', () => runResearch({ jobId }), setResearch)}
+        >
+          {running === 'research' ? 'Researching…' : 'Research company'}
+        </button>
+        <button
+          className="button button--ghost"
+          type="button"
+          disabled={busy}
+          onClick={() => run('skillGap', () => runSkillGap({ jobId, resumeText }), setSkillGap)}
+        >
+          {running === 'skillGap' ? 'Planning…' : 'Skill-gap plan'}
+        </button>
+      </div>
+
+      {interview ? (
+        <div className="stack">
+          <h3 className="callout__title">Interview prep</h3>
+          <DetailList title="Likely questions" items={interview.likely_questions} />
+          <DetailList title="Talking points" items={interview.talking_points} />
+          <DetailList title="Gaps to address" items={interview.gaps_to_address} />
+          <DetailList title="Questions to ask them" items={interview.questions_to_ask} />
+        </div>
+      ) : null}
+
+      {research ? (
+        <div className="stack">
+          <h3 className="callout__title">
+            Company research{research.used_web_search ? ' · web search used' : ''}
+          </h3>
+          <div className="callout">
+            <p className="callout__text">{research.company_summary}</p>
+          </div>
+          <DetailList title="Recent signals" items={research.recent_signals} />
+          <DetailList title="Talking points" items={research.talking_points} />
+          <DetailList title="Questions to ask them" items={research.questions_to_ask} />
+        </div>
+      ) : null}
+
+      {skillGap ? (
+        <div className="stack">
+          <h3 className="callout__title">Skill-gap plan</h3>
+          <div className="callout">
+            <p className="callout__text">{skillGap.summary}</p>
+          </div>
+          {skillGap.prioritized_skills.map((item, index) => (
+            <div key={`${item.skill}-${index}`} className="detail-card">
+              <p className="detail-card__title">
+                {item.skill}
+                {item.estimated_time ? ` · ${item.estimated_time}` : ''}
+              </p>
+              <p className="detail-card__value">{item.why_it_matters}</p>
+              {item.learning_resources?.length ? (
+                <ul className="list">
+                  {item.learning_resources.map((resource, resourceIndex) => (
+                    <li key={`${item.skill}-resource-${resourceIndex}`}>{resource}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -200,6 +200,61 @@ export async function updateOutreach(
   });
 }
 
+export interface InterviewPrepResponse {
+  likely_questions: string[];
+  talking_points: string[];
+  gaps_to_address: string[];
+  questions_to_ask: string[];
+}
+
+export interface ResearchBriefResponse {
+  company_summary: string;
+  recent_signals: string[];
+  role_context: string;
+  talking_points: string[];
+  questions_to_ask: string[];
+  used_web_search: boolean;
+}
+
+export interface SkillGapItemResponse {
+  skill: string;
+  why_it_matters: string;
+  learning_resources: string[];
+  estimated_time: string;
+}
+
+export interface SkillGapPlanResponse {
+  summary: string;
+  prioritized_skills: SkillGapItemResponse[];
+}
+
+export async function runInterviewPrep(payload: {
+  jobId: string;
+  resumeText?: string;
+}): Promise<InterviewPrepResponse> {
+  return requestJson<InterviewPrepResponse>('/api/ai/agents/interview-prep', {
+    method: 'POST',
+    body: JSON.stringify({ job_id: payload.jobId, resume_text: payload.resumeText }),
+  });
+}
+
+export async function runResearch(payload: { jobId: string }): Promise<ResearchBriefResponse> {
+  return requestJson<ResearchBriefResponse>('/api/ai/agents/research', {
+    method: 'POST',
+    body: JSON.stringify({ job_id: payload.jobId }),
+  });
+}
+
+export async function runSkillGap(payload: {
+  jobId: string;
+  resumeText?: string;
+}): Promise<SkillGapPlanResponse> {
+  return requestJson<SkillGapPlanResponse>('/api/ai/agents/skill-gap', {
+    method: 'POST',
+    body: JSON.stringify({ job_id: payload.jobId, resume_text: payload.resumeText }),
+  });
+}
+
 export async function fetchWeeklyReports(): Promise<WeeklyReport[]> {
   const response = await requestJson<WeeklyReportsResponse>('/api/reports', { cache: 'no-store' });
   return response.reports;

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -20,6 +20,9 @@ auto-detected from whichever credentials are present.
 | `POST` | `/weekly-recommendations` | LLM-narrated weekly strategy recommendations. |
 | `POST` | `/rag/ingest` | Chunk + embed a document into the pgvector store. |
 | `POST` | `/rag/search` | Cosine-similarity retrieval over stored embeddings. |
+| `POST` | `/agents/interview-prep` | Interview-prep agent (structured brief). |
+| `POST` | `/agents/research` | Company/role research agent (web-search tool use). |
+| `POST` | `/agents/skill-gap` | Skill-gap learning-plan agent. |
 
 RAG (Phase 10): `score-fit` is **retrieval-augmented** — it ingests the resume
 into pgvector (Hugging Face `all-MiniLM-L6-v2` embeddings, on PyTorch) and feeds
@@ -27,7 +30,12 @@ the chunks most relevant to the job description back to the model so the
 assessment is grounded in real resume evidence. RAG is best-effort: when
 `DATABASE_URL` is unset the service scores directly without it.
 
-Later phases add `/agents/*` (Phase 8) and `/telemetry/*` (Phase 11).
+Agents (Phase 8): real LangChain agents built with `create_agent` + `ToolStrategy`
+for provider-agnostic structured output. The research agent uses a Tavily-backed
+`web_search` tool (degrades gracefully without `TAVILY_API_KEY`). They require a
+configured LLM provider — unlike the analysis chains, they have no mock fallback.
+
+Later phases add `/telemetry/*` (Phase 11).
 
 Each endpoint returns **structured, validated JSON** whose shape mirrors the
 TypeScript contracts in `apps/api/src/lib/analysis-core.ts`, so the Node API

--- a/services/agent/app/agents/runner.py
+++ b/services/agent/app/agents/runner.py
@@ -1,0 +1,91 @@
+"""LangChain agents (Phase 8).
+
+Each agent is built with ``create_agent`` and returns a structured result via
+``ToolStrategy`` (provider-agnostic, works on Claude/OpenAI/Gemini). The research
+agent additionally uses the ``web_search`` tool for genuine multi-step tool use.
+"""
+
+from __future__ import annotations
+
+from langchain.agents import create_agent
+from langchain.agents.structured_output import ToolStrategy
+
+from app.agents.tools import web_search
+from app.llm.provider import get_model
+from app.prompts import INTERVIEW_PREP_SYSTEM, RESEARCH_SYSTEM, SKILL_GAP_SYSTEM
+from app.schemas import (
+    InterviewPrep,
+    InterviewPrepRequest,
+    ResearchBrief,
+    ResearchRequest,
+    SkillGapPlan,
+    SkillGapRequest,
+)
+
+
+def _final_structured(agent, prompt: str):
+    result = agent.invoke({"messages": [{"role": "user", "content": prompt}]})
+    return result, result["structured_response"]
+
+
+def _used_a_tool(result) -> bool:
+    return any(
+        getattr(message, "type", None) == "tool"
+        or message.__class__.__name__ == "ToolMessage"
+        for message in result.get("messages", [])
+    )
+
+
+def run_interview_prep(req: InterviewPrepRequest) -> InterviewPrep:
+    model, _ = get_model()
+    agent = create_agent(
+        model,
+        tools=[],
+        system_prompt=INTERVIEW_PREP_SYSTEM,
+        response_format=ToolStrategy(InterviewPrep),
+    )
+    parts = [f"Job description:\n{req.job_description}"]
+    if req.company:
+        parts.append(f"Company: {req.company}")
+    if req.role:
+        parts.append(f"Role: {req.role}")
+    if req.resume_text:
+        parts.append(f"Candidate resume (only truthful claims):\n{req.resume_text}")
+    _, brief = _final_structured(agent, "\n\n".join(parts))
+    return brief
+
+
+def run_skill_gap(req: SkillGapRequest) -> SkillGapPlan:
+    model, _ = get_model()
+    agent = create_agent(
+        model,
+        tools=[],
+        system_prompt=SKILL_GAP_SYSTEM,
+        response_format=ToolStrategy(SkillGapPlan),
+    )
+    parts = ["Missing skills: " + (", ".join(req.missing_skills) or "none provided")]
+    if req.job_description:
+        parts.append(f"Job description:\n{req.job_description}")
+    if req.resume_text:
+        parts.append(f"Resume:\n{req.resume_text}")
+    _, plan = _final_structured(agent, "\n\n".join(parts))
+    return plan
+
+
+def run_research(req: ResearchRequest) -> ResearchBrief:
+    model, _ = get_model()
+    agent = create_agent(
+        model,
+        tools=[web_search],
+        system_prompt=RESEARCH_SYSTEM,
+        response_format=ToolStrategy(ResearchBrief),
+    )
+    parts = [f"Company: {req.company}"]
+    if req.role:
+        parts.append(f"Role: {req.role}")
+    if req.context:
+        parts.append(f"Additional context:\n{req.context}")
+    parts.append("Research this company and role for an upcoming interview.")
+    result, brief = _final_structured(agent, "\n\n".join(parts))
+    brief.used_web_search = _used_a_tool(result)
+    return brief

--- a/services/agent/app/agents/tools.py
+++ b/services/agent/app/agents/tools.py
@@ -1,0 +1,47 @@
+"""Tools available to the agents.
+
+The web_search tool uses Tavily when ``TAVILY_API_KEY`` is set, and degrades
+gracefully (returns a clear note) when it is not — so the research agent always
+runs, with or without live search.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from langchain.tools import tool
+
+from app.config import settings
+
+logger = logging.getLogger("jobops.agent.tools")
+
+
+@tool
+def web_search(query: str) -> str:
+    """Search the public web for recent, factual information about a company,
+    product, person, or job role. Use this to gather details you do not already
+    know before answering."""
+    if not settings.tavily_api_key:
+        return (
+            "Web search is unavailable (no TAVILY_API_KEY). Answer from the provided "
+            "context and general knowledge, and clearly flag anything that should be verified."
+        )
+    try:
+        response = httpx.post(
+            "https://api.tavily.com/search",
+            headers={"Authorization": f"Bearer {settings.tavily_api_key}"},
+            json={"query": query, "max_results": 5, "search_depth": "basic"},
+            timeout=settings.request_timeout,
+        )
+        response.raise_for_status()
+        results = response.json().get("results", [])
+        if not results:
+            return "No web results found."
+        return "\n\n".join(
+            f"- {item.get('title')}: {item.get('content', '')[:300]} ({item.get('url')})"
+            for item in results
+        )
+    except Exception as exc:  # noqa: BLE001 - tool failures must not crash the agent
+        logger.warning("web_search failed: %s", exc)
+        return f"Web search failed ({exc}). Proceed from available context and flag what to verify."

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -12,6 +12,7 @@ import logging
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from app.agents.runner import run_interview_prep, run_research, run_skill_gap
 from app.chains.draft_outreach import draft_outreach
 from app.chains.parse_job import parse_job
 from app.chains.score_fit import score_fit
@@ -21,10 +22,16 @@ from app.rag.store import ingest_document, rag_available, retrieve, retrieve_res
 from app.schemas import (
     DraftOutreachRequest,
     FitScoreResponse,
+    InterviewPrep,
+    InterviewPrepRequest,
     OutreachDraftResponse,
     ParsedJob,
     ParseJobRequest,
+    ResearchBrief,
+    ResearchRequest,
     ScoreFitRequest,
+    SkillGapPlan,
+    SkillGapRequest,
     WeeklyRecommendationsLLM,
     WeeklyRecommendationsRequest,
 )
@@ -126,3 +133,24 @@ def weekly_recommendations_endpoint(
 ) -> WeeklyRecommendationsLLM:
     _require_llm()
     return _run(weekly_recommendations, req)
+
+
+# --- Phase 8 agents ---------------------------------------------------------
+
+
+@app.post("/agents/interview-prep", response_model=InterviewPrep)
+def interview_prep_endpoint(req: InterviewPrepRequest) -> InterviewPrep:
+    _require_llm()
+    return _run(run_interview_prep, req)
+
+
+@app.post("/agents/research", response_model=ResearchBrief)
+def research_endpoint(req: ResearchRequest) -> ResearchBrief:
+    _require_llm()
+    return _run(run_research, req)
+
+
+@app.post("/agents/skill-gap", response_model=SkillGapPlan)
+def skill_gap_endpoint(req: SkillGapRequest) -> SkillGapPlan:
+    _require_llm()
+    return _run(run_skill_gap, req)

--- a/services/agent/app/prompts.py
+++ b/services/agent/app/prompts.py
@@ -48,3 +48,36 @@ Rules:
 - Keep it honest and encouraging without hype.
 - Focus on the highest-leverage next actions (e.g., converting shortlisted roles, closing skill gaps).
 """
+
+INTERVIEW_PREP_SYSTEM = """You are an interview coach. Given a job description and (optionally) the candidate's
+resume, produce focused, realistic interview preparation.
+
+Rules:
+- likely_questions: questions this specific role/company would actually ask (technical + behavioral).
+- talking_points: truthful strengths from the resume to emphasize; never invent experience.
+- gaps_to_address: honest weak spots versus the role, with how to frame them constructively.
+- questions_to_ask: thoughtful questions the candidate could ask the interviewer.
+- Be specific to the role; avoid generic filler.
+"""
+
+RESEARCH_SYSTEM = """You are a company research analyst preparing a candidate for an interview.
+Use the web_search tool to gather recent, factual information about the company and role when helpful.
+
+Rules:
+- company_summary: what the company does, stage, and market, grounded in what you find.
+- recent_signals: notable recent news/funding/product/hiring signals (cite sources inline when from search).
+- role_context: how this role likely fits the company's priorities.
+- talking_points / questions_to_ask: specific, informed, and useful for the interview.
+- If web search is unavailable, reason from provided context and clearly flag what should be verified.
+- Never fabricate facts; prefer "unverified" over guessing.
+"""
+
+SKILL_GAP_SYSTEM = """You are a learning planner. Given a list of missing skills (and optional job/resume context),
+build a prioritized, realistic learning plan.
+
+Rules:
+- prioritized_skills: order by impact for THIS role; for each give why_it_matters, concrete
+  learning_resources (specific, real, well-known resources), and an estimated_time.
+- summary: a short paragraph framing the plan and quickest wins.
+- Be honest about effort; do not overpromise mastery in unrealistic timeframes.
+"""

--- a/services/agent/app/schemas.py
+++ b/services/agent/app/schemas.py
@@ -66,6 +66,41 @@ class WeeklyRecommendationsLLM(BaseModel):
     recommendations: str = ""
 
 
+# --- Phase 8 agent outputs --------------------------------------------------
+
+
+class InterviewPrep(BaseModel):
+    """Prep brief produced by the interview-prep agent."""
+
+    likely_questions: list[str] = Field(default_factory=list)
+    talking_points: list[str] = Field(default_factory=list)
+    gaps_to_address: list[str] = Field(default_factory=list)
+    questions_to_ask: list[str] = Field(default_factory=list)
+
+
+class SkillGapItem(BaseModel):
+    skill: str
+    why_it_matters: str = ""
+    learning_resources: list[str] = Field(default_factory=list)
+    estimated_time: str = ""
+
+
+class SkillGapPlan(BaseModel):
+    summary: str = ""
+    prioritized_skills: list[SkillGapItem] = Field(default_factory=list)
+
+
+class ResearchBrief(BaseModel):
+    """Company/role research brief produced by the research agent."""
+
+    company_summary: str = ""
+    recent_signals: list[str] = Field(default_factory=list)
+    role_context: str = ""
+    talking_points: list[str] = Field(default_factory=list)
+    questions_to_ask: list[str] = Field(default_factory=list)
+    used_web_search: bool = False
+
+
 # --- API request bodies ----------------------------------------------------
 
 
@@ -98,6 +133,25 @@ class DraftOutreachRequest(BaseModel):
 class WeeklyRecommendationsRequest(BaseModel):
     metrics: dict[str, int] = Field(default_factory=dict)
     common_missing_skills: list[str] = Field(default_factory=list)
+
+
+class InterviewPrepRequest(BaseModel):
+    job_description: str
+    resume_text: str | None = None
+    company: str | None = None
+    role: str | None = None
+
+
+class ResearchRequest(BaseModel):
+    company: str
+    role: str | None = None
+    context: str | None = None
+
+
+class SkillGapRequest(BaseModel):
+    missing_skills: list[str] = Field(default_factory=list)
+    job_description: str | None = None
+    resume_text: str | None = None
 
 
 # --- API responses (add server-controlled fields) --------------------------

--- a/services/agent/requirements.txt
+++ b/services/agent/requirements.txt
@@ -12,3 +12,6 @@ langchain>=1.0,<2
 langchain-anthropic>=1.0,<2
 langchain-openai>=1.0,<2
 langchain-google-genai>=3.0,<4
+
+# HTTP client for agent tools (web search)
+httpx>=0.27,<1

--- a/services/agent/tests/test_agents.py
+++ b/services/agent/tests/test_agents.py
@@ -1,0 +1,83 @@
+"""Agent endpoint tests using fakes (no network/LLM, CI-safe)."""
+
+from fastapi.testclient import TestClient
+
+import app.main as main
+from app.agents.tools import web_search
+from app.schemas import InterviewPrep, ResearchBrief, SkillGapItem, SkillGapPlan
+
+client = TestClient(main.app)
+
+
+def test_web_search_degrades_without_key(monkeypatch):
+    import app.agents.tools as tools
+
+    monkeypatch.setattr(tools.settings, "tavily_api_key", None)
+    out = web_search.invoke({"query": "Pebble RV company"})
+    assert "unavailable" in out.lower()
+
+
+def test_interview_prep_endpoint(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+    monkeypatch.setattr(
+        main,
+        "run_interview_prep",
+        lambda req: InterviewPrep(
+            likely_questions=["Tell me about an AI agent you built."],
+            talking_points=["Built LangChain agents."],
+            gaps_to_address=["Limited PyTorch production experience."],
+            questions_to_ask=["How does the team evaluate agent quality?"],
+        ),
+    )
+    res = client.post(
+        "/agents/interview-prep",
+        json={"job_description": "AI Software Engineer", "resume_text": "x"},
+    )
+    assert res.status_code == 200
+    assert res.json()["likely_questions"]
+
+
+def test_research_endpoint(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+    monkeypatch.setattr(
+        main,
+        "run_research",
+        lambda req: ResearchBrief(
+            company_summary="Pebble builds electric RV trailers.",
+            recent_signals=["Launched a new trailer model."],
+            role_context="AI for vehicle telemetry.",
+            talking_points=["Sustainable mobility."],
+            questions_to_ask=["What telemetry stack do you use?"],
+            used_web_search=True,
+        ),
+    )
+    res = client.post("/agents/research", json={"company": "Pebble", "role": "AI SWE"})
+    assert res.status_code == 200
+    assert res.json()["used_web_search"] is True
+
+
+def test_skill_gap_endpoint(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+    monkeypatch.setattr(
+        main,
+        "run_skill_gap",
+        lambda req: SkillGapPlan(
+            summary="Focus on PyTorch first.",
+            prioritized_skills=[
+                SkillGapItem(
+                    skill="PyTorch",
+                    why_it_matters="Core to the role.",
+                    learning_resources=["pytorch.org tutorials"],
+                    estimated_time="2 weeks",
+                )
+            ],
+        ),
+    )
+    res = client.post("/agents/skill-gap", json={"missing_skills": ["PyTorch"]})
+    assert res.status_code == 200
+    assert res.json()["prioritized_skills"][0]["skill"] == "PyTorch"
+
+
+def test_agents_require_llm(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: False)
+    assert client.post("/agents/interview-prep", json={"job_description": "x"}).status_code == 503


### PR DESCRIPTION
## Summary
Adds three real, multi-step **LangChain agents** to the Python service and surfaces them in the dashboard — the headline "agent orchestration" capability from the JD.

## Agents (services/agent)
Built with `create_agent` + `ToolStrategy` for **provider-agnostic structured output**:
- **Interview-prep** — likely questions, truthful talking points, honest gaps, questions to ask.
- **Company/hiring research** — uses a Tavily-backed `web_search` **tool** (genuine multi-step tool use); degrades gracefully without `TAVILY_API_KEY` and reports whether search ran.
- **Skill-gap planner** — prioritized skills with concrete resources + time estimates.

Endpoints: `/agents/interview-prep`, `/agents/research`, `/agents/skill-gap`. These require a configured LLM provider (503 otherwise) — no mock, since they're net-new capabilities.

## Node API
- `runAgentTask` in `agent-client.ts` (longer timeout for tool loops) + `AgentDisabledError` → 503.
- Three proxy routes in `ai.ts` that load the job and call the agent service.

## Web
- New `JobAgentsPanel` client component + an **"AI agents"** section on the job detail page that renders structured agent output.

## Verification
- ✅ 31 agent tests + 20 API tests + ruff pass; ✅ `npm run check` green.
- ✅ Live runs via OpenAI: interview-prep and skill-gap returned rich structured briefs; the research agent's tool loop reached the model (a transient 429 during burst testing aside).

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)