### PR TITLE
feat: time-series telemetry intelligence — pandas + LLM narration (Phase 11)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import { jobsRouter } from '@/routes/jobs';
 import { n8nRouter } from '@/routes/n8n';
 import { reportsRouter } from '@/routes/reports';
 import { outreachRouter } from '@/routes/outreach';
+import { telemetryRouter } from '@/routes/telemetry';
 
 const mutatingMethods = new Set(['POST', 'PATCH', 'PUT', 'DELETE']);
 
@@ -54,6 +55,7 @@ export function createApp() {
   app.use('/api/ai', aiRouter);
   app.use('/api/outreach', outreachRouter);
   app.use('/api/reports', reportsRouter);
+  app.use('/api/telemetry', telemetryRouter);
   app.use('/api/n8n', n8nRouter);
 
   app.use((_request, response) => {

--- a/apps/api/src/lib/agent-client.ts
+++ b/apps/api/src/lib/agent-client.ts
@@ -17,6 +17,7 @@ import {
   type ParsedJobOutput,
 } from '@/lib/analysis-core';
 import { draftOutreachBody } from '@/data/mock-store';
+import type { ActivityPoint, TelemetryInsights } from '@/lib/telemetry';
 import type { DraftOutreachBody } from '@/types';
 
 const AGENT_URL = process.env.AGENT_SERVICE_URL?.trim().replace(/\/$/, '');
@@ -61,6 +62,25 @@ export async function runAgentTask<T>(path: string, payload: unknown): Promise<T
     throw new AgentDisabledError();
   }
   return callAgent<T>(path, payload, AGENT_TASK_TIMEOUT_MS);
+}
+
+/** Analyze the activity series via the agent (pandas + LLM narration). */
+export async function analyzeTelemetryViaAgent(series: ActivityPoint[]): Promise<TelemetryInsights> {
+  return callAgent<TelemetryInsights>('/telemetry/insights', { series }, AGENT_TASK_TIMEOUT_MS);
+}
+
+/** Fetch the synthetic EV battery telemetry demo from the agent (GET). */
+export async function fetchEvDemoViaAgent(): Promise<TelemetryInsights> {
+  if (!isAgentEnabled()) {
+    throw new AgentDisabledError();
+  }
+  const response = await fetch(`${AGENT_URL}/telemetry/ev-demo`, {
+    signal: AbortSignal.timeout(AGENT_TASK_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`agent /telemetry/ev-demo responded with ${response.status}`);
+  }
+  return (await response.json()) as TelemetryInsights;
 }
 
 export interface ScoreFitInput {

--- a/apps/api/src/lib/telemetry.ts
+++ b/apps/api/src/lib/telemetry.ts
@@ -1,0 +1,93 @@
+/**
+ * Builds a daily activity time-series from the CRM and provides a local
+ * fallback summary used when the Python telemetry/analysis service is offline.
+ * The pipeline is framed as "telemetry": discovery/outreach events over time,
+ * analyzed the same way vehicle sensor streams would be (trend, anomalies,
+ * forecast) in the agent service.
+ */
+
+import type { JobRecord } from '@/types';
+
+export interface ActivityPoint {
+  date: string;
+  discovered: number;
+  outreach_drafted: number;
+  outreach_sent: number;
+}
+
+export interface TelemetryInsights {
+  metric: string;
+  total: number;
+  trend: string;
+  moving_average_7d: number;
+  anomaly_dates: string[];
+  forecast_next: number;
+  narrative: string;
+  recommendations: string[];
+  series_labels: string[];
+  series_values: number[];
+  llm_used: boolean;
+}
+
+function dayKey(iso?: string): string | null {
+  if (!iso) {
+    return null;
+  }
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString().slice(0, 10);
+}
+
+export function buildActivitySeries(jobs: JobRecord[]): ActivityPoint[] {
+  const byDate = new Map<string, ActivityPoint>();
+
+  const bump = (date: string | null, field: 'discovered' | 'outreach_drafted' | 'outreach_sent') => {
+    if (!date) {
+      return;
+    }
+    const point = byDate.get(date) ?? { date, discovered: 0, outreach_drafted: 0, outreach_sent: 0 };
+    point[field] += 1;
+    byDate.set(date, point);
+  };
+
+  for (const job of jobs) {
+    bump(dayKey(job.discoveredAt), 'discovered');
+    for (const draft of job.outreach ?? []) {
+      bump(dayKey(draft.createdAt), 'outreach_drafted');
+      if (draft.sentAt) {
+        bump(dayKey(draft.sentAt), 'outreach_sent');
+      }
+    }
+  }
+
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/** Deterministic insights used when the agent service is unavailable. */
+export function localTelemetryFallback(series: ActivityPoint[]): TelemetryInsights {
+  const values = series.map((point) => point.discovered);
+  const total = values.reduce((sum, value) => sum + value, 0);
+  const n = values.length;
+
+  let trend = 'flat';
+  if (n >= 2) {
+    const first = values[0] ?? 0;
+    const last = values[n - 1] ?? 0;
+    trend = last > first ? 'rising' : last < first ? 'falling' : 'flat';
+  }
+  const recent = values.slice(-7);
+  const movingAverage = recent.length ? recent.reduce((sum, value) => sum + value, 0) / recent.length : 0;
+
+  return {
+    metric: 'jobs_discovered_per_day',
+    total,
+    trend,
+    moving_average_7d: movingAverage,
+    anomaly_dates: [],
+    forecast_next: movingAverage,
+    narrative: `Tracked ${total} discovery event(s) across ${n} active day(s); the recent trend is ${trend}.`,
+    recommendations: ['Configure the agent service for AI-narrated, anomaly-aware telemetry insights.'],
+    series_labels: series.map((point) => point.date),
+    series_values: values,
+    llm_used: false,
+  };
+}

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -1,0 +1,51 @@
+import { Router } from 'express';
+import { listJobs } from '@/data/job-store';
+import {
+  AgentDisabledError,
+  analyzeTelemetryViaAgent,
+  fetchEvDemoViaAgent,
+  isAgentEnabled,
+} from '@/lib/agent-client';
+import { buildActivitySeries, localTelemetryFallback } from '@/lib/telemetry';
+
+export const telemetryRouter = Router();
+
+/**
+ * Pipeline telemetry insights. Builds a daily activity series from the CRM and
+ * analyzes it via the agent (pandas trend/anomaly/forecast + LLM narration),
+ * falling back to a deterministic local summary when the agent is unavailable.
+ */
+telemetryRouter.get('/insights', async (_request, response, next) => {
+  try {
+    const series = buildActivitySeries(await listJobs());
+
+    if (isAgentEnabled()) {
+      try {
+        return response.json(await analyzeTelemetryViaAgent(series));
+      } catch (error) {
+        console.warn('telemetry agent failed; using local fallback', error);
+      }
+    }
+
+    return response.json(localTelemetryFallback(series));
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * Synthetic EV battery telemetry demo — the same anomaly/trend/forecast
+ * analysis applied to vehicle sensor data, to show the pattern transfers.
+ */
+telemetryRouter.get('/ev-demo', async (_request, response, next) => {
+  try {
+    return response.json(await fetchEvDemoViaAgent());
+  } catch (error) {
+    if (error instanceof AgentDisabledError) {
+      return response.status(503).json({
+        error: 'The EV telemetry demo requires the agent service. Set AGENT_SERVICE_URL.',
+      });
+    }
+    next(error);
+  }
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,6 +5,7 @@ import { formatPercent } from '@/lib/format';
 import { StatCard } from '@/components/stat-card';
 import { SectionCard } from '@/components/section-card';
 import { StatusPill } from '@/components/status-pill';
+import { TelemetryInsightsPanel } from '@/components/telemetry-insights';
 
 export const dynamic = 'force-dynamic';
 
@@ -141,6 +142,13 @@ export default async function DashboardPage() {
           </div>
         </SectionCard>
       </section>
+
+      <SectionCard
+        title="Pipeline telemetry intelligence"
+        description="Time-series trend, anomaly detection, and forecasting — the same analysis that transfers to vehicle sensor data."
+      >
+        <TelemetryInsightsPanel />
+      </SectionCard>
 
       <SectionCard
         title="What this phase already proves"

--- a/apps/web/src/components/telemetry-insights.tsx
+++ b/apps/web/src/components/telemetry-insights.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  ApiRequestError,
+  fetchEvTelemetryDemo,
+  fetchTelemetryInsights,
+  type TelemetryInsightsResponse,
+} from '@/lib/api';
+
+type Mode = 'pipeline' | 'ev';
+
+function SparkBars({ values }: { values: number[] }) {
+  if (!values.length) {
+    return null;
+  }
+  const max = Math.max(...values, 1);
+  const min = Math.min(...values, 0);
+  const span = max - min || 1;
+  return (
+    <div className="report-bars">
+      {values.map((value, index) => (
+        <div className="report-bar" key={index}>
+          <div className="report-bar__track">
+            <div
+              className="report-bar__fill"
+              style={{ width: `${Math.max(6, ((value - min) / span) * 100)}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TelemetryInsightsPanel() {
+  const [running, setRunning] = useState<Mode | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [insights, setInsights] = useState<TelemetryInsightsResponse | null>(null);
+
+  async function run(mode: Mode) {
+    setError(null);
+    setRunning(mode);
+    try {
+      setInsights(await (mode === 'pipeline' ? fetchTelemetryInsights() : fetchEvTelemetryDemo()));
+    } catch (requestError) {
+      if (requestError instanceof ApiRequestError) {
+        setError(requestError.message);
+      } else {
+        setError(requestError instanceof Error ? requestError.message : 'Telemetry analysis failed.');
+      }
+    } finally {
+      setRunning(null);
+    }
+  }
+
+  const busy = running !== null;
+
+  return (
+    <div className="stack">
+      <p className="callout__text">
+        Time-series intelligence: trend, anomaly detection, and a short forecast — computed with
+        pandas and narrated by an LLM in the agent service. The EV demo applies the same analysis to
+        synthetic battery-health sensor data.
+      </p>
+
+      <div className="hero__actions">
+        <button
+          className="button button--primary"
+          type="button"
+          disabled={busy}
+          onClick={() => run('pipeline')}
+        >
+          {running === 'pipeline' ? 'Analyzing…' : 'Analyze pipeline telemetry'}
+        </button>
+        <button
+          className="button button--ghost"
+          type="button"
+          disabled={busy}
+          onClick={() => run('ev')}
+        >
+          {running === 'ev' ? 'Analyzing…' : 'EV battery telemetry demo'}
+        </button>
+      </div>
+
+      {error ? (
+        <div className="callout callout--accent">
+          <p className="callout__title">Telemetry unavailable</p>
+          <p className="callout__text">{error}</p>
+        </div>
+      ) : null}
+
+      {insights ? (
+        <div className="stack">
+          <div className="inline-metrics">
+            <div className="inline-metric">
+              <strong>{insights.trend}</strong>
+              <span>Trend</span>
+            </div>
+            <div className="inline-metric">
+              <strong>{insights.moving_average_7d.toFixed(1)}</strong>
+              <span>7-pt avg</span>
+            </div>
+            <div className="inline-metric">
+              <strong>{insights.forecast_next.toFixed(1)}</strong>
+              <span>Forecast</span>
+            </div>
+            <div className="inline-metric">
+              <strong>{insights.anomaly_dates.length}</strong>
+              <span>Anomalies</span>
+            </div>
+          </div>
+
+          <div className="callout">
+            <p className="callout__title">
+              {insights.metric}
+              {insights.llm_used ? ' · LLM narrated' : ''}
+            </p>
+            <p className="callout__text">{insights.narrative}</p>
+          </div>
+
+          <SparkBars values={insights.series_values} />
+
+          {insights.anomaly_dates.length ? (
+            <div className="detail-card">
+              <p className="detail-card__title">Anomaly points</p>
+              <p className="detail-card__value">{insights.anomaly_dates.join(', ')}</p>
+            </div>
+          ) : null}
+
+          {insights.recommendations.length ? (
+            <div className="detail-card">
+              <p className="detail-card__title">Recommendations</p>
+              <ul className="list">
+                {insights.recommendations.map((rec, index) => (
+                  <li key={index}>{rec}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -255,6 +255,28 @@ export async function runSkillGap(payload: {
   });
 }
 
+export interface TelemetryInsightsResponse {
+  metric: string;
+  total: number;
+  trend: string;
+  moving_average_7d: number;
+  anomaly_dates: string[];
+  forecast_next: number;
+  narrative: string;
+  recommendations: string[];
+  series_labels: string[];
+  series_values: number[];
+  llm_used: boolean;
+}
+
+export async function fetchTelemetryInsights(): Promise<TelemetryInsightsResponse> {
+  return requestJson<TelemetryInsightsResponse>('/api/telemetry/insights', { cache: 'no-store' });
+}
+
+export async function fetchEvTelemetryDemo(): Promise<TelemetryInsightsResponse> {
+  return requestJson<TelemetryInsightsResponse>('/api/telemetry/ev-demo', { cache: 'no-store' });
+}
+
 export async function fetchWeeklyReports(): Promise<WeeklyReport[]> {
   const response = await requestJson<WeeklyReportsResponse>('/api/reports', { cache: 'no-store' });
   return response.reports;

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -32,9 +32,12 @@ from app.schemas import (
     ScoreFitRequest,
     SkillGapPlan,
     SkillGapRequest,
+    TelemetryInsights,
+    TelemetryRequest,
     WeeklyRecommendationsLLM,
     WeeklyRecommendationsRequest,
 )
+from app.telemetry.insights import ev_demo_insights, pipeline_insights
 
 logger = logging.getLogger("jobops.agent")
 
@@ -154,3 +157,18 @@ def research_endpoint(req: ResearchRequest) -> ResearchBrief:
 def skill_gap_endpoint(req: SkillGapRequest) -> SkillGapPlan:
     _require_llm()
     return _run(run_skill_gap, req)
+
+
+# --- Phase 11 telemetry -----------------------------------------------------
+# These do NOT require an LLM: pandas computes the analysis, and narration
+# degrades to a deterministic summary when no provider is configured.
+
+
+@app.post("/telemetry/insights", response_model=TelemetryInsights)
+def telemetry_insights_endpoint(req: TelemetryRequest) -> TelemetryInsights:
+    return _run(pipeline_insights, req.series)
+
+
+@app.get("/telemetry/ev-demo", response_model=TelemetryInsights)
+def telemetry_ev_demo_endpoint() -> TelemetryInsights:
+    return _run(ev_demo_insights)

--- a/services/agent/app/prompts.py
+++ b/services/agent/app/prompts.py
@@ -81,3 +81,13 @@ Rules:
 - summary: a short paragraph framing the plan and quickest wins.
 - Be honest about effort; do not overpromise mastery in unrealistic timeframes.
 """
+
+TELEMETRY_NARRATION_SYSTEM = """You are a time-series analyst. You are given pre-computed statistics about a metric
+(trend, moving average, detected anomalies, and a forecast). Explain what they mean and what to do.
+
+Rules:
+- narrative: 2-3 plain sentences interpreting the trend, anomalies, and forecast for this domain.
+- recommendations: 2-4 short, concrete next actions implied by the data.
+- Do not invent numbers beyond those provided; reference the actual trend/anomaly signals.
+- Keep it practical and grounded.
+"""

--- a/services/agent/app/schemas.py
+++ b/services/agent/app/schemas.py
@@ -154,6 +154,39 @@ class SkillGapRequest(BaseModel):
     resume_text: str | None = None
 
 
+# --- Phase 11 telemetry -----------------------------------------------------
+
+
+class ActivityPoint(BaseModel):
+    date: str
+    discovered: int = 0
+    outreach_drafted: int = 0
+    outreach_sent: int = 0
+
+
+class TelemetryRequest(BaseModel):
+    series: list[ActivityPoint] = Field(default_factory=list)
+
+
+class TelemetryNarrationLLM(BaseModel):
+    narrative: str = ""
+    recommendations: list[str] = Field(default_factory=list)
+
+
+class TelemetryInsights(BaseModel):
+    metric: str
+    total: float
+    trend: str  # rising | falling | flat
+    moving_average_7d: float
+    anomaly_dates: list[str] = Field(default_factory=list)
+    forecast_next: float
+    narrative: str = ""
+    recommendations: list[str] = Field(default_factory=list)
+    series_labels: list[str] = Field(default_factory=list)
+    series_values: list[float] = Field(default_factory=list)
+    llm_used: bool = False
+
+
 # --- API responses (add server-controlled fields) --------------------------
 
 

--- a/services/agent/app/telemetry/analyzer.py
+++ b/services/agent/app/telemetry/analyzer.py
@@ -1,0 +1,79 @@
+"""Time-series analysis with pandas/numpy.
+
+Domain-agnostic: the same routine analyzes job-pipeline activity and the
+synthetic EV battery-telemetry demo, demonstrating that the pattern-recognition
+approach transfers directly to vehicle sensor data.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+# z-score threshold above which a point is flagged as an anomaly
+ANOMALY_Z = 2.0
+
+
+def analyze_series(values: list[float], labels: list[str] | None = None) -> dict:
+    """Compute trend, 7-window moving average, anomalies, and a naive forecast.
+
+    Returns plain Python types so the result is JSON-serialisable.
+    """
+    n = len(values)
+    labels = labels or [str(i) for i in range(n)]
+    if n == 0:
+        return {
+            "total": 0.0,
+            "trend": "flat",
+            "slope": 0.0,
+            "moving_average_7d": 0.0,
+            "anomaly_indices": [],
+            "anomaly_labels": [],
+            "forecast_next": 0.0,
+        }
+
+    series = pd.Series(values, dtype="float64")
+    total = float(series.sum())
+    window = min(7, n)
+    moving_average = float(series.rolling(window=window, min_periods=1).mean().iloc[-1])
+
+    slope = float(np.polyfit(np.arange(n), series.to_numpy(), 1)[0]) if n >= 2 else 0.0
+    trend = "rising" if slope > 0.05 else "falling" if slope < -0.05 else "flat"
+
+    mean = float(series.mean())
+    std = float(series.std(ddof=0))
+    anomaly_indices: list[int] = []
+    if std > 0:
+        z_scores = (series - mean) / std
+        anomaly_indices = [int(i) for i, z in enumerate(z_scores) if abs(z) >= ANOMALY_Z]
+
+    forecast_next = max(0.0, moving_average + slope)
+
+    return {
+        "total": total,
+        "trend": trend,
+        "slope": slope,
+        "moving_average_7d": moving_average,
+        "anomaly_indices": anomaly_indices,
+        "anomaly_labels": [labels[i] for i in anomaly_indices],
+        "forecast_next": forecast_next,
+    }
+
+
+def build_ev_demo_series(points: int = 30, seed: int = 7) -> dict:
+    """Synthesize an EV battery state-of-health time-series with a gentle
+    degradation trend and an injected anomaly dip. Mirrors the kind of vehicle
+    telemetry Pebble works with, to show the analysis transfers."""
+    rng = np.random.default_rng(seed)
+    base = 100.0 - np.linspace(0, 6, points)  # slow degradation from 100%
+    noise = rng.normal(0, 0.4, points)
+    values = base + noise
+    # inject an anomalous dip (e.g., a faulty cell reading)
+    spike_index = points // 2
+    values[spike_index] -= 8.0
+    labels = [f"t-{points - i}" for i in range(points)]
+    return {
+        "metric": "battery_state_of_health_pct",
+        "labels": labels,
+        "values": [round(float(v), 2) for v in values],
+    }

--- a/services/agent/app/telemetry/insights.py
+++ b/services/agent/app/telemetry/insights.py
@@ -1,0 +1,87 @@
+"""Compose pandas analysis with an LLM narration into TelemetryInsights.
+
+Narration is best-effort: when no LLM provider is configured we return a
+deterministic narrative so the endpoint still works offline.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.llm.provider import get_model, llm_available
+from app.prompts import TELEMETRY_NARRATION_SYSTEM
+from app.schemas import TelemetryInsights, TelemetryNarrationLLM
+from app.telemetry.analyzer import analyze_series, build_ev_demo_series
+
+logger = logging.getLogger("jobops.agent.telemetry")
+
+
+def _narrate(metric: str, analysis: dict, domain_hint: str) -> tuple[str, list[str], bool]:
+    if not llm_available():
+        narrative = (
+            f"{metric}: total {analysis['total']:.0f}, 7-point average "
+            f"{analysis['moving_average_7d']:.1f}, trend {analysis['trend']}. "
+            f"{len(analysis['anomaly_labels'])} anomaly point(s) detected."
+        )
+        recs = ["Connect an LLM provider for richer, narrated insights."]
+        return narrative, recs, False
+
+    try:
+        model, _ = get_model()
+        structured = model.with_structured_output(TelemetryNarrationLLM)
+        human = (
+            f"Domain: {domain_hint}\n"
+            f"Metric: {metric}\n"
+            f"Total: {analysis['total']:.2f}\n"
+            f"Trend: {analysis['trend']} (slope {analysis['slope']:.3f})\n"
+            f"7-point moving average: {analysis['moving_average_7d']:.2f}\n"
+            f"Anomaly points: {analysis['anomaly_labels'] or 'none'}\n"
+            f"Forecast (next point): {analysis['forecast_next']:.2f}"
+        )
+        result = structured.invoke([("system", TELEMETRY_NARRATION_SYSTEM), ("human", human)])
+        return result.narrative, result.recommendations, True
+    except Exception:  # noqa: BLE001 - narration is best-effort
+        logger.exception("telemetry narration failed; using deterministic narrative")
+        return f"{metric} trend is {analysis['trend']}.", [], False
+
+
+def insights_from_values(
+    metric: str,
+    labels: list[str],
+    values: list[float],
+    domain_hint: str,
+) -> TelemetryInsights:
+    analysis = analyze_series(values, labels)
+    narrative, recommendations, llm_used = _narrate(metric, analysis, domain_hint)
+    return TelemetryInsights(
+        metric=metric,
+        total=analysis["total"],
+        trend=analysis["trend"],
+        moving_average_7d=analysis["moving_average_7d"],
+        anomaly_dates=analysis["anomaly_labels"],
+        forecast_next=analysis["forecast_next"],
+        narrative=narrative,
+        recommendations=recommendations,
+        series_labels=labels,
+        series_values=[float(v) for v in values],
+        llm_used=llm_used,
+    )
+
+
+def pipeline_insights(series) -> TelemetryInsights:
+    """Analyze the 'discovered per day' signal of the job-search pipeline."""
+    labels = [point.date for point in series]
+    values = [float(point.discovered) for point in series]
+    return insights_from_values(
+        "jobs_discovered_per_day", labels, values, domain_hint="job-search pipeline activity"
+    )
+
+
+def ev_demo_insights() -> TelemetryInsights:
+    demo = build_ev_demo_series()
+    return insights_from_values(
+        demo["metric"],
+        demo["labels"],
+        demo["values"],
+        domain_hint="electric-vehicle battery telemetry (predictive maintenance)",
+    )

--- a/services/agent/requirements.txt
+++ b/services/agent/requirements.txt
@@ -15,3 +15,7 @@ langchain-google-genai>=3.0,<4
 
 # HTTP client for agent tools (web search)
 httpx>=0.27,<1
+
+# Time-series telemetry intelligence (Phase 11)
+pandas>=2.2,<3
+numpy>=1.26,<3

--- a/services/agent/tests/test_telemetry.py
+++ b/services/agent/tests/test_telemetry.py
@@ -1,0 +1,67 @@
+"""Telemetry analyzer + endpoint tests (no LLM needed; CI-safe)."""
+
+from fastapi.testclient import TestClient
+
+import app.main as main
+from app.telemetry.analyzer import analyze_series, build_ev_demo_series
+
+client = TestClient(main.app)
+
+
+def test_analyze_empty_series():
+    out = analyze_series([])
+    assert out["trend"] == "flat"
+    assert out["total"] == 0.0
+    assert out["anomaly_indices"] == []
+
+
+def test_analyze_detects_rising_trend():
+    out = analyze_series([1, 2, 3, 4, 5, 6, 7])
+    assert out["trend"] == "rising"
+    assert out["total"] == 28.0
+    assert out["forecast_next"] >= out["moving_average_7d"]
+
+
+def test_analyze_detects_anomaly():
+    out = analyze_series([1, 1, 1, 1, 50, 1, 1], labels=["a", "b", "c", "d", "e", "f", "g"])
+    assert "e" in out["anomaly_labels"]
+
+
+def test_ev_demo_series_has_injected_anomaly():
+    demo = build_ev_demo_series()
+    assert demo["metric"] == "battery_state_of_health_pct"
+    out = analyze_series(demo["values"], demo["labels"])
+    # the injected dip should register as an anomaly and the trend should fall
+    assert out["anomaly_labels"]
+    assert out["trend"] in {"falling", "flat"}
+
+
+def test_telemetry_insights_endpoint_without_llm(monkeypatch):
+    # llm_available is imported into the insights module
+    import app.telemetry.insights as insights
+
+    monkeypatch.setattr(insights, "llm_available", lambda: False)
+    res = client.post(
+        "/telemetry/insights",
+        json={
+            "series": [
+                {"date": "2026-05-01", "discovered": 2},
+                {"date": "2026-05-02", "discovered": 3},
+                {"date": "2026-05-03", "discovered": 5},
+            ]
+        },
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["metric"] == "jobs_discovered_per_day"
+    assert body["llm_used"] is False
+    assert body["series_values"] == [2.0, 3.0, 5.0]
+
+
+def test_ev_demo_endpoint(monkeypatch):
+    import app.telemetry.insights as insights
+
+    monkeypatch.setattr(insights, "llm_available", lambda: False)
+    res = client.get("/telemetry/ev-demo")
+    assert res.status_code == 200
+    assert res.json()["metric"] == "battery_state_of_health_pct"


### PR DESCRIPTION
## Summary
Adds **time-series intelligence** to JobOps Copilot. The job pipeline is framed as telemetry and analyzed exactly the way vehicle sensor streams are — trend, anomaly detection, and forecasting — directly mirroring **Pebble's time-series / predictive-maintenance** domain.

## Agent service
- `app/telemetry/analyzer.py`: pandas/numpy **trend** (linear slope), 7-point **moving average**, **z-score anomaly detection**, and a naive **forecast**. Domain-agnostic.
- Composes the analysis with an **LLM narration** (structured), with a deterministic fallback when no provider is configured.
- Endpoints: `/telemetry/insights` (job pipeline) and `/telemetry/ev-demo` — a **synthetic EV battery state-of-health** series with an injected anomaly, proving the same analysis transfers to vehicle data.

## Node API + Web
- `lib/telemetry.ts` builds a daily activity series from the CRM (local fallback when the agent is off); `routes/telemetry.ts` exposes `/api/telemetry/insights` and `/api/telemetry/ev-demo`.
- Dashboard **TelemetryInsightsPanel**: trend/anomaly/forecast metrics, a sparkline, narrative, and recommendations — plus an EV battery telemetry demo button.

## Verification
- ✅ 38 agent tests + 20 API tests + ruff pass; ✅ `npm run check` green.
- ✅ Live EV-demo run: pandas detected the falling trend + injected anomaly (`t-15`); the LLM produced predictive-maintenance recommendations.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)