### PR TITLE
chore: Next.js standalone output + live Azure deploy (Phase 6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ workflows/n8n/owner.env
 .serena/
 tmp/
 
+.deploy/
+
 # Python (services/agent)
 .venv/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ the loop at every critical step.
 It is intentionally a **responsible AI operations system, not an auto-apply
 bot**: it drafts and recommends, but never sends or fabricates.
 
+> **Live on Azure:** dashboard → https://jobops-web.azurewebsites.net ·
+> API health → https://jobops-api.azurewebsites.net/api/health
+> (Web + API run on Azure App Service against Azure PostgreSQL. The Python
+> agent service runs locally for the full-AI demo; the cloud app degrades
+> gracefully to the deterministic analysis when the agent is not attached.)
+
 ## Highlights
 
 - **Real, multi-provider LLMs** — a Python agent service routes to Anthropic

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,0 +1,12 @@
+import path from 'node:path';
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  // Produce a self-contained server bundle for Azure App Service.
+  output: 'standalone',
+  // In this npm-workspaces monorepo, dependencies are hoisted to the repo root,
+  // so widen the file-tracing root past apps/web to include them.
+  outputFileTracingRoot: path.join(__dirname, '..', '..'),
+};
+
+export default nextConfig;

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -47,11 +47,21 @@ intelligence.
 - The API switches between local file mode and Postgres mode depending on `DATABASE_URL`
 - `GET /api/health` reports which store is active
 
+## Live Deployment
+
+- Web (Next.js, standalone) and API (Express) are deployed on **Azure App Service**
+  (one B1 Linux plan, Mexico Central) against the live **Azure PostgreSQL**:
+  - dashboard: https://jobops-web.azurewebsites.net
+  - API health: https://jobops-api.azurewebsites.net/api/health
+- `pgvector` is allow-listed on the Postgres server; firewall opened to Azure services.
+- The Python agent service runs locally for the full-AI demo; the cloud API
+  degrades gracefully to the deterministic analysis when the agent is unattached.
+
 ## What Is Still Pending
 
-- Live Azure hosting: provision web/api/agent App Services and wire publish profiles (scaffold in `.github/workflows/azure-app-service.yml`; provisioning in `scripts/azure/provision.sh`)
-- Application Insights wiring at runtime (connection string set during provisioning)
-- Phase 7 (Zapier/Make companion flows) — deferred
+- Optional: host the Python agent in the cloud (Azure Container Apps from `services/agent/Dockerfile`) for an agent-attached cloud demo.
+- Apply the `embeddings` (pgvector) migration to the cloud DB from a stable network (`npm run db:init --workspace @jobops/api`); core schema is already live.
+- Phase 7 (Zapier/Make companion flows) — deferred.
 
 ## How To Verify The Live Stack
 


### PR DESCRIPTION
## Summary
Finalizes the live Azure deployment of the web + API.

- **apps/web/next.config.ts** — `output: 'standalone'` + `outputFileTracingRoot` at the monorepo root, so the Next.js app deploys as a self-contained server bundle.
- **.gitignore** — ignore the local `.deploy/` zip-staging dir.
- **README + IMPLEMENTATION_STATUS** — live URLs + the web-live / agent-local deployment model.

## Live
- Dashboard: https://jobops-web.azurewebsites.net
- API health: https://jobops-api.azurewebsites.net/api/health (Azure App Service → Azure PostgreSQL)

Verified live: web returns the dashboard, API is healthy in `postgres` mode, `/api/jobs` returns CRM data, telemetry degrades gracefully.

Part of #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)