### PR TITLE
ci: auto-deploy web to Azure on push to main

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,56 @@
+name: Deploy web (Azure)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/**'
+      - '.github/workflows/deploy-web.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-web
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build + deploy web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web (standalone)
+        env:
+          NEXT_PUBLIC_API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_BASE_URL }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          NEXT_PUBLIC_CLERK_SIGN_IN_URL: /sign-in
+          NEXT_PUBLIC_CLERK_SIGN_UP_URL: /sign-up
+          NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL: /dashboard
+          NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL: /dashboard
+        run: |
+          npm run build:web
+          # Assemble the Next.js standalone bundle (monorepo layout: apps/web/server.js)
+          cp -r apps/web/.next/static apps/web/.next/standalone/apps/web/.next/static
+          if [ -d apps/web/public ]; then
+            cp -r apps/web/public apps/web/.next/standalone/apps/web/public
+          fi
+
+      - name: Deploy to Azure App Service
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ vars.AZURE_WEBAPP_NAME_WEB }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_WEB }}
+          package: apps/web/.next/standalone


### PR DESCRIPTION
Adds a push-triggered CD workflow (`deploy-web.yml`) that builds the Next.js standalone bundle (Clerk publishable key + API URL from repo vars) and deploys to the `jobops-web` App Service via publish profile.

- Triggers: push to `main` touching `apps/web/**`, plus manual `workflow_dispatch`.
- Repo vars set: `AZURE_WEBAPP_NAME_WEB`, `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`.
- Secret set: `AZURE_WEBAPP_PUBLISH_PROFILE_WEB`.
- `SCM_DO_BUILD_DURING_DEPLOYMENT=false` on the web app (bundle is self-contained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)