### PR TITLE
feat: multi-tenant data isolation + per-user profile/demo (backend)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,16 +13,21 @@
   },
   "dependencies": {
     "@azure/storage-blob": "^12.28.0",
+    "@clerk/express": "^1.7.5",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "multer": "^2.0.1",
+    "pdf-parse": "^1.1.1",
     "pg": "^8.20.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",
+    "@types/multer": "^1.4.12",
     "@types/node": "^22.0.0",
+    "@types/pdf-parse": "^1.1.4",
     "@types/pg": "^8.20.0",
     "eslint": "^9.0.0",
     "tsx": "^4.19.2",

--- a/apps/api/scripts/db-init.ts
+++ b/apps/api/scripts/db-init.ts
@@ -14,7 +14,6 @@ if (!databaseUrl) {
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(scriptDir, '..', '..', '..');
 const migrationDir = join(repoRoot, 'db', 'migrations');
-const seedPath = join(repoRoot, 'db', 'seed', 'sample_jobs.sql');
 
 function describeTarget(url: string) {
   const parsed = new URL(url);
@@ -57,7 +56,7 @@ async function main() {
     for (const migrationPath of await listMigrationFiles()) {
       await runSql(pool, `schema migration ${migrationPath.split('\\').pop() ?? migrationPath}`, migrationPath);
     }
-    await runSql(pool, 'seed data', seedPath);
+    // No global seed: sample data is loaded per-account via POST /api/demo/seed.
     console.log('Azure PostgreSQL bootstrap completed successfully.');
   } finally {
     await pool.end();

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,9 +1,12 @@
 import cors from 'cors';
 import express from 'express';
+import { attachUserId, clerkAuth } from '@/lib/auth';
 import { aiRouter } from '@/routes/ai';
+import { demoRouter } from '@/routes/demo';
 import { healthRouter } from '@/routes/health';
 import { jobsRouter } from '@/routes/jobs';
 import { n8nRouter } from '@/routes/n8n';
+import { profileRouter } from '@/routes/profile';
 import { reportsRouter } from '@/routes/reports';
 import { outreachRouter } from '@/routes/outreach';
 import { telemetryRouter } from '@/routes/telemetry';
@@ -48,11 +51,15 @@ export function createApp() {
     }),
   );
   app.use(requireSharedApiKey);
-  app.use(express.json({ limit: '1mb' }));
+  app.use(express.json({ limit: '5mb' }));
+  app.use(clerkAuth);
+  app.use(attachUserId);
 
   app.use('/api', healthRouter);
   app.use('/api/jobs', jobsRouter);
   app.use('/api/ai', aiRouter);
+  app.use('/api/profile', profileRouter);
+  app.use('/api/demo', demoRouter);
   app.use('/api/outreach', outreachRouter);
   app.use('/api/reports', reportsRouter);
   app.use('/api/telemetry', telemetryRouter);

--- a/apps/api/src/data/job-store.postgres.ts
+++ b/apps/api/src/data/job-store.postgres.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import type { PoolClient } from 'pg';
 import type {
   CreateJobBody,
   JobAnalysis,
@@ -71,8 +70,6 @@ type JobStateRow = {
   status: string;
   next_action: string | null;
 };
-
-let readyPromise: Promise<void> | null = null;
 
 function poolOrThrow() {
   const pool = getPool();
@@ -166,218 +163,13 @@ function mapJob(row: JobRow, analysisRow?: JobAnalysisRow, outreachRows: Outreac
   };
 }
 
-async function ensureSeedData(client: PoolClient) {
-  const { rows } = await client.query<{ count: string }>('select count(*)::text as count from jobs');
-  if (Number(rows[0]?.count ?? '0') > 0) {
-    return;
-  }
-
-  for (const job of seedJobs) {
-    await client.query(
-      `
-        insert into jobs (
-          id,
-          job_url,
-          source,
-          company,
-          title,
-          location,
-          employment_type,
-          workplace_type,
-          date_posted,
-          discovered_at,
-          description_text,
-          status,
-          priority,
-          fit_score,
-          notes,
-          next_action,
-          next_action_due,
-          created_at,
-          updated_at
-        ) values (
-          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19
-        )
-        on conflict (id) do update set
-          job_url = excluded.job_url,
-          source = excluded.source,
-          company = excluded.company,
-          title = excluded.title,
-          location = excluded.location,
-          employment_type = excluded.employment_type,
-          workplace_type = excluded.workplace_type,
-          date_posted = excluded.date_posted,
-          discovered_at = excluded.discovered_at,
-          description_text = excluded.description_text,
-          status = excluded.status,
-          priority = excluded.priority,
-          fit_score = excluded.fit_score,
-          notes = excluded.notes,
-          next_action = excluded.next_action,
-          next_action_due = excluded.next_action_due,
-          created_at = excluded.created_at,
-          updated_at = excluded.updated_at
-      `,
-      [
-        job.id,
-        job.jobUrl ?? null,
-        job.source,
-        job.company,
-        job.title,
-        job.location,
-        job.employmentType,
-        job.workplaceType,
-        job.datePosted ?? null,
-        job.discoveredAt,
-        job.descriptionText,
-        job.status,
-        job.priority,
-        job.fitScore,
-        job.notes ?? null,
-        job.nextAction ?? null,
-        job.nextActionDue ?? null,
-        job.createdAt,
-        job.updatedAt,
-      ],
-    );
-
-    await client.query(
-      `
-        insert into job_analysis (
-          job_id,
-          required_skills,
-          preferred_skills,
-          matched_skills,
-          missing_skills,
-          ats_keywords,
-          fit_summary,
-          recommended_resume_angle,
-          apply_recommendation,
-          confidence_score,
-          model_used,
-          created_at
-        ) values (
-          $1, $2::jsonb, $3::jsonb, $4::jsonb, $5::jsonb, $6::jsonb, $7, $8, $9, $10, $11, $12
-        )
-        on conflict (job_id) do update set
-          required_skills = excluded.required_skills,
-          preferred_skills = excluded.preferred_skills,
-          matched_skills = excluded.matched_skills,
-          missing_skills = excluded.missing_skills,
-          ats_keywords = excluded.ats_keywords,
-          fit_summary = excluded.fit_summary,
-          recommended_resume_angle = excluded.recommended_resume_angle,
-          apply_recommendation = excluded.apply_recommendation,
-          confidence_score = excluded.confidence_score,
-          model_used = excluded.model_used
-      `,
-      [
-        job.id,
-        JSON.stringify(job.analysis.requiredSkills),
-        JSON.stringify(job.analysis.preferredSkills),
-        JSON.stringify(job.analysis.matchedSkills),
-        JSON.stringify(job.analysis.missingSkills),
-        JSON.stringify(job.analysis.atsKeywords),
-        job.analysis.fitSummary,
-        job.analysis.recommendedResumeAngle,
-        job.analysis.applyRecommendation,
-        job.analysis.confidenceScore,
-        job.analysis.modelUsed,
-        job.createdAt,
-      ],
-    );
-
-    for (const draft of job.outreach) {
-      await client.query(
-        `
-        insert into outreach (
-          id,
-          job_id,
-          contact_name,
-          contact_role,
-          contact_source,
-          linkedin_url,
-          email,
-          message_type,
-          draft_text,
-          gmail_draft_id,
-          status,
-          created_at,
-          sent_at,
-          follow_up_due
-        ) values (
-          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14
-        )
-        on conflict (id) do update set
-          job_id = excluded.job_id,
-          contact_name = excluded.contact_name,
-          contact_role = excluded.contact_role,
-          contact_source = excluded.contact_source,
-          linkedin_url = excluded.linkedin_url,
-          email = excluded.email,
-          message_type = excluded.message_type,
-          draft_text = excluded.draft_text,
-          gmail_draft_id = excluded.gmail_draft_id,
-          status = excluded.status,
-          created_at = excluded.created_at,
-          sent_at = excluded.sent_at,
-          follow_up_due = excluded.follow_up_due
-      `,
-        [
-          draft.id,
-          job.id,
-          draft.contactName ?? null,
-          draft.contactRole ?? null,
-          draft.contactSource ?? null,
-          draft.linkedinUrl ?? null,
-          draft.email ?? null,
-          draft.messageType,
-          draft.draftText,
-          draft.gmailDraftId ?? null,
-          draft.status,
-          draft.createdAt,
-          draft.sentAt ?? null,
-          draft.followUpDue ?? null,
-        ],
-      );
-    }
-  }
-}
-
-async function ensureReady() {
-  if (readyPromise) {
-    await readyPromise;
-    return;
-  }
-
+export async function listJobs(userId: string): Promise<JobRecord[]> {
   const pool = poolOrThrow();
 
-  readyPromise = (async () => {
-    const client = await pool.connect();
-    try {
-      await client.query('begin');
-      await ensureSeedData(client);
-      await client.query('commit');
-    } catch (error) {
-      await client.query('rollback');
-      throw error;
-    } finally {
-      client.release();
-    }
-  })();
-
-  try {
-    await readyPromise;
-  } finally {
-    readyPromise = null;
-  }
-}
-
-export async function listJobs(): Promise<JobRecord[]> {
-  await ensureReady();
-  const pool = poolOrThrow();
-
-  const jobsResult = await pool.query<JobRow>('select * from jobs order by created_at desc');
+  const jobsResult = await pool.query<JobRow>(
+    'select * from jobs where user_id = $1 order by created_at desc',
+    [userId],
+  );
   if (jobsResult.rowCount === 0) {
     return [];
   }
@@ -407,11 +199,13 @@ export async function listJobs(): Promise<JobRecord[]> {
   return jobsResult.rows.map((row: JobRow) => mapJob(row, analysisByJobId.get(row.id), outreachByJobId.get(row.id)));
 }
 
-export async function getJobById(jobId: string): Promise<JobRecord | undefined> {
-  await ensureReady();
+export async function getJobById(userId: string, jobId: string): Promise<JobRecord | undefined> {
   const pool = poolOrThrow();
 
-  const { rows } = await pool.query<JobRow>('select * from jobs where id::text = $1 limit 1', [jobId]);
+  const { rows } = await pool.query<JobRow>(
+    'select * from jobs where id::text = $1 and user_id = $2 limit 1',
+    [jobId, userId],
+  );
   const job = rows[0] as JobRow | undefined;
 
   if (!job) {
@@ -428,8 +222,7 @@ export async function getJobById(jobId: string): Promise<JobRecord | undefined> 
   return mapJob(job, analysisResult.rows[0] as JobAnalysisRow | undefined, outreachResult.rows as OutreachRow[]);
 }
 
-export async function createJob(body: CreateJobBody): Promise<JobRecord> {
-  await ensureReady();
+export async function createJob(userId: string, body: CreateJobBody): Promise<JobRecord> {
   const pool = poolOrThrow();
   const client = await pool.connect();
   const jobId = randomUUID();
@@ -443,6 +236,7 @@ export async function createJob(body: CreateJobBody): Promise<JobRecord> {
       `
         insert into jobs (
           id,
+          user_id,
           job_url,
           source,
           company,
@@ -461,12 +255,13 @@ export async function createJob(body: CreateJobBody): Promise<JobRecord> {
           created_at,
           updated_at
         ) values (
-          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18
+          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19
         )
         returning *
       `,
       [
         jobId,
+        userId,
         body.jobUrl ?? null,
         body.source ?? 'manual',
         body.company.trim(),
@@ -543,7 +338,7 @@ export async function createJob(body: CreateJobBody): Promise<JobRecord> {
     );
 
     await client.query('commit');
-    const created = await getJobById(insertedJob.id);
+    const created = await getJobById(userId, insertedJob.id);
     if (!created) {
       throw new Error('Created job could not be reloaded');
     }
@@ -557,8 +352,11 @@ export async function createJob(body: CreateJobBody): Promise<JobRecord> {
   }
 }
 
-export async function updateJob(jobId: string, body: UpdateJobBody): Promise<JobRecord | undefined> {
-  await ensureReady();
+export async function updateJob(
+  userId: string,
+  jobId: string,
+  body: UpdateJobBody,
+): Promise<JobRecord | undefined> {
   const pool = poolOrThrow();
   const client = await pool.connect();
 
@@ -575,7 +373,7 @@ export async function updateJob(jobId: string, body: UpdateJobBody): Promise<Job
           fit_score = coalesce($5, fit_score),
           next_action = case when $6::text is null then next_action else nullif($6::text, '') end,
           next_action_due = case when $7::timestamptz is null then next_action_due else $7::timestamptz end
-        where id::text = $1
+        where id::text = $1 and user_id = $8
         returning *
       `,
       [
@@ -586,6 +384,7 @@ export async function updateJob(jobId: string, body: UpdateJobBody): Promise<Job
         typeof body.fitScore === 'undefined' ? null : body.fitScore,
         body.nextAction ?? null,
         body.nextActionDue ?? null,
+        userId,
       ],
     );
 
@@ -595,7 +394,7 @@ export async function updateJob(jobId: string, body: UpdateJobBody): Promise<Job
       return undefined;
     }
 
-    return getJobById(jobId);
+    return getJobById(userId, jobId);
   } catch (error) {
     await client.query('rollback');
     throw error;
@@ -604,13 +403,25 @@ export async function updateJob(jobId: string, body: UpdateJobBody): Promise<Job
   }
 }
 
-export async function appendOutreachDraft(jobId: string, draft: OutreachDraft): Promise<OutreachDraft | undefined> {
-  await ensureReady();
+export async function appendOutreachDraft(
+  userId: string,
+  jobId: string,
+  draft: OutreachDraft,
+): Promise<OutreachDraft | undefined> {
   const pool = poolOrThrow();
   const client = await pool.connect();
 
   try {
     await client.query('begin');
+
+    const ownership = await client.query('select 1 from jobs where id::text = $1 and user_id = $2 limit 1', [
+      jobId,
+      userId,
+    ]);
+    if (ownership.rowCount === 0) {
+      await client.query('rollback');
+      return undefined;
+    }
 
     const { rows } = await client.query<OutreachRow>(
       `
@@ -694,10 +505,10 @@ export async function appendOutreachDraft(jobId: string, draft: OutreachDraft): 
 }
 
 export async function updateOutreachDraft(
+  userId: string,
   outreachId: string,
   body: UpdateOutreachBody,
 ): Promise<OutreachDraft | undefined> {
-  await ensureReady();
   const pool = poolOrThrow();
   const client = await pool.connect();
 
@@ -717,6 +528,7 @@ export async function updateOutreachDraft(
           end,
           follow_up_due = case when $5::timestamptz is null then follow_up_due else $5::timestamptz end
         where id::text = $1
+          and job_id in (select id from jobs where user_id = $6)
         returning *
       `,
       [
@@ -725,6 +537,7 @@ export async function updateOutreachDraft(
         body.gmailDraftId ?? null,
         body.sentAt ?? null,
         body.followUpDue ?? null,
+        userId,
       ],
     );
 
@@ -778,18 +591,18 @@ export async function updateOutreachDraft(
 }
 
 export async function saveJobAnalysis(
+  userId: string,
   jobId: string,
   analysis: JobAnalysis,
   fitScore?: number | null,
 ): Promise<JobRecord | undefined> {
-  await ensureReady();
   const pool = poolOrThrow();
 
   if (!validateJobAnalysis(analysis)) {
     throw new Error('Invalid job analysis payload');
   }
 
-  const job = await getJobById(jobId);
+  const job = await getJobById(userId, jobId);
   if (!job) {
     return undefined;
   }
@@ -851,14 +664,14 @@ export async function saveJobAnalysis(
     await pool.query('update jobs set updated_at = now() where id::text = $1', [jobId]);
   }
 
-  return getJobById(jobId);
+  return getJobById(userId, jobId);
 }
 
 export async function updateOutreachGmailDraftId(
+  userId: string,
   outreachId: string,
   gmailDraftId: string,
 ): Promise<OutreachDraft | undefined> {
-  await ensureReady();
   const pool = poolOrThrow();
   const client = await pool.connect();
 
@@ -870,9 +683,10 @@ export async function updateOutreachGmailDraftId(
         update outreach
         set gmail_draft_id = case when $2::text is null then gmail_draft_id else nullif($2::text, '') end
         where id::text = $1
+          and job_id in (select id from jobs where user_id = $3)
         returning *
       `,
-      [outreachId, gmailDraftId],
+      [outreachId, gmailDraftId, userId],
     );
 
     const outreach = rows[0] as OutreachRow | undefined;
@@ -883,6 +697,121 @@ export async function updateOutreachGmailDraftId(
 
     await client.query('commit');
     return mapOutreach(outreach);
+  } catch (error) {
+    await client.query('rollback');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+/** Delete a user's jobs (cascades analysis/outreach) and their embeddings. */
+export async function clearUserData(userId: string): Promise<void> {
+  const pool = poolOrThrow();
+  const client = await pool.connect();
+  try {
+    await client.query('begin');
+    await client.query('delete from embeddings where user_id = $1', [userId]);
+    await client.query('delete from jobs where user_id = $1', [userId]);
+    await client.query('commit');
+  } catch (error) {
+    await client.query('rollback');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+/** Replace a user's data with the sample CRM (for instant demos). */
+export async function seedDemoData(userId: string): Promise<void> {
+  await clearUserData(userId);
+  const pool = poolOrThrow();
+  const client = await pool.connect();
+  try {
+    await client.query('begin');
+
+    for (const job of seedJobs) {
+      const jobId = randomUUID();
+      await client.query(
+        `insert into jobs (
+          id, user_id, job_url, source, company, title, location, employment_type,
+          workplace_type, date_posted, discovered_at, description_text, status, priority,
+          fit_score, notes, next_action, next_action_due, created_at, updated_at
+        ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)`,
+        [
+          jobId,
+          userId,
+          job.jobUrl ?? null,
+          job.source,
+          job.company,
+          job.title,
+          job.location,
+          job.employmentType,
+          job.workplaceType,
+          job.datePosted ?? null,
+          job.discoveredAt,
+          job.descriptionText,
+          job.status,
+          job.priority,
+          job.fitScore,
+          job.notes ?? null,
+          job.nextAction ?? null,
+          job.nextActionDue ?? null,
+          job.createdAt,
+          job.updatedAt,
+        ],
+      );
+
+      await client.query(
+        `insert into job_analysis (
+          id, job_id, required_skills, preferred_skills, matched_skills, missing_skills,
+          ats_keywords, fit_summary, recommended_resume_angle, apply_recommendation,
+          confidence_score, model_used, created_at
+        ) values ($1,$2,$3::jsonb,$4::jsonb,$5::jsonb,$6::jsonb,$7::jsonb,$8,$9,$10,$11,$12,$13)`,
+        [
+          randomUUID(),
+          jobId,
+          JSON.stringify(job.analysis.requiredSkills),
+          JSON.stringify(job.analysis.preferredSkills),
+          JSON.stringify(job.analysis.matchedSkills),
+          JSON.stringify(job.analysis.missingSkills),
+          JSON.stringify(job.analysis.atsKeywords),
+          job.analysis.fitSummary,
+          job.analysis.recommendedResumeAngle,
+          job.analysis.applyRecommendation,
+          job.analysis.confidenceScore,
+          job.analysis.modelUsed,
+          job.createdAt,
+        ],
+      );
+
+      for (const draft of job.outreach) {
+        await client.query(
+          `insert into outreach (
+            id, job_id, contact_name, contact_role, contact_source, linkedin_url, email,
+            message_type, draft_text, gmail_draft_id, status, created_at, sent_at, follow_up_due
+          ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+          [
+            randomUUID(),
+            jobId,
+            draft.contactName ?? null,
+            draft.contactRole ?? null,
+            draft.contactSource ?? null,
+            draft.linkedinUrl ?? null,
+            draft.email ?? null,
+            draft.messageType,
+            draft.draftText,
+            draft.gmailDraftId ?? null,
+            draft.status,
+            draft.createdAt,
+            draft.sentAt ?? null,
+            draft.followUpDue ?? null,
+          ],
+        );
+      }
+    }
+
+    await client.query('commit');
   } catch (error) {
     await client.query('rollback');
     throw error;

--- a/apps/api/src/data/job-store.ts
+++ b/apps/api/src/data/job-store.ts
@@ -70,11 +70,12 @@ function extractKeywords(text: string): string[] {
   return keywords.filter((keyword) => text.toLowerCase().includes(keyword.toLowerCase()));
 }
 
-function createBaseJob(body: CreateJobBody): JobRecord {
+function createBaseJob(userId: string, body: CreateJobBody): JobRecord {
   const timestamp = new Date().toISOString();
 
   return {
     id: randomUUID(),
+    userId,
     jobUrl: body.jobUrl,
     source: body.source ?? 'manual',
     company: body.company.trim(),
@@ -161,47 +162,51 @@ async function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
   }
 }
 
-export async function listJobs(): Promise<JobRecord[]> {
+export async function listJobs(userId: string): Promise<JobRecord[]> {
   if (hasPostgresConnection()) {
-    return postgresStore.listJobs();
+    return postgresStore.listJobs(userId);
   }
 
   const jobs = await ensureLoaded();
-  return clone(jobs);
+  return clone(jobs.filter((entry) => entry.userId === userId));
 }
 
-export async function getJobById(jobId: string): Promise<JobRecord | undefined> {
+export async function getJobById(userId: string, jobId: string): Promise<JobRecord | undefined> {
   if (hasPostgresConnection()) {
-    return postgresStore.getJobById(jobId);
+    return postgresStore.getJobById(userId, jobId);
   }
 
   const jobs = await ensureLoaded();
-  const job = jobs.find((entry) => entry.id === jobId);
+  const job = jobs.find((entry) => entry.id === jobId && entry.userId === userId);
   return job ? clone(job) : undefined;
 }
 
-export async function createJob(body: CreateJobBody): Promise<JobRecord> {
+export async function createJob(userId: string, body: CreateJobBody): Promise<JobRecord> {
   if (hasPostgresConnection()) {
-    return postgresStore.createJob(body);
+    return postgresStore.createJob(userId, body);
   }
 
   return runExclusive(async () => {
     const jobs = await ensureLoaded();
-    const job = createBaseJob(body);
+    const job = createBaseJob(userId, body);
     jobs.unshift(job);
     await persistJobs();
     return clone(job);
   });
 }
 
-export async function updateJob(jobId: string, body: UpdateJobBody): Promise<JobRecord | undefined> {
+export async function updateJob(
+  userId: string,
+  jobId: string,
+  body: UpdateJobBody,
+): Promise<JobRecord | undefined> {
   if (hasPostgresConnection()) {
-    return postgresStore.updateJob(jobId, body);
+    return postgresStore.updateJob(userId, jobId, body);
   }
 
   return runExclusive(async () => {
     const jobs = await ensureLoaded();
-    const job = jobs.find((entry) => entry.id === jobId);
+    const job = jobs.find((entry) => entry.id === jobId && entry.userId === userId);
 
     if (!job) {
       return undefined;
@@ -232,14 +237,18 @@ export async function updateJob(jobId: string, body: UpdateJobBody): Promise<Job
   });
 }
 
-export async function appendOutreachDraft(jobId: string, draft: OutreachDraft): Promise<OutreachDraft | undefined> {
+export async function appendOutreachDraft(
+  userId: string,
+  jobId: string,
+  draft: OutreachDraft,
+): Promise<OutreachDraft | undefined> {
   if (hasPostgresConnection()) {
-    return postgresStore.appendOutreachDraft(jobId, draft);
+    return postgresStore.appendOutreachDraft(userId, jobId, draft);
   }
 
   return runExclusive(async () => {
     const jobs = await ensureLoaded();
-    const job = jobs.find((entry) => entry.id === jobId);
+    const job = jobs.find((entry) => entry.id === jobId && entry.userId === userId);
 
     if (!job) {
       return undefined;
@@ -264,17 +273,22 @@ export async function appendOutreachDraft(jobId: string, draft: OutreachDraft): 
 }
 
 export async function updateOutreachDraft(
+  userId: string,
   outreachId: string,
   body: UpdateOutreachBody,
 ): Promise<OutreachDraft | undefined> {
   if (hasPostgresConnection()) {
-    return postgresStore.updateOutreachDraft(outreachId, body);
+    return postgresStore.updateOutreachDraft(userId, outreachId, body);
   }
 
   return runExclusive(async () => {
     const jobs = await ensureLoaded();
 
     for (const job of jobs) {
+      if (job.userId !== userId) {
+        continue;
+      }
+
       const draft = job.outreach.find((entry) => entry.id === outreachId);
 
       if (!draft) {
@@ -315,17 +329,22 @@ export async function updateOutreachDraft(
 }
 
 export async function updateOutreachGmailDraftId(
+  userId: string,
   outreachId: string,
   gmailDraftId: string,
 ): Promise<OutreachDraft | undefined> {
   if (hasPostgresConnection()) {
-    return postgresStore.updateOutreachGmailDraftId(outreachId, gmailDraftId);
+    return postgresStore.updateOutreachGmailDraftId(userId, outreachId, gmailDraftId);
   }
 
   return runExclusive(async () => {
     const jobs = await ensureLoaded();
 
     for (const job of jobs) {
+      if (job.userId !== userId) {
+        continue;
+      }
+
       const draft = job.outreach.find((entry) => entry.id === outreachId);
 
       if (!draft) {
@@ -343,17 +362,18 @@ export async function updateOutreachGmailDraftId(
 }
 
 export async function saveJobAnalysis(
+  userId: string,
   jobId: string,
   analysis: JobAnalysis,
   fitScore?: number | null,
 ): Promise<JobRecord | undefined> {
   if (hasPostgresConnection()) {
-    return postgresStore.saveJobAnalysis(jobId, analysis, fitScore);
+    return postgresStore.saveJobAnalysis(userId, jobId, analysis, fitScore);
   }
 
   return runExclusive(async () => {
     const jobs = await ensureLoaded();
-    const job = jobs.find((entry) => entry.id === jobId);
+    const job = jobs.find((entry) => entry.id === jobId && entry.userId === userId);
 
     if (!job) {
       return undefined;
@@ -370,5 +390,36 @@ export async function saveJobAnalysis(
     job.updatedAt = new Date().toISOString();
     await persistJobs();
     return clone(job);
+  });
+}
+
+export async function clearUserData(userId: string): Promise<void> {
+  if (hasPostgresConnection()) {
+    return postgresStore.clearUserData(userId);
+  }
+
+  await runExclusive(async () => {
+    const jobs = await ensureLoaded();
+    jobsCache = jobs.filter((entry) => entry.userId !== userId);
+    await persistJobs();
+  });
+}
+
+export async function seedDemoData(userId: string): Promise<void> {
+  if (hasPostgresConnection()) {
+    return postgresStore.seedDemoData(userId);
+  }
+
+  await runExclusive(async () => {
+    const jobs = await ensureLoaded();
+    const others = jobs.filter((entry) => entry.userId !== userId);
+    const mine = clone(seedJobs).map((job) => ({
+      ...job,
+      id: randomUUID(),
+      userId,
+      outreach: job.outreach.map((draft) => ({ ...draft, id: randomUUID() })),
+    }));
+    jobsCache = [...mine, ...others];
+    await persistJobs();
   });
 }

--- a/apps/api/src/data/profile-store.ts
+++ b/apps/api/src/data/profile-store.ts
@@ -1,0 +1,107 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getPool, hasPostgresConnection } from '@/lib/postgres';
+
+export interface UserProfile {
+  userId: string;
+  displayName?: string;
+  resumeText?: string;
+  resumeFileName?: string;
+  resumeFileUrl?: string;
+  profileText?: string;
+  updatedAt?: string;
+}
+
+type ProfileRow = {
+  user_id: string;
+  display_name: string | null;
+  resume_text: string | null;
+  resume_file_name: string | null;
+  resume_file_url: string | null;
+  profile_text: string | null;
+  updated_at: string;
+};
+
+function mapRow(row: ProfileRow): UserProfile {
+  return {
+    userId: row.user_id,
+    displayName: row.display_name ?? undefined,
+    resumeText: row.resume_text ?? undefined,
+    resumeFileName: row.resume_file_name ?? undefined,
+    resumeFileUrl: row.resume_file_url ?? undefined,
+    profileText: row.profile_text ?? undefined,
+    updatedAt: row.updated_at,
+  };
+}
+
+// File-mode fallback (local dev / tests without DATABASE_URL).
+const dataDir = () => join(process.cwd(), 'data');
+const dataFile = () => join(dataDir(), 'user-profiles.json');
+
+async function readFileProfiles(): Promise<Record<string, UserProfile>> {
+  try {
+    const raw = await readFile(dataFile(), 'utf8');
+    return JSON.parse(raw) as Record<string, UserProfile>;
+  } catch {
+    return {};
+  }
+}
+
+async function writeFileProfiles(profiles: Record<string, UserProfile>) {
+  await mkdir(dataDir(), { recursive: true });
+  await writeFile(dataFile(), `${JSON.stringify(profiles, null, 2)}\n`, 'utf8');
+}
+
+export async function getUserProfile(userId: string): Promise<UserProfile | undefined> {
+  if (hasPostgresConnection()) {
+    const pool = getPool()!;
+    const { rows } = await pool.query<ProfileRow>('select * from user_profiles where user_id = $1 limit 1', [userId]);
+    return rows[0] ? mapRow(rows[0]) : undefined;
+  }
+
+  const profiles = await readFileProfiles();
+  return profiles[userId];
+}
+
+export async function upsertUserProfile(
+  userId: string,
+  patch: Partial<Omit<UserProfile, 'userId'>>,
+): Promise<UserProfile> {
+  if (hasPostgresConnection()) {
+    const pool = getPool()!;
+    const { rows } = await pool.query<ProfileRow>(
+      `
+        insert into user_profiles (user_id, display_name, resume_text, resume_file_name, resume_file_url, profile_text)
+        values ($1, $2, $3, $4, $5, $6)
+        on conflict (user_id) do update set
+          display_name = coalesce($2, user_profiles.display_name),
+          resume_text = coalesce($3, user_profiles.resume_text),
+          resume_file_name = coalesce($4, user_profiles.resume_file_name),
+          resume_file_url = coalesce($5, user_profiles.resume_file_url),
+          profile_text = coalesce($6, user_profiles.profile_text)
+        returning *
+      `,
+      [
+        userId,
+        patch.displayName ?? null,
+        patch.resumeText ?? null,
+        patch.resumeFileName ?? null,
+        patch.resumeFileUrl ?? null,
+        patch.profileText ?? null,
+      ],
+    );
+    return mapRow(rows[0]!);
+  }
+
+  const profiles = await readFileProfiles();
+  const existing = profiles[userId] ?? { userId };
+  const merged: UserProfile = {
+    ...existing,
+    ...Object.fromEntries(Object.entries(patch).filter(([, value]) => value !== undefined)),
+    userId,
+    updatedAt: new Date().toISOString(),
+  };
+  profiles[userId] = merged;
+  await writeFileProfiles(profiles);
+  return merged;
+}

--- a/apps/api/src/data/profile-store.ts
+++ b/apps/api/src/data/profile-store.ts
@@ -105,3 +105,18 @@ export async function upsertUserProfile(
   await writeFileProfiles(profiles);
   return merged;
 }
+
+/** Deletes a user's stored profile (resume + profile text). */
+export async function deleteUserProfile(userId: string): Promise<void> {
+  if (hasPostgresConnection()) {
+    const pool = getPool()!;
+    await pool.query('delete from user_profiles where user_id = $1', [userId]);
+    return;
+  }
+
+  const profiles = await readFileProfiles();
+  if (userId in profiles) {
+    delete profiles[userId];
+    await writeFileProfiles(profiles);
+  }
+}

--- a/apps/api/src/data/report-store.postgres.ts
+++ b/apps/api/src/data/report-store.postgres.ts
@@ -1,4 +1,4 @@
-import type { PoolClient } from 'pg';
+import { randomUUID } from 'node:crypto';
 import type { WeeklyReportRecord } from '@/types';
 import { getPool } from '@/lib/postgres';
 import { seedWeeklyReports } from '@/data/mock-store';
@@ -20,8 +20,6 @@ type WeeklyReportRow = {
   report_url: string | null;
   created_at: string;
 };
-
-let readyPromise: Promise<void> | null = null;
 
 function poolOrThrow() {
   const pool = getPool();
@@ -61,119 +59,25 @@ function mapReport(row: WeeklyReportRow): WeeklyReportRecord {
   };
 }
 
-async function ensureSeedData(client: PoolClient) {
-  const { rows } = await client.query<{ count: string }>('select count(*)::text as count from weekly_reports');
-  if (Number(rows[0]?.count ?? '0') > 0) {
-    return;
-  }
-
-  for (const report of seedWeeklyReports) {
-    await client.query(
-      `
-        insert into weekly_reports (
-          id,
-          week_start,
-          week_end,
-          jobs_discovered,
-          jobs_shortlisted,
-          jobs_applied,
-          outreach_drafted,
-          outreach_sent,
-          responses_received,
-          interviews,
-          common_missing_skills,
-          recommendations,
-          report_markdown,
-          report_url,
-          created_at
-        ) values (
-          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,$12::jsonb,$13,$14,$15
-        )
-        on conflict (id) do update set
-          week_start = excluded.week_start,
-          week_end = excluded.week_end,
-          jobs_discovered = excluded.jobs_discovered,
-          jobs_shortlisted = excluded.jobs_shortlisted,
-          jobs_applied = excluded.jobs_applied,
-          outreach_drafted = excluded.outreach_drafted,
-          outreach_sent = excluded.outreach_sent,
-          responses_received = excluded.responses_received,
-          interviews = excluded.interviews,
-          common_missing_skills = excluded.common_missing_skills,
-          recommendations = excluded.recommendations,
-          report_markdown = excluded.report_markdown,
-          report_url = excluded.report_url,
-          created_at = excluded.created_at
-      `,
-      [
-        report.id,
-        report.weekStart,
-        report.weekEnd,
-        report.jobsDiscovered,
-        report.jobsShortlisted,
-        report.jobsApplied,
-        report.outreachDrafted,
-        report.outreachSent,
-        report.responsesReceived,
-        report.interviews,
-        JSON.stringify(report.commonMissingSkills),
-        JSON.stringify(report.recommendations),
-        report.reportMarkdown,
-        report.reportUrl ?? null,
-        report.createdAt,
-      ],
-    );
-  }
-}
-
-async function ensureReady() {
-  if (readyPromise) {
-    await readyPromise;
-    return;
-  }
-
-  const pool = poolOrThrow();
-
-  readyPromise = (async () => {
-    const client = await pool.connect();
-    try {
-      await client.query('begin');
-      await ensureSeedData(client);
-      await client.query('commit');
-    } catch (error) {
-      await client.query('rollback');
-      throw error;
-    } finally {
-      client.release();
-    }
-  })();
-
-  try {
-    await readyPromise;
-  } finally {
-    readyPromise = null;
-  }
-}
-
-export async function listWeeklyReports(): Promise<WeeklyReportRecord[]> {
-  await ensureReady();
+export async function listWeeklyReports(userId: string): Promise<WeeklyReportRecord[]> {
   const pool = poolOrThrow();
 
   const { rows } = await pool.query<WeeklyReportRow>(
-    'select * from weekly_reports order by created_at desc, week_end desc, week_start desc',
+    'select * from weekly_reports where user_id = $1 order by created_at desc, week_end desc, week_start desc',
+    [userId],
   );
 
   return rows.map(mapReport);
 }
 
-export async function saveWeeklyReport(report: WeeklyReportRecord): Promise<WeeklyReportRecord> {
-  await ensureReady();
+export async function saveWeeklyReport(userId: string, report: WeeklyReportRecord): Promise<WeeklyReportRecord> {
   const pool = poolOrThrow();
 
   const { rows } = await pool.query<WeeklyReportRow>(
     `
       insert into weekly_reports (
         id,
+        user_id,
         week_start,
         week_end,
         jobs_discovered,
@@ -189,9 +93,9 @@ export async function saveWeeklyReport(report: WeeklyReportRecord): Promise<Week
         report_url,
         created_at
       ) values (
-        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,$12::jsonb,$13,$14,$15
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb,$13::jsonb,$14,$15,$16
       )
-      on conflict (week_start, week_end) do update set
+      on conflict (user_id, week_start, week_end) do update set
         jobs_discovered = excluded.jobs_discovered,
         jobs_shortlisted = excluded.jobs_shortlisted,
         jobs_applied = excluded.jobs_applied,
@@ -208,6 +112,7 @@ export async function saveWeeklyReport(report: WeeklyReportRecord): Promise<Week
     `,
     [
       report.id,
+      userId,
       report.weekStart,
       report.weekEnd,
       report.jobsDiscovered,
@@ -233,7 +138,19 @@ export async function saveWeeklyReport(report: WeeklyReportRecord): Promise<Week
   return mapReport(savedReport);
 }
 
-export async function getLatestWeeklyReport(): Promise<WeeklyReportRecord | undefined> {
-  const reports = await listWeeklyReports();
+export async function getLatestWeeklyReport(userId: string): Promise<WeeklyReportRecord | undefined> {
+  const reports = await listWeeklyReports(userId);
   return reports[0];
+}
+
+export async function clearUserReports(userId: string): Promise<void> {
+  const pool = poolOrThrow();
+  await pool.query('delete from weekly_reports where user_id = $1', [userId]);
+}
+
+export async function seedDemoReports(userId: string): Promise<void> {
+  await clearUserReports(userId);
+  for (const report of seedWeeklyReports) {
+    await saveWeeklyReport(userId, { ...report, id: randomUUID() });
+  }
 }

--- a/apps/api/src/data/report-store.test.ts
+++ b/apps/api/src/data/report-store.test.ts
@@ -8,7 +8,10 @@ import {
   listWeeklyReports,
   resetWeeklyReportStoreForTests,
   saveWeeklyReport,
+  seedDemoReports,
 } from './report-store';
+
+const USER = 'user_test';
 
 function makeReport(overrides: Partial<WeeklyReportRecord> = {}): WeeklyReportRecord {
   return {
@@ -34,7 +37,7 @@ function snapshotCwd() {
   return process.cwd();
 }
 
-test('loads the seeded weekly report into the current data directory', async () => {
+test('a new user starts empty and can load the sample report', async () => {
   const originalCwd = snapshotCwd();
   const tempDir = await mkdtemp(join(tmpdir(), 'jobops-weekly-report-'));
 
@@ -42,10 +45,15 @@ test('loads the seeded weekly report into the current data directory', async () 
     process.chdir(tempDir);
     resetWeeklyReportStoreForTests();
 
-    const reports = await listWeeklyReports();
+    assert.equal((await listWeeklyReports(USER)).length, 0);
 
+    await seedDemoReports(USER);
+    const reports = await listWeeklyReports(USER);
     assert.equal(reports.length, 1);
-    assert.equal(reports[0]?.id, '44444444-4444-4444-8444-444444444444');
+    assert.equal(reports[0]?.weekStart, '2026-05-11');
+
+    // Isolation: a different user still sees nothing.
+    assert.equal((await listWeeklyReports('user_other')).length, 0);
   } finally {
     process.chdir(originalCwd);
     await rm(tempDir, { recursive: true, force: true });
@@ -60,8 +68,9 @@ test('upserts reports by week range and keeps the latest version first', async (
     process.chdir(tempDir);
     resetWeeklyReportStoreForTests();
 
-    const firstSave = await saveWeeklyReport(makeReport({ createdAt: '2026-05-24T18:00:00.000Z' }));
+    const firstSave = await saveWeeklyReport(USER, makeReport({ createdAt: '2026-05-24T18:00:00.000Z' }));
     const updatedSave = await saveWeeklyReport(
+      USER,
       makeReport({
         jobsApplied: 2,
         recommendations: ['Review the higher-priority shortlist first.'],
@@ -70,7 +79,7 @@ test('upserts reports by week range and keeps the latest version first', async (
       }),
     );
 
-    const reports = await listWeeklyReports();
+    const reports = await listWeeklyReports(USER);
     const latest = reports[0];
     assert.ok(latest);
     assert.equal(firstSave.weekStart, updatedSave.weekStart);

--- a/apps/api/src/data/report-store.ts
+++ b/apps/api/src/data/report-store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { WeeklyReportRecord } from '@/types';
@@ -89,37 +90,44 @@ async function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
   }
 }
 
-export async function listWeeklyReports(): Promise<WeeklyReportRecord[]> {
+export async function listWeeklyReports(userId: string): Promise<WeeklyReportRecord[]> {
   if (hasPostgresConnection()) {
-    return postgresStore.listWeeklyReports();
+    return postgresStore.listWeeklyReports(userId);
   }
 
   const reports = await ensureLoaded();
-  return sortReports(clone(reports));
+  return sortReports(clone(reports.filter((entry) => entry.userId === userId)));
 }
 
-export async function getLatestWeeklyReport(): Promise<WeeklyReportRecord | undefined> {
-  const reports = await listWeeklyReports();
+export async function getLatestWeeklyReport(userId: string): Promise<WeeklyReportRecord | undefined> {
+  const reports = await listWeeklyReports(userId);
   return reports[0];
 }
 
-export async function saveWeeklyReport(report: WeeklyReportRecord): Promise<WeeklyReportRecord> {
+export async function saveWeeklyReport(
+  userId: string,
+  report: WeeklyReportRecord,
+): Promise<WeeklyReportRecord> {
   if (hasPostgresConnection()) {
-    return postgresStore.saveWeeklyReport(report);
+    return postgresStore.saveWeeklyReport(userId, report);
   }
 
   return runExclusive(async () => {
     const reports = await ensureLoaded();
     const reportIndex = reports.findIndex(
-      (entry) => entry.weekStart === report.weekStart && entry.weekEnd === report.weekEnd,
+      (entry) =>
+        entry.userId === userId &&
+        entry.weekStart === report.weekStart &&
+        entry.weekEnd === report.weekEnd,
     );
     const savedReport: WeeklyReportRecord =
       reportIndex >= 0
         ? {
             ...clone(report),
             id: reports[reportIndex]!.id,
+            userId,
           }
-        : clone(report);
+        : { ...clone(report), userId };
 
     if (reportIndex >= 0) {
       reports[reportIndex] = savedReport;
@@ -130,6 +138,36 @@ export async function saveWeeklyReport(report: WeeklyReportRecord): Promise<Week
     reportsCache = sortReports(reports);
     await persistReports();
     return clone(savedReport);
+  });
+}
+
+export async function clearUserReports(userId: string): Promise<void> {
+  if (hasPostgresConnection()) {
+    return postgresStore.clearUserReports(userId);
+  }
+
+  await runExclusive(async () => {
+    const reports = await ensureLoaded();
+    reportsCache = reports.filter((entry) => entry.userId !== userId);
+    await persistReports();
+  });
+}
+
+export async function seedDemoReports(userId: string): Promise<void> {
+  if (hasPostgresConnection()) {
+    return postgresStore.seedDemoReports(userId);
+  }
+
+  await runExclusive(async () => {
+    const reports = await ensureLoaded();
+    const others = reports.filter((entry) => entry.userId !== userId);
+    const mine = clone(seedWeeklyReports).map((report) => ({
+      ...report,
+      id: randomUUID(),
+      userId,
+    }));
+    reportsCache = sortReports([...mine, ...others]);
+    await persistReports();
   });
 }
 

--- a/apps/api/src/express-augment.d.ts
+++ b/apps/api/src/express-augment.d.ts
@@ -1,0 +1,12 @@
+// Adds the per-request user id resolved by the auth middleware (src/lib/auth.ts).
+import 'express';
+
+declare global {
+  namespace Express {
+    interface Request {
+      userId?: string;
+    }
+  }
+}
+
+export {};

--- a/apps/api/src/lib/agent-client.ts
+++ b/apps/api/src/lib/agent-client.ts
@@ -84,6 +84,7 @@ export async function fetchEvDemoViaAgent(): Promise<TelemetryInsights> {
 }
 
 export interface ScoreFitInput {
+  userId?: string;
   descriptionText: string;
   resumeText: string;
   profileText: string;
@@ -122,6 +123,7 @@ export async function resolveFitScore(input: ScoreFitInput): Promise<FitScoreOut
   if (isAgentEnabled()) {
     try {
       const scored = await callAgent<FitScoreOutput>('/score-fit', {
+        user_id: input.userId,
         description_text: input.descriptionText,
         resume_text: input.resumeText,
         profile_text: input.profileText,

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -1,0 +1,55 @@
+/**
+ * Per-request user identity.
+ *
+ * In production the web app forwards the Clerk session token as a Bearer header;
+ * `clerkMiddleware()` verifies it and `getAuth(req).userId` yields the Clerk user
+ * id. Locally and in tests (no `CLERK_SECRET_KEY`), we fall back to a dev user id
+ * (overridable per request via `X-User-Id`) so the API stays runnable offline.
+ *
+ * n8n webhook calls are machine-to-machine; they own data under a configurable
+ * system user (`N8N_USER_ID`).
+ */
+
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+import { clerkMiddleware, getAuth } from '@clerk/express';
+
+const DEV_USER_ID = process.env.DEV_USER_ID?.trim() || 'user_local_dev';
+
+/** The user that machine-to-machine n8n webhook data is owned by. */
+export const N8N_USER_ID = process.env.N8N_USER_ID?.trim() || DEV_USER_ID;
+
+export const clerkEnabled = Boolean(process.env.CLERK_SECRET_KEY?.trim());
+
+/** Populates Clerk auth state on the request (no-op when Clerk is unconfigured). */
+export const clerkAuth: RequestHandler = clerkEnabled
+  ? clerkMiddleware()
+  : (_request, _response, next) => next();
+
+/** Resolves `req.userId` from Clerk (or the dev/n8n fallback). */
+export function attachUserId(request: Request, _response: Response, next: NextFunction) {
+  if (request.path.startsWith('/api/n8n')) {
+    request.userId = N8N_USER_ID;
+    return next();
+  }
+
+  if (clerkEnabled) {
+    const { userId } = getAuth(request);
+    if (userId) {
+      request.userId = userId;
+    }
+  } else {
+    request.userId = request.header('X-User-Id')?.trim() || DEV_USER_ID;
+  }
+
+  next();
+}
+
+/** Returns the request user id, or sends 401 and returns null when absent. */
+export function requireUser(request: Request, response: Response): string | null {
+  const userId = request.userId;
+  if (!userId) {
+    response.status(401).json({ error: 'Authentication required' });
+    return null;
+  }
+  return userId;
+}

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -23,6 +23,8 @@ import {
   updateOutreachGmailDraftId,
 } from '@/data/job-store';
 import { saveWeeklyReport } from '@/data/report-store';
+import { getUserProfile } from '@/data/profile-store';
+import { requireUser } from '@/lib/auth';
 import { exportWeeklyReportMarkdown } from '@/lib/report-export';
 import { getRequestBaseUrl } from '@/lib/request-url';
 import { buildWeeklyReportRecord, formatWeeklyReportResponse } from '@/lib/weekly-report';
@@ -31,6 +33,9 @@ import type { DraftOutreachBody, OutreachDraft, ParseJobBody, ScoreFitBody, Week
 export const aiRouter = Router();
 
 aiRouter.post('/parse-job', async (request, response, next) => {
+  const userId = requireUser(request, response);
+  if (!userId) return;
+
   const body = request.body as ParseJobBody;
 
   try {
@@ -45,12 +50,12 @@ aiRouter.post('/parse-job', async (request, response, next) => {
     }
 
     if (body.job_id) {
-      const job = await getJobById(body.job_id);
+      const job = await getJobById(userId, body.job_id);
       if (!job) {
         return response.status(404).json({ error: 'Job not found' });
       }
 
-      await saveJobAnalysis(body.job_id, analysisFromParsed(parsed));
+      await saveJobAnalysis(userId, body.job_id, analysisFromParsed(parsed));
     }
 
     return response.json({
@@ -63,26 +68,38 @@ aiRouter.post('/parse-job', async (request, response, next) => {
 });
 
 aiRouter.post('/score-fit', async (request, response, next) => {
+  const userId = requireUser(request, response);
+  if (!userId) return;
+
   const body = request.body as ScoreFitBody;
 
   if (!body.job_id) {
     return response.status(400).json({ error: 'job_id is required' });
   }
 
-  if (!body.resume_text?.trim() || !body.profile_text?.trim()) {
-    return response.status(400).json({ error: 'resume_text and profile_text are required' });
-  }
-
   try {
-    const job = await getJobById(body.job_id);
+    const job = await getJobById(userId, body.job_id);
     if (!job) {
       return response.status(404).json({ error: 'Job not found' });
     }
 
+    // Fall back to the saved profile so the client doesn't need to resend the
+    // resume on every call; require that a resume exists somewhere.
+    const profile = await getUserProfile(userId);
+    const resumeText = body.resume_text?.trim() || profile?.resumeText || '';
+    const profileText = body.profile_text?.trim() || profile?.profileText || resumeText;
+
+    if (!resumeText) {
+      return response
+        .status(400)
+        .json({ error: 'No resume on file. Add your resume in onboarding or settings first.' });
+    }
+
     const scored = await resolveFitScore({
+      userId,
       descriptionText: job.descriptionText,
-      resumeText: body.resume_text,
-      profileText: body.profile_text,
+      resumeText,
+      profileText,
       requiredSkills: job.analysis.requiredSkills,
       preferredSkills: job.analysis.preferredSkills,
       atsKeywords: job.analysis.atsKeywords,
@@ -97,7 +114,7 @@ aiRouter.post('/score-fit', async (request, response, next) => {
       preferredSkills: job.analysis.preferredSkills,
     });
 
-    await saveJobAnalysis(body.job_id, analysis, scored.fit_score);
+    await saveJobAnalysis(userId, body.job_id, analysis, scored.fit_score);
 
     return response.json({
       job_id: body.job_id,
@@ -109,6 +126,9 @@ aiRouter.post('/score-fit', async (request, response, next) => {
 });
 
 aiRouter.post('/draft-outreach', async (request, response, next) => {
+  const userId = requireUser(request, response);
+  if (!userId) return;
+
   const body = request.body as DraftOutreachBody;
   const contactEmail = body.contact_email?.trim();
 
@@ -122,19 +142,20 @@ aiRouter.post('/draft-outreach', async (request, response, next) => {
   let job: Awaited<ReturnType<typeof getJobById>> = undefined;
   if (body.job_id) {
     try {
-      job = await getJobById(body.job_id);
+      job = await getJobById(userId, body.job_id);
     } catch (error) {
       next(error);
       return;
     }
   }
 
+  const profile = await getUserProfile(userId);
   const payload = await resolveOutreachDraft({
     ...body,
     contact_email: contactEmail,
     company: job?.company,
     job_context: body.job_context ?? job?.descriptionText,
-    resume_summary: body.resume_summary,
+    resume_summary: body.resume_summary ?? profile?.profileText ?? profile?.resumeText,
   });
   const draft: OutreachDraft = {
     id: randomUUID(),
@@ -154,7 +175,7 @@ aiRouter.post('/draft-outreach', async (request, response, next) => {
 
   if (job) {
     try {
-      await appendOutreachDraft(job.id, draft);
+      await appendOutreachDraft(userId, job.id, draft);
     } catch (error) {
       next(error);
       return;
@@ -175,7 +196,7 @@ aiRouter.post('/draft-outreach', async (request, response, next) => {
 
       if (job) {
         try {
-          await updateOutreachGmailDraftId(draft.id, gmailDraft.gmailDraftId);
+          await updateOutreachGmailDraftId(userId, draft.id, gmailDraft.gmailDraftId);
         } catch (error) {
           gmailDraftMessage = `${gmailDraft.message} The local outreach record could not be updated.`;
           console.error('Gmail draft created but local outreach update failed', error);
@@ -206,6 +227,9 @@ const AGENT_DISABLED_MESSAGE =
   'The AI agent service is not configured. Set AGENT_SERVICE_URL and a provider key to enable the agents.';
 
 aiRouter.post('/agents/interview-prep', async (request, response, next) => {
+  const userId = requireUser(request, response);
+  if (!userId) return;
+
   const body = request.body as { job_id?: string; resume_text?: string };
 
   if (!body.job_id) {
@@ -213,14 +237,15 @@ aiRouter.post('/agents/interview-prep', async (request, response, next) => {
   }
 
   try {
-    const job = await getJobById(body.job_id);
+    const job = await getJobById(userId, body.job_id);
     if (!job) {
       return response.status(404).json({ error: 'Job not found' });
     }
 
+    const profile = await getUserProfile(userId);
     const result = await runAgentTask('/agents/interview-prep', {
       job_description: job.descriptionText,
-      resume_text: body.resume_text,
+      resume_text: body.resume_text ?? profile?.resumeText,
       company: job.company,
       role: job.title,
     });
@@ -235,6 +260,9 @@ aiRouter.post('/agents/interview-prep', async (request, response, next) => {
 });
 
 aiRouter.post('/agents/research', async (request, response, next) => {
+  const userId = requireUser(request, response);
+  if (!userId) return;
+
   const body = request.body as { job_id?: string };
 
   if (!body.job_id) {
@@ -242,7 +270,7 @@ aiRouter.post('/agents/research', async (request, response, next) => {
   }
 
   try {
-    const job = await getJobById(body.job_id);
+    const job = await getJobById(userId, body.job_id);
     if (!job) {
       return response.status(404).json({ error: 'Job not found' });
     }
@@ -263,6 +291,9 @@ aiRouter.post('/agents/research', async (request, response, next) => {
 });
 
 aiRouter.post('/agents/skill-gap', async (request, response, next) => {
+  const userId = requireUser(request, response);
+  if (!userId) return;
+
   const body = request.body as { job_id?: string; resume_text?: string };
 
   if (!body.job_id) {
@@ -270,15 +301,16 @@ aiRouter.post('/agents/skill-gap', async (request, response, next) => {
   }
 
   try {
-    const job = await getJobById(body.job_id);
+    const job = await getJobById(userId, body.job_id);
     if (!job) {
       return response.status(404).json({ error: 'Job not found' });
     }
 
+    const profile = await getUserProfile(userId);
     const result = await runAgentTask('/agents/skill-gap', {
       missing_skills: job.analysis.missingSkills,
       job_description: job.descriptionText,
-      resume_text: body.resume_text,
+      resume_text: body.resume_text ?? profile?.resumeText,
     });
 
     return response.json(result);
@@ -291,6 +323,9 @@ aiRouter.post('/agents/skill-gap', async (request, response, next) => {
 });
 
 aiRouter.post('/generate-weekly-report', async (request, response, next) => {
+  const userId = requireUser(request, response);
+  if (!userId) return;
+
   const body = request.body as WeeklyReportBody;
 
   if (!body.week_start || !body.week_end) {
@@ -298,12 +333,12 @@ aiRouter.post('/generate-weekly-report', async (request, response, next) => {
   }
 
   try {
-    const jobs = await listJobs();
+    const jobs = await listJobs(userId);
     const report = buildWeeklyReportRecord(jobs, body);
     const reportUrl = await exportWeeklyReportMarkdown(report, {
       publicBaseUrl: getRequestBaseUrl(request),
     });
-    const savedReport = await saveWeeklyReport({
+    const savedReport = await saveWeeklyReport(userId, {
       ...report,
       reportUrl,
     });

--- a/apps/api/src/routes/demo.ts
+++ b/apps/api/src/routes/demo.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { clearUserData, seedDemoData } from '@/data/job-store';
 import { clearUserReports, seedDemoReports } from '@/data/report-store';
+import { deleteUserProfile } from '@/data/profile-store';
 import { requireUser } from '@/lib/auth';
 
 export const demoRouter = Router();
@@ -25,6 +26,7 @@ demoRouter.post('/clear', async (request, response, next) => {
     if (!userId) return;
     await clearUserData(userId);
     await clearUserReports(userId);
+    await deleteUserProfile(userId);
     response.json({ ok: true });
   } catch (error) {
     next(error);

--- a/apps/api/src/routes/demo.ts
+++ b/apps/api/src/routes/demo.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { clearUserData, seedDemoData } from '@/data/job-store';
+import { clearUserReports, seedDemoReports } from '@/data/report-store';
+import { requireUser } from '@/lib/auth';
+
+export const demoRouter = Router();
+
+// Load the sample CRM into the signed-in account (instant demo).
+demoRouter.post('/seed', async (request, response, next) => {
+  try {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+    await seedDemoData(userId);
+    await seedDemoReports(userId);
+    response.json({ ok: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Wipe everything the signed-in account owns.
+demoRouter.post('/clear', async (request, response, next) => {
+  try {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+    await clearUserData(userId);
+    await clearUserReports(userId);
+    response.json({ ok: true });
+  } catch (error) {
+    next(error);
+  }
+});

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -5,6 +5,7 @@ import {
   listJobs,
   updateJob,
 } from '@/data/job-store';
+import { requireUser } from '@/lib/auth';
 import type { CreateJobBody, JobPriority, JobStatus, UpdateJobBody } from '@/types';
 
 export const jobsRouter = Router();
@@ -34,10 +35,13 @@ function isValidUrl(value: string) {
   }
 }
 
-jobsRouter.get('/', async (_request, response, next) => {
+jobsRouter.get('/', async (request, response, next) => {
   try {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
     response.json({
-      jobs: await listJobs(),
+      jobs: await listJobs(userId),
     });
   } catch (error) {
     next(error);
@@ -46,9 +50,12 @@ jobsRouter.get('/', async (_request, response, next) => {
 
 jobsRouter.post('/', async (request, response, next) => {
   try {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
     const body = request.body as Partial<CreateJobBody>;
     const errors: Record<string, string> = {};
-    const existingJobs = await listJobs();
+    const existingJobs = await listJobs(userId);
     const normalizedJobUrl = body.jobUrl?.trim();
 
     if (!body.company?.trim()) {
@@ -78,7 +85,7 @@ jobsRouter.post('/', async (request, response, next) => {
       return;
     }
 
-    const job = await createJob({
+    const job = await createJob(userId, {
       company: body.company!.trim(),
       title: body.title!.trim(),
       descriptionText: body.descriptionText!.trim(),
@@ -100,7 +107,10 @@ jobsRouter.post('/', async (request, response, next) => {
 
 jobsRouter.get('/:id', async (request, response, next) => {
   try {
-    const job = await getJobById(request.params.id);
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
+    const job = await getJobById(userId, request.params.id);
 
     if (!job) {
       response.status(404).json({ error: 'Job not found' });
@@ -114,6 +124,9 @@ jobsRouter.get('/:id', async (request, response, next) => {
 });
 
 jobsRouter.patch('/:id', async (request, response, next) => {
+  const userId = requireUser(request, response);
+  if (!userId) return;
+
   const body = request.body as UpdateJobBody;
   const errors: Record<string, string> = {};
 
@@ -139,7 +152,7 @@ jobsRouter.patch('/:id', async (request, response, next) => {
   }
 
   try {
-    const job = await updateJob(request.params.id, {
+    const job = await updateJob(userId, request.params.id, {
       status: body.status,
       priority: body.priority,
       notes: body.notes?.trim(),

--- a/apps/api/src/routes/n8n.test.ts
+++ b/apps/api/src/routes/n8n.test.ts
@@ -226,17 +226,17 @@ test('creates and enriches a job-intake webhook payload', async () => {
   try {
     await withServer(
       createN8nRouter({
-        createJob: async (body) => {
+        createJob: async (_userId, body) => {
           createdJobBody = body;
           return createdJob;
         },
         listJobs: async () => [],
-        saveJobAnalysis: async (_jobId, analysis, fitScore) => {
+        saveJobAnalysis: async (_userId, _jobId, analysis, fitScore) => {
           savedAnalysis = analysis;
           savedFitScore = fitScore;
           return scoredJob;
         },
-        updateJob: async (_jobId, body) => {
+        updateJob: async (_userId, _jobId, body) => {
           updatedJobBody = body;
           return scoredJob;
         },
@@ -463,7 +463,8 @@ test('persists weekly report drafts generated through the n8n webhook', async ()
         assert.ok(reportPayload.report_id);
         assert.ok(reportPayload.report_url);
 
-        const reports = await listWeeklyReports();
+        // The n8n webhook owns its data under the system user (default dev id).
+        const reports = await listWeeklyReports('user_local_dev');
         assert.equal(reports[0]?.id, reportPayload.report_id);
         assert.equal(reports[0]?.reportUrl, reportPayload.report_url ?? undefined);
       },

--- a/apps/api/src/routes/n8n.ts
+++ b/apps/api/src/routes/n8n.ts
@@ -6,6 +6,7 @@ import {
   updateJob,
 } from '@/data/job-store';
 import { saveWeeklyReport } from '@/data/report-store';
+import { N8N_USER_ID } from '@/lib/auth';
 import {
   analysisFromFit,
   analysisFromParsed,
@@ -164,6 +165,8 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
   router.use(requireN8nWebhookSecret);
 
   router.post('/job-intake', async (request, response, next) => {
+    const userId = N8N_USER_ID;
+
     const body = request.body as Partial<N8nJobIntakeBody>;
     const validation = validateJobIntakeBody(body);
 
@@ -176,7 +179,7 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
         return;
       }
 
-      const existingJobs = await dependencies.listJobs();
+      const existingJobs = await dependencies.listJobs(userId);
 
       if (validation.normalized.jobUrl) {
         const existingJob = existingJobs.find((job) => job.jobUrl === validation.normalized.jobUrl);
@@ -192,7 +195,7 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
         }
       }
 
-      const createdJob = await dependencies.createJob({
+      const createdJob = await dependencies.createJob(userId, {
         jobUrl: validation.normalized.jobUrl,
         source: validation.normalized.source,
         company: validation.normalized.company!,
@@ -220,6 +223,7 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
 
       if (validation.normalized.resumeText && validation.normalized.profileText) {
         const fit = await resolveFitScore({
+          userId,
           descriptionText: createdJob.descriptionText,
           resumeText: validation.normalized.resumeText,
           profileText: validation.normalized.profileText,
@@ -244,14 +248,14 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
         fitMessage = 'Fit scoring was skipped because both resume_text and profile_text are required.';
       }
 
-      const savedJob = await dependencies.saveJobAnalysis(createdJob.id, analysis, fitScore);
+      const savedJob = await dependencies.saveJobAnalysis(userId, createdJob.id, analysis, fitScore);
 
       if (!savedJob) {
         response.status(500).json({ error: 'Could not save the n8n analysis result' });
         return;
       }
 
-      const updatedJob = await dependencies.updateJob(savedJob.id, {
+      const updatedJob = await dependencies.updateJob(userId, savedJob.id, {
         nextAction: fitStatus === 'scored'
           ? 'Review the AI analysis and decide whether to shortlist.'
           : 'Review the parsed job and decide whether to score it.',
@@ -274,6 +278,8 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
   });
 
   router.post('/follow-up-reminders', async (request, response, next) => {
+    const userId = N8N_USER_ID;
+
     const body = request.body as Partial<N8nFollowUpRemindersBody>;
     const validation = validateFollowUpBody(body);
 
@@ -286,7 +292,7 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
     }
 
     try {
-      const jobs = await dependencies.listJobs();
+      const jobs = await dependencies.listJobs(userId);
       const asOf = validation.normalized.as_of ? new Date(validation.normalized.as_of) : new Date();
       const reminders = selectDueFollowUps(jobs, asOf);
 
@@ -303,6 +309,8 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
   });
 
   router.post('/weekly-report', async (request, response, next) => {
+    const userId = N8N_USER_ID;
+
     const body = request.body as Partial<N8nWeeklyReportBody>;
     const validation = validateWeeklyReportBody(body);
 
@@ -315,7 +323,7 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
     }
 
     try {
-      const jobs = await dependencies.listJobs();
+      const jobs = await dependencies.listJobs(userId);
       const report = buildWeeklyReportRecord(jobs, {
         week_start: validation.normalized.week_start!,
         week_end: validation.normalized.week_end!,
@@ -323,7 +331,7 @@ export function createN8nRouter(dependencies: N8nDependencies = defaultDependenc
       const reportUrl = await exportWeeklyReportMarkdown(report, {
         publicBaseUrl: getRequestBaseUrl(request),
       });
-      const savedReport = await saveWeeklyReport({
+      const savedReport = await saveWeeklyReport(userId, {
         ...report,
         reportUrl,
       });

--- a/apps/api/src/routes/outreach.ts
+++ b/apps/api/src/routes/outreach.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { updateOutreachDraft } from '@/data/job-store';
+import { requireUser } from '@/lib/auth';
 import type { OutreachStatus } from '@/types';
 
 export const outreachRouter = Router();
@@ -47,6 +48,9 @@ export function validateOutreachUpdateBody(body: OutreachUpdateInput) {
 }
 
 outreachRouter.patch('/:id', async (request, response, next) => {
+  const userId = requireUser(request, response);
+  if (!userId) return;
+
   const body = request.body as OutreachUpdateInput;
   const { errors, normalized } = validateOutreachUpdateBody(body);
 
@@ -56,7 +60,7 @@ outreachRouter.patch('/:id', async (request, response, next) => {
   }
 
   try {
-    const outreach = await updateOutreachDraft(request.params.id, {
+    const outreach = await updateOutreachDraft(userId, request.params.id, {
       status: normalized.status as OutreachStatus | undefined,
       gmailDraftId: normalized.gmailDraftId,
       sentAt: normalized.sentAt,

--- a/apps/api/src/routes/profile.ts
+++ b/apps/api/src/routes/profile.ts
@@ -1,0 +1,104 @@
+import { Router } from 'express';
+import multer from 'multer';
+import { getUserProfile, upsertUserProfile } from '@/data/profile-store';
+import { listJobs } from '@/data/job-store';
+import { listWeeklyReports } from '@/data/report-store';
+import { requireUser } from '@/lib/auth';
+
+export const profileRouter = Router();
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+});
+
+function publicProfile(profile: Awaited<ReturnType<typeof getUserProfile>>) {
+  if (!profile) {
+    return null;
+  }
+  // Never ship the full resume text to the client; expose presence + metadata.
+  return {
+    displayName: profile.displayName ?? null,
+    resumeFileName: profile.resumeFileName ?? null,
+    hasResume: Boolean(profile.resumeText),
+    profileText: profile.profileText ?? null,
+    updatedAt: profile.updatedAt ?? null,
+  };
+}
+
+profileRouter.get('/', async (request, response, next) => {
+  try {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+    const profile = await getUserProfile(userId);
+    response.json({ profile: publicProfile(profile) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+profileRouter.put('/', async (request, response, next) => {
+  try {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+    const body = request.body as { displayName?: string; profileText?: string };
+    const updated = await upsertUserProfile(userId, {
+      displayName: body.displayName?.trim() || undefined,
+      profileText: body.profileText?.trim() || undefined,
+    });
+    response.json({ profile: publicProfile(updated) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Accept either a PDF upload (field "file") or pasted text in the JSON body.
+profileRouter.post('/resume', upload.single('file'), async (request, response, next) => {
+  try {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
+    const body = request.body as { resume_text?: string; display_name?: string };
+    let resumeText = body.resume_text?.trim();
+    let resumeFileName: string | undefined;
+
+    if (request.file) {
+      resumeFileName = request.file.originalname;
+      const { default: pdfParse } = await import('pdf-parse');
+      const parsed = await pdfParse(request.file.buffer);
+      resumeText = parsed.text?.trim();
+    }
+
+    if (!resumeText) {
+      return response.status(400).json({ error: 'Provide a PDF file or resume_text.' });
+    }
+
+    const updated = await upsertUserProfile(userId, {
+      resumeText,
+      resumeFileName: resumeFileName ?? 'resume.txt',
+      displayName: body.display_name?.trim() || undefined,
+    });
+
+    response.json({ profile: publicProfile(updated) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Full export of the signed-in user's data (Settings "Export data").
+profileRouter.get('/export', async (request, response, next) => {
+  try {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+    const [jobs, reports, profile] = await Promise.all([
+      listJobs(userId),
+      listWeeklyReports(userId),
+      getUserProfile(userId),
+    ]);
+    response
+      .set('Content-Disposition', 'attachment; filename="jobops-export.json"')
+      .json({ exportedAt: new Date().toISOString(), profile: publicProfile(profile), jobs, reports });
+  } catch (error) {
+    next(error);
+  }
+});

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -79,7 +79,8 @@ test('persists generated weekly reports and exposes them through the reports API
         reports: Array<{ id: string }>;
       };
       assert.equal(listPayload.reports[0]?.id, generatedPayload.report_id);
-      assert.equal(listPayload.reports.length, 2);
+      // New accounts start empty, so only the just-generated report exists.
+      assert.equal(listPayload.reports.length, 1);
 
       const exportResponse = await fetch(generatedPayload.report_url);
       assert.equal(exportResponse.status, 200);

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { readFile } from 'node:fs/promises';
 import { getLatestWeeklyReport, listWeeklyReports } from '@/data/report-store';
+import { requireUser } from '@/lib/auth';
 import {
   buildLocalWeeklyReportExportPath,
   buildWeeklyReportExportFileName,
@@ -8,18 +9,24 @@ import {
 
 export const reportsRouter = Router();
 
-reportsRouter.get('/', async (_request, response, next) => {
+reportsRouter.get('/', async (request, response, next) => {
   try {
-    const reports = await listWeeklyReports();
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
+    const reports = await listWeeklyReports(userId);
     response.json({ reports });
   } catch (error) {
     next(error);
   }
 });
 
-reportsRouter.get('/latest', async (_request, response, next) => {
+reportsRouter.get('/latest', async (request, response, next) => {
   try {
-    const report = await getLatestWeeklyReport();
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
+    const report = await getLatestWeeklyReport(userId);
 
     if (!report) {
       response.status(404).json({ error: 'No weekly reports found' });
@@ -34,7 +41,10 @@ reportsRouter.get('/latest', async (_request, response, next) => {
 
 reportsRouter.get('/:reportId/export', async (request, response, next) => {
   try {
-    const reports = await listWeeklyReports();
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
+    const reports = await listWeeklyReports(userId);
     const report = reports.find((entry) => entry.id === request.params.reportId);
 
     if (!report) {

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -6,6 +6,7 @@ import {
   fetchEvDemoViaAgent,
   isAgentEnabled,
 } from '@/lib/agent-client';
+import { requireUser } from '@/lib/auth';
 import { buildActivitySeries, localTelemetryFallback } from '@/lib/telemetry';
 
 export const telemetryRouter = Router();
@@ -15,9 +16,12 @@ export const telemetryRouter = Router();
  * analyzes it via the agent (pandas trend/anomaly/forecast + LLM narration),
  * falling back to a deterministic local summary when the agent is unavailable.
  */
-telemetryRouter.get('/insights', async (_request, response, next) => {
+telemetryRouter.get('/insights', async (request, response, next) => {
   try {
-    const series = buildActivitySeries(await listJobs());
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
+    const series = buildActivitySeries(await listJobs(userId));
 
     if (isAgentEnabled()) {
       try {

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -56,6 +56,7 @@ export interface OutreachDraft {
 
 export interface JobRecord {
   id: string;
+  userId?: string;
   jobUrl?: string;
   source: string;
   company: string;
@@ -80,6 +81,7 @@ export interface JobRecord {
 
 export interface WeeklyReportRecord {
   id: string;
+  userId?: string;
   weekStart: string;
   weekEnd: string;
   jobsDiscovered: number;

--- a/db/migrations/004_multitenant.sql
+++ b/db/migrations/004_multitenant.sql
@@ -11,6 +11,11 @@
 -- 1. Per-user ownership columns ------------------------------------------------
 alter table jobs add column if not exists user_id text;
 create index if not exists jobs_user_id_idx on jobs (user_id);
+-- job_url was globally unique (jobs_job_url_key). Scope it per user so two
+-- accounts can track the same posting and per-user demo seeding never collides.
+alter table jobs drop constraint if exists jobs_job_url_key;
+create unique index if not exists jobs_user_job_url_unique_idx
+  on jobs (user_id, job_url) where job_url is not null;
 
 alter table weekly_reports add column if not exists user_id text;
 create index if not exists weekly_reports_user_id_idx on weekly_reports (user_id);

--- a/db/migrations/004_multitenant.sql
+++ b/db/migrations/004_multitenant.sql
@@ -1,0 +1,53 @@
+-- Multi-tenancy: scope all user-owned data to a Clerk user id.
+--
+-- Clerk gates access to the app, but the CRM was previously a single shared
+-- store. This migration adds a `user_id` (Clerk user id, e.g. "user_abc123")
+-- to every top-level owned entity and introduces a per-user profile that holds
+-- the resume/profile text used to ground fit scoring and outreach.
+--
+-- Child tables (job_analysis, outreach, resume_versions) stay scoped through
+-- their job_id foreign key, so only the top-level tables need the column.
+
+-- 1. Per-user ownership columns ------------------------------------------------
+alter table jobs add column if not exists user_id text;
+create index if not exists jobs_user_id_idx on jobs (user_id);
+
+alter table weekly_reports add column if not exists user_id text;
+create index if not exists weekly_reports_user_id_idx on weekly_reports (user_id);
+-- The old (week_start, week_end) unique index was global; scope it per-user so
+-- two accounts can each have a report for the same week.
+drop index if exists weekly_reports_week_range_unique_idx;
+create unique index if not exists weekly_reports_user_week_range_unique_idx
+  on weekly_reports (user_id, week_start, week_end);
+
+alter table embeddings add column if not exists user_id text;
+create index if not exists embeddings_user_id_idx on embeddings (user_id);
+
+-- 2. Per-user profile (resume + profile text) ---------------------------------
+create table if not exists user_profiles (
+  user_id text primary key,
+  display_name text,
+  resume_text text,
+  resume_file_name text,
+  resume_file_url text,
+  profile_text text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+drop trigger if exists user_profiles_set_updated_at on user_profiles;
+
+create trigger user_profiles_set_updated_at
+before update on user_profiles
+for each row
+execute function set_updated_at();
+
+-- 3. Remove the legacy global demo data ---------------------------------------
+-- These fixed-id rows were seeded globally and were visible to every account.
+-- Real per-account sample data is now loaded on demand via POST /api/demo/seed.
+delete from jobs where id in (
+  '11111111-1111-4111-8111-111111111111',
+  '22222222-2222-4222-8222-222222222222',
+  '33333333-3333-4333-8333-333333333333'
+);
+delete from weekly_reports where id = '44444444-4444-4444-8444-444444444444';

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,16 +16,21 @@
       "version": "0.1.0",
       "dependencies": {
         "@azure/storage-blob": "^12.28.0",
+        "@clerk/express": "^1.7.5",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "multer": "^2.0.1",
+        "pdf-parse": "^1.1.1",
         "pg": "^8.20.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.0",
+        "@types/multer": "^1.4.12",
         "@types/node": "^22.0.0",
+        "@types/pdf-parse": "^1.1.4",
         "@types/pg": "^8.20.0",
         "eslint": "^9.0.0",
         "tsc-alias": "^1.8.17",
@@ -769,6 +774,75 @@
         "node": ">=20.9.0"
       }
     },
+    "node_modules/@clerk/express": {
+      "version": "1.7.81",
+      "resolved": "https://registry.npmjs.org/@clerk/express/-/express-1.7.81.tgz",
+      "integrity": "sha512-Z59BIqeNzPF0LNEzaSnJ4bX6OtfobQk3Xo7gOoTD70r02iQ5pse0NgDfBOKykrhaiRLezbwZ9os1c5+pkY1ylA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^2.33.5",
+        "@clerk/shared": "^3.47.7",
+        "@clerk/types": "^4.101.25",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "express": "^4.17.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@clerk/express/node_modules/@clerk/backend": {
+      "version": "2.33.5",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.5.tgz",
+      "integrity": "sha512-YOzUYJfb1d4w+0rKKm+LnnNpkJGQ+NI/g7qmF3mgaSN9X9huteuwCZyufdsI7z2DDkwy/yGRgb9eUWV96t7xLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.7",
+        "@clerk/types": "^4.101.25",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
+    "node_modules/@clerk/express/node_modules/@clerk/shared": {
+      "version": "3.47.7",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.7.tgz",
+      "integrity": "sha512-9Yv4MJFEaC7BzV0whxa4txQ4SoMu/3j1LBnI85EBykb5CcfXxIKvNX/9sjMUUySHlTOjsj7XZa5i3W5Dx02K/Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7",
+        "std-env": "^3.9.0",
+        "swr": "2.3.4"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/express/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
     "node_modules/@clerk/nextjs": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.4.3.tgz",
@@ -833,6 +907,54 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@clerk/types": {
+      "version": "4.101.25",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.25.tgz",
+      "integrity": "sha512-gPxm3hlBkP7B9EfKyp3/UDonNOjg7Z0UvqfrMj5u8gA8nyzvC1UFYtSTTmTfgSY82+5Yo38YV0DYu9vNf6t9CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.7"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
+    "node_modules/@clerk/types/node_modules/@clerk/shared": {
+      "version": "3.47.7",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.7.tgz",
+      "integrity": "sha512-9Yv4MJFEaC7BzV0whxa4txQ4SoMu/3j1LBnI85EBykb5CcfXxIKvNX/9sjMUUySHlTOjsj7XZa5i3W5Dx02K/Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7",
+        "std-env": "^3.9.0",
+        "swr": "2.3.4"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/types/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.71.0",
@@ -3557,6 +3679,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
+      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
@@ -3564,6 +3696,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -4383,6 +4525,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4768,6 +4916,12 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -4781,6 +4935,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -5061,6 +5226,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -6297,6 +6477,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -8651,6 +8832,25 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
@@ -8807,6 +9007,12 @@
       "engines": {
         "node": ">=10.5.0"
       }
+    },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
@@ -9325,6 +9531,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/pdf-parse": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
+      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -9737,6 +9959,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -10563,6 +10799,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
+    },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
@@ -10589,11 +10831,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -10880,6 +11139,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tagged-tag": {
@@ -11254,6 +11526,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -71,6 +71,7 @@ class IngestRequest(BaseModel):
     source_type: str
     source_id: str
     text: str
+    user_id: str | None = None
 
 
 class SearchRequest(BaseModel):
@@ -78,6 +79,7 @@ class SearchRequest(BaseModel):
     k: int = Field(default=4, ge=1, le=20)
     source_type: str | None = None
     source_id: str | None = None
+    user_id: str | None = None
 
 
 @app.get("/health")
@@ -102,7 +104,9 @@ def score_fit_endpoint(req: ScoreFitRequest) -> FitScoreResponse:
     # RAG augmentation: ground the assessment in the resume chunks most relevant
     # to this job. Best-effort — falls through to direct scoring if RAG is off.
     if rag_available() and req.resume_text and not req.retrieved_context:
-        evidence = retrieve_resume_evidence(req.resume_text, req.description_text)
+        evidence = retrieve_resume_evidence(
+            req.resume_text, req.description_text, user_id=req.user_id
+        )
         if evidence:
             req.retrieved_context = evidence
     return _run(score_fit, req)
@@ -112,7 +116,7 @@ def score_fit_endpoint(req: ScoreFitRequest) -> FitScoreResponse:
 def rag_ingest_endpoint(req: IngestRequest) -> dict:
     if not rag_available():
         raise HTTPException(status_code=503, detail="RAG is disabled; set DATABASE_URL.")
-    count = _run(ingest_document, req.source_type, req.source_id, req.text)
+    count = _run(ingest_document, req.source_type, req.source_id, req.text, req.user_id)
     return {"source_type": req.source_type, "source_id": req.source_id, "chunks_ingested": count}
 
 
@@ -120,7 +124,7 @@ def rag_ingest_endpoint(req: IngestRequest) -> dict:
 def rag_search_endpoint(req: SearchRequest) -> dict:
     if not rag_available():
         raise HTTPException(status_code=503, detail="RAG is disabled; set DATABASE_URL.")
-    matches = _run(retrieve, req.query, req.k, req.source_type, req.source_id)
+    matches = _run(retrieve, req.query, req.k, req.source_type, req.source_id, req.user_id)
     return {"query": req.query, "matches": matches}
 
 

--- a/services/agent/app/rag/store.py
+++ b/services/agent/app/rag/store.py
@@ -37,8 +37,17 @@ def _vector_literal(vector: list[float]) -> str:
     return "[" + ",".join(f"{value:.6f}" for value in vector) + "]"
 
 
-def ingest_document(source_type: str, source_id: str, text: str) -> int:
-    """Chunk, embed, and upsert a document's embeddings. Returns chunk count."""
+def ingest_document(
+    source_type: str,
+    source_id: str,
+    text: str,
+    user_id: str | None = None,
+) -> int:
+    """Chunk, embed, and upsert a document's embeddings. Returns chunk count.
+
+    Embeddings are scoped to ``user_id`` so one user's resume can never ground
+    another user's retrieval.
+    """
     chunks = chunk_text(text)
     if not chunks:
         return 0
@@ -46,15 +55,24 @@ def ingest_document(source_type: str, source_id: str, text: str) -> int:
     vectors = embed_texts(chunks)
     with _connect() as conn, conn.cursor() as cur:
         cur.execute(
-            "delete from embeddings where source_type = %s and source_id = %s",
-            (source_type, source_id),
+            "delete from embeddings "
+            "where source_type = %s and source_id = %s and user_id is not distinct from %s",
+            (source_type, source_id, user_id),
         )
         for index, (chunk, vector) in enumerate(zip(chunks, vectors, strict=False)):
             cur.execute(
                 "insert into embeddings "
-                "(id, source_type, source_id, chunk_index, chunk_text, embedding) "
-                "values (%s, %s, %s, %s, %s, %s::vector)",
-                (str(uuid.uuid4()), source_type, source_id, index, chunk, _vector_literal(vector)),
+                "(id, user_id, source_type, source_id, chunk_index, chunk_text, embedding) "
+                "values (%s, %s, %s, %s, %s, %s, %s::vector)",
+                (
+                    str(uuid.uuid4()),
+                    user_id,
+                    source_type,
+                    source_id,
+                    index,
+                    chunk,
+                    _vector_literal(vector),
+                ),
             )
         conn.commit()
     return len(chunks)
@@ -65,6 +83,7 @@ def retrieve(
     k: int = 4,
     source_type: str | None = None,
     source_id: str | None = None,
+    user_id: str | None = None,
 ) -> list[str]:
     """Return the ``k`` most similar chunk texts (cosine distance)."""
     query_literal = _vector_literal(embed_query(query))
@@ -77,6 +96,9 @@ def retrieve(
     if source_id:
         conditions.append("source_id = %s")
         params.append(source_id)
+    if user_id is not None:
+        conditions.append("user_id = %s")
+        params.append(user_id)
     where_sql = ("where " + " and ".join(conditions)) if conditions else ""
 
     sql = (
@@ -90,14 +112,21 @@ def retrieve(
         return [row[0] for row in cur.fetchall()]
 
 
-def retrieve_resume_evidence(resume_text: str, job_description: str, k: int = 4) -> list[str]:
+def retrieve_resume_evidence(
+    resume_text: str,
+    job_description: str,
+    k: int = 4,
+    user_id: str | None = None,
+) -> list[str]:
     """Ingest the resume (idempotent) and retrieve the chunks most relevant to
     the job description. Returns [] and logs on any failure so callers can
     proceed without RAG."""
     try:
         source_id = resume_source_id(resume_text)
-        ingest_document("resume", source_id, resume_text)
-        return retrieve(job_description, k=k, source_type="resume", source_id=source_id)
+        ingest_document("resume", source_id, resume_text, user_id=user_id)
+        return retrieve(
+            job_description, k=k, source_type="resume", source_id=source_id, user_id=user_id
+        )
     except Exception:  # noqa: BLE001 - RAG is best-effort augmentation
         logger.exception("resume RAG retrieval failed; continuing without evidence")
         return []

--- a/services/agent/app/schemas.py
+++ b/services/agent/app/schemas.py
@@ -115,6 +115,8 @@ class ScoreFitRequest(BaseModel):
     required_skills: list[str] | None = None
     preferred_skills: list[str] | None = None
     ats_keywords: list[str] | None = None
+    # Scopes RAG retrieval so a user's resume only grounds their own scoring.
+    user_id: str | None = None
     # Optional retrieved resume evidence (Phase 10 RAG). When present the model
     # is instructed to ground its assessment in these snippets.
     retrieved_context: list[str] | None = None


### PR DESCRIPTION
## Why
Reviewing the live app as a new user revealed it was a single shared CRM seeded with global demo data — every account saw the same jobs/reports/"Test Recruiter" drafts. This PR makes the **backend** genuinely multi-tenant. (Web onboarding/settings/UX follows in PR B.)

## What
- **Migration 004**: `user_id` on `jobs`/`weekly_reports`/`embeddings`; new `user_profiles`; per-user unique `(user_id, week_start, week_end)`; deletes the legacy global demo rows. `db:init` no longer seeds globally.
- **Auth bridge**: `@clerk/express` verifies the forwarded Bearer token → `req.userId`. Falls back to a dev/n8n user when `CLERK_SECRET_KEY` is unset (so local/tests still run). All `jobs/ai/outreach/reports/telemetry` routes require + scope by it.
- **Data layer**: `userId` threaded through `job-store` & `report-store` (Postgres + file), with ownership checks on by-id / outreach mutations.
- **New routes**: `GET/PUT /api/profile`, `POST /api/profile/resume` (PDF via `pdf-parse` or pasted text), `GET /api/profile/export`, `POST /api/demo/seed` + `/clear` (per-account sample data). `score-fit`/`draft-outreach` default the resume from the saved profile.
- **RAG isolation**: embeddings carry `user_id`; the agent's `/score-fit` and `/rag/*` filter retrieval by user.

## Tests
- API: 20/20 pass (updated store/route tests for `userId` + no-global-seed; added per-user isolation assertions).
- Agent: ruff + pytest (32) green.

## Deploy note
Safe to merge, but **do not enable `CLERK_SECRET_KEY` on the API until PR B ships** the web token-forwarding — otherwise the web can't authenticate to the API. Until then the API uses the dev-user fallback (no regression vs today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)