### PR TITLE
chore(azure): Key Vault for App Service secrets (managed-identity references)

### DIFF
--- a/scripts/azure/provision-keyvault.sh
+++ b/scripts/azure/provision-keyvault.sh
@@ -29,6 +29,23 @@ fi
 
 KV_ID=$(az keyvault show --name "$VAULT" --resource-group "$RG" --query id -o tsv)
 
+# Idempotent role assignment: create only if an equivalent assignment is absent.
+# Re-running an unguarded `az role assignment create` hits RoleAssignmentExists and
+# aborts under `set -e`. Queries by principalId at the scope (ARM only, no Graph).
+ensure_role() {
+  local oid="$1" ptype="$2" role="$3" scope="$4"
+  local existing
+  existing=$(az role assignment list --scope "$scope" \
+    --query "[?principalId=='$oid' && roleDefinitionName=='$role'] | [0].id" -o tsv 2>/dev/null)
+  if [ -n "$existing" ]; then
+    echo "Role '$role' already assigned to $oid; skipping."
+  else
+    az role assignment create \
+      --assignee-object-id "$oid" --assignee-principal-type "$ptype" \
+      --role "$role" --scope "$scope"
+  fi
+}
+
 # Deployer (current signed-in user) needs a data-plane role to manage secrets.
 # RBAC mode rejects secret writes from Owner/Contributor alone.
 # Derive the object id from the access-token `oid` claim instead of calling
@@ -36,17 +53,13 @@ KV_ID=$(az keyvault show --name "$VAULT" --resource-group "$RG" --query id -o ts
 # subscription (recurring invalid_grant) even right after `az login`.
 CALLER_OID=$(az account get-access-token --query accessToken -o tsv \
   | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{const p=d.trim().split('.')[1].replace(/-/g,'+').replace(/_/g,'/');process.stdout.write(JSON.parse(Buffer.from(p,'base64').toString()).oid)})")
-az role assignment create \
-  --assignee-object-id "$CALLER_OID" --assignee-principal-type User \
-  --role "Key Vault Secrets Officer" --scope "$KV_ID"
+ensure_role "$CALLER_OID" User "Key Vault Secrets Officer" "$KV_ID"
 
 # Grant each App Service's system-assigned identity read access to secrets.
 for APP in jobops-api jobops-web; do
   az webapp identity assign --resource-group "$RG" --name "$APP"
   PID=$(az webapp identity show --resource-group "$RG" --name "$APP" --query principalId -o tsv)
-  az role assignment create \
-    --assignee-object-id "$PID" --assignee-principal-type ServicePrincipal \
-    --role "Key Vault Secrets User" --scope "$KV_ID"
+  ensure_role "$PID" ServicePrincipal "Key Vault Secrets User" "$KV_ID"
 done
 
 echo "Key Vault $VAULT ready. Vault URI:"

--- a/scripts/azure/provision-keyvault.sh
+++ b/scripts/azure/provision-keyvault.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Provision Key Vault (RBAC mode) and grant:
+#  - the signed-in deployer "Key Vault Secrets Officer" (so `secret set` works),
+#  - the web + API App Service managed identities "Key Vault Secrets User" (read).
+# No app code change; app settings are switched to Key Vault references separately.
+set -euo pipefail
+
+# On Windows Git Bash, stop MSYS from rewriting the ARM resource id (/subscriptions/...)
+# into a C:\ path when passed to --scope. No-op elsewhere.
+export MSYS_NO_PATHCONV=1
+
+RG="${RG:-projects}"
+LOCATION="${LOCATION:-eastus}"
+VAULT="${VAULT:-jobops-kv}"
+
+# Fail early with a clear message if not logged in.
+az account show -o none
+
+# Ensure the Key Vault resource provider is registered (idempotent; --wait blocks
+# until Registered). Azure-for-Students subscriptions often start unregistered.
+az provider register --namespace Microsoft.KeyVault --wait
+
+# Create only if absent (`az keyvault create` errors on a pre-existing vault).
+if ! az keyvault show --name "$VAULT" --resource-group "$RG" -o none 2>/dev/null; then
+  az keyvault create \
+    --name "$VAULT" --resource-group "$RG" --location "$LOCATION" \
+    --enable-rbac-authorization true
+fi
+
+KV_ID=$(az keyvault show --name "$VAULT" --resource-group "$RG" --query id -o tsv)
+
+# Deployer (current signed-in user) needs a data-plane role to manage secrets.
+# RBAC mode rejects secret writes from Owner/Contributor alone.
+# Derive the object id from the access-token `oid` claim instead of calling
+# Microsoft Graph (`az ad signed-in-user show`) — Graph tokens go stale on this
+# subscription (recurring invalid_grant) even right after `az login`.
+CALLER_OID=$(az account get-access-token --query accessToken -o tsv \
+  | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{const p=d.trim().split('.')[1].replace(/-/g,'+').replace(/_/g,'/');process.stdout.write(JSON.parse(Buffer.from(p,'base64').toString()).oid)})")
+az role assignment create \
+  --assignee-object-id "$CALLER_OID" --assignee-principal-type User \
+  --role "Key Vault Secrets Officer" --scope "$KV_ID"
+
+# Grant each App Service's system-assigned identity read access to secrets.
+for APP in jobops-api jobops-web; do
+  az webapp identity assign --resource-group "$RG" --name "$APP"
+  PID=$(az webapp identity show --resource-group "$RG" --name "$APP" --query principalId -o tsv)
+  az role assignment create \
+    --assignee-object-id "$PID" --assignee-principal-type ServicePrincipal \
+    --role "Key Vault Secrets User" --scope "$KV_ID"
+done
+
+echo "Key Vault $VAULT ready. Vault URI:"
+az keyvault show --name "$VAULT" --resource-group "$RG" --query properties.vaultUri -o tsv


### PR DESCRIPTION
Part B of the optional hardening plan. Moves the App Services' high-value secrets into Azure Key Vault, referenced via system-assigned managed identity.

## What this does (live infra, captured in `scripts/azure/provision-keyvault.sh`)
- Creates RBAC Key Vault `jobops-kv` (eastus), registering the `Microsoft.KeyVault` provider first (Azure-for-Students subs start unregistered).
- Grants the deployer **Key Vault Secrets Officer** and the web + API managed identities **Key Vault Secrets User**.
- Stores `DATABASE-URL` and `CLERK-SECRET-KEY` in the vault.
- Switches App Service settings to `@Microsoft.KeyVault(SecretUri=…)` references.

## Verified
KV reference resolution confirmed **Resolved** for all three (via the App Service `configreferences` API):
- `jobops-api` → `DATABASE_URL`, `CLERK_SECRET_KEY`
- `jobops-web` → `CLERK_SECRET_KEY`

Live checks: API `/api/health` returns `mode: postgres` (DB URL resolved from KV), web 200.

## Scope / notes
- Agent Container App keeps its native (encrypted) secret store — out of scope by design.
- Script hardening learned the hard way: idempotent vault create, `MSYS_NO_PATHCONV` for ARM ids in Git Bash, and deriving the deployer object id from the access-token `oid` claim (avoids a stale Microsoft Graph token).

Infra/script-only PR — no app code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)