### PR TITLE
feat: Phase 7 — Zapier + Make companion automation (blueprints + guides)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ bot**: it drafts and recommends, but never sends or fabricates.
   sparklines, and a kanban outreach board. Verified with Playwright across
   breakpoints.
 - **Workflow automation** — n8n webhooks for job intake, follow-up reminders,
-  and weekly reports.
+  and weekly reports. Companion flows for Make.com (webhook → API → email) and
+  Zapier (sheet row → calendar reminder) are ready to import/build.
 - **Production discipline** — npm + Python CI (lint, typecheck, build, tests),
   protected `main`, Azure PostgreSQL, Blob Storage export, and an App Service
   deploy workflow.
@@ -69,7 +70,15 @@ A full walkthrough is in **[docs/DEMO.md](docs/DEMO.md)**; design detail in
 - **API:** Express 4, TypeScript, `pg`.
 - **Agent service:** Python 3.12, FastAPI, LangChain, sentence-transformers (PyTorch), pandas, psycopg/pgvector.
 - **Data/cloud:** Azure Database for PostgreSQL (+ pgvector), Azure Blob Storage, Azure App Service.
-- **Automation:** n8n.
+- **Automation:** n8n (primary orchestrator, self-hosted), Make.com (hosted webhook-to-API scenario), Zapier (2-step sidecar).
+
+## Automation tiers
+
+Three automation tools cover different points in the free-tier / complexity space. See [docs/AUTOMATION_WORKFLOWS.md](docs/AUTOMATION_WORKFLOWS.md) for the full comparison and the n8n vs Make vs Zapier decision guide.
+
+- **n8n** — self-hosted, full orchestration, unlimited ops. The primary pipeline: job intake, fit scoring, follow-up reminders, weekly reports. Setup: [workflows/n8n/README.md](workflows/n8n/README.md).
+- **Make.com** — hosted SaaS, 1,000 ops/month free, custom webhooks and HTTP calls free. Runs the same webhook → `/api/n8n/job-intake` → email-notification flow as n8n, without a server to manage. Blueprint ready to import: [workflows/make/setup.md](workflows/make/setup.md).
+- **Zapier** — hosted SaaS, 100 tasks/month free, 2-step Zaps only on the free plan (no webhooks). A lightweight sidecar: adds a Google Calendar follow-up reminder whenever you add a row to your Jobs tracking sheet. Zap ready to build: [workflows/zapier/setup.md](workflows/zapier/setup.md).
 
 ## Local development
 

--- a/docs/AUTOMATION_WORKFLOWS.md
+++ b/docs/AUTOMATION_WORKFLOWS.md
@@ -1,10 +1,10 @@
 # Automation Workflows
 
-The workflow docs describe how JobOps Copilot should automate the job-search process while keeping the user in control. The API already exposes the main integration surfaces, but the orchestrated n8n, Zapier, and Make.com flows are still documentation-first.
+The workflow docs describe how JobOps Copilot automates the job-search process while keeping the user in control. The API exposes the main integration surfaces, and the n8n, Zapier, and Make.com flows are ready to import or build in their respective GUIs.
 
 ## Current API Hooks
 
-The workflows should build on the endpoints that already exist:
+The workflows build on the endpoints that already exist:
 
 - `POST /api/jobs` for manual intake
 - `POST /api/ai/parse-job` for structured parsing
@@ -26,7 +26,7 @@ The API expects `X-N8N-Webhook-Secret` when `N8N_WEBHOOK_SECRET` is configured.
 For the cheapest beginner-friendly setup, see
 [workflows/n8n/self-hosting.md](../workflows/n8n/self-hosting.md).
 
-Planned workflows:
+Implemented workflows:
 
 - manual job intake processing
 - daily job discovery
@@ -51,29 +51,44 @@ Recommended n8n pattern:
 
 ## Zapier
 
-Zapier is the lightweight companion automation layer.
+Zapier is a lightweight companion sidecar — a 2-step Zap that watches a Google Sheet of tracked job applications and creates a Google Calendar follow-up reminder for each new row.
 
-Planned use:
+**Trigger:** Google Sheets — New Spreadsheet Row  
+**Action:** Google Calendar — Create Detailed Event (summary `Follow up: <title> @ <company>`, date from `follow_up_date`, description with `notes` and `job_url`).
 
-- create calendar reminders
-- create Gmail drafts
-- send a self-notification after a job is added
-- surface quick "needs review" tasks
+Setup: [workflows/zapier/setup.md](../workflows/zapier/setup.md) — includes creating the sheet from the CSV template, building the Zap step by step, field mapping, and testing.
 
-Zapier should stay narrow and user-facing. It is best for simple sidecar automations rather than the main CRM orchestration path.
+Zapier is kept narrow and user-facing. It handles the human scheduling layer rather than the API-integrated intake path.
 
 ## Make.com
 
-Make.com demonstrates a visual automation scenario.
+Make.com runs the API-integrated job-intake scenario: a custom webhook receives a job payload, POSTs it to `/api/n8n/job-intake` (with the `X-N8N-Webhook-Secret` header), and sends an email notification with the API's `fit_status` and `notification` response fields.
 
-Planned use:
+**Trigger:** Custom Webhook  
+**Step 2:** HTTP POST → `https://jobops-api.azurewebsites.net/api/n8n/job-intake`  
+**Step 3:** Email notification with fit status and notification text.
 
-- receive a new job payload via webhook
-- call the API for parsing and scoring
-- store or update the CRM record
-- send a formatted summary message to the user
+The scenario blueprint is at `workflows/make/exports/job-intake.blueprint.json` — import it directly into Make.com via **Create scenario → ⋮ → Import Blueprint**.
 
-Make is useful as a visual proof point for the portfolio, especially if a workflow needs to be easy to explain in screenshots or a case study.
+Setup: [workflows/make/setup.md](../workflows/make/setup.md) — includes blueprint import, credential wiring, webhook URL retrieval, and a curl test command.
+
+## n8n vs Zapier vs Make — When to Reach for Each
+
+| Dimension | n8n | Make.com | Zapier (free) |
+|-----------|-----|----------|---------------|
+| **Hosting** | Self-hosted (Docker) | Hosted SaaS | Hosted SaaS |
+| **Orchestration depth** | Full — multi-step, branching, custom code, schedules | Visual multi-step, data transformation | 2-step only (free tier) |
+| **Webhooks** | Free, built-in | Free (Custom Webhook module) | Premium app — not free |
+| **HTTP / API calls** | Free, built-in | Free (HTTP module) | Premium app — not free |
+| **Free tier ops** | Unlimited (self-hosted) | 1,000 ops/month | 100 tasks/month |
+| **Role in JobOps** | Primary orchestrator for full pipeline | Full API-integrated intake scenario | Lightweight sidecar (sheet → calendar) |
+| **Best when** | You want full control, self-hosting is fine, complex flows needed | You want a visual hosted scenario that calls the API without a server | You need a dead-simple human-scheduling hook and have no need for webhooks |
+
+**Rule of thumb:**
+
+- Reach for **n8n** when you want the full job-intake + fit-scoring + outreach-drafting pipeline running on your own infrastructure.
+- Reach for **Make.com** when you want the same API-integrated scenario without running a server, and you can stay within 1,000 ops/month.
+- Reach for **Zapier** when you need a quick, business-user-friendly sidecar (like a spreadsheet row firing a calendar reminder) and your monthly volume fits within 100 tasks.
 
 ## Shared Automation Rules
 
@@ -89,4 +104,4 @@ Make is useful as a visual proof point for the portfolio, especially if a workfl
 - Outreach drafts are stored as drafts, not sent automatically, and the inbox can move them through manual review states.
 - Gmail draft creation is optional and only runs when the feature flag plus OAuth credentials are present.
 - Weekly report generation currently returns a draft report from seeded analytics data.
-- Workflow execution will become more useful once n8n and the companion tools are connected to the live API.
+- The Make.com blueprint and Zapier setup guide are ready to import/build. Screenshots will be added to `docs/design/phase7/` after the maintainer activates the flows.

--- a/workflows/make/README.md
+++ b/workflows/make/README.md
@@ -1,15 +1,36 @@
 # Make.com Companion Scenario
 
-Make.com is used to show a visual automation scenario alongside n8n.
+This directory contains a **ready-to-import** Make.com scenario that connects a custom webhook to the JobOps API and sends an email notification — the full job-intake loop in three modules.
 
-## Intended Flow
+## What the Scenario Does
 
-- Trigger: webhook receives a new job payload
-- Parse the payload
-- Call the backend scoring endpoint
-- Store or update the CRM record
-- Send a formatted notification
+```
+Custom Webhook  →  HTTP POST /api/n8n/job-intake  →  Email notification
+```
 
-## Purpose
+1. **Trigger (Custom Webhook)** — Make receives a JSON payload containing `company`, `title`, `description_text`, `job_url`, and `source`.
+2. **API call (HTTP module)** — The scenario POSTs the payload to `https://jobops-api.azurewebsites.net/api/n8n/job-intake` with the `X-N8N-Webhook-Secret` header. The API creates the job record, parses the description, and runs fit scoring in a single request, returning `fit_status` and `notification`.
+3. **Email notification (Email module)** — Make sends you a plain-text email with the job title, company, fit status, and notification string from the API response.
 
-Make.com is useful for demonstrating visual workflow construction and comparing it with the more code-first n8n approach.
+## Files
+
+| File | Purpose |
+|------|---------|
+| `exports/job-intake.blueprint.json` | Importable Make scenario blueprint |
+| `setup.md` | Click-by-click guide to import, configure, and test the scenario |
+
+## Status
+
+The blueprint is **ready to import and build** in the Make.com GUI. It is not a live running scenario — the maintainer imports it, wires credentials, and activates it following `setup.md`. Screenshots of the live scenario will be added to `docs/design/phase7/make-scenario.png` after activation.
+
+## Free Tier Envelope
+
+Make.com's free plan includes **1,000 operations per month**. Custom webhooks and HTTP modules are available at no cost. This three-module scenario consumes 3 operations per run (~333 job intakes/month on the free tier).
+
+## Setup
+
+See [setup.md](setup.md) for the full walkthrough: prerequisites, blueprint import, per-module credential fixes, webhook URL retrieval, and a curl test command.
+
+## Why Make for This Scenario?
+
+Make's visual canvas makes the webhook-to-API-to-email flow easy to understand and demo. Compared with n8n (self-hosted, full orchestration) and Zapier (lightweight 2-step sidecar), Make sits in the middle: hosted, free for moderate volumes, and capable of the full API-integrated scenario without a server to maintain. See `docs/AUTOMATION_WORKFLOWS.md` for the full three-tool comparison.

--- a/workflows/make/README.md
+++ b/workflows/make/README.md
@@ -10,7 +10,7 @@ Custom Webhook  →  HTTP POST /api/n8n/job-intake  →  Email notification
 
 1. **Trigger (Custom Webhook)** — Make receives a JSON payload containing `company`, `title`, `description_text`, `job_url`, and `source`.
 2. **API call (HTTP module)** — The scenario POSTs the payload to `https://jobops-api.azurewebsites.net/api/n8n/job-intake` with the `X-N8N-Webhook-Secret` header. The API creates the job record, parses the description, and runs fit scoring in a single request, returning `fit_status` and `notification`.
-3. **Email notification (Email module)** — Make sends you a plain-text email with the job title, company, fit status, and notification string from the API response.
+3. **Email notification (Email module)** — Make sends you a plain-text email whose **subject** carries the job title and company (e.g. `JobOps: AI Engineer @ Acme processed`) and whose **body** carries the fit status and notification string from the API response.
 
 ## Files
 

--- a/workflows/make/exports/job-intake.blueprint.json
+++ b/workflows/make/exports/job-intake.blueprint.json
@@ -1,0 +1,49 @@
+{
+  "name": "JobOps - Job Intake (webhook -> API -> notify)",
+  "flow": [
+    {
+      "id": 1,
+      "module": "gateway:CustomWebHook",
+      "version": 1,
+      "parameters": { "hook": "JobOps job intake", "maxResults": 1 },
+      "mapper": {},
+      "metadata": { "designer": { "x": 0, "y": 0 } }
+    },
+    {
+      "id": 2,
+      "module": "http:ActionSendData",
+      "version": 3,
+      "parameters": { "handleErrors": true, "useNewZLibDeCompress": true },
+      "mapper": {
+        "url": "https://jobops-api.azurewebsites.net/api/n8n/job-intake",
+        "method": "post",
+        "headers": [
+          { "name": "Content-Type", "value": "application/json" },
+          { "name": "X-N8N-Webhook-Secret", "value": "REPLACE_WITH_N8N_WEBHOOK_SECRET" }
+        ],
+        "bodyType": "raw",
+        "contentType": "application/json",
+        "data": "{\n  \"company\": \"{{1.company}}\",\n  \"title\": \"{{1.title}}\",\n  \"description_text\": \"{{1.description_text}}\",\n  \"job_url\": \"{{1.job_url}}\",\n  \"source\": \"make\"\n}"
+      },
+      "metadata": { "designer": { "x": 300, "y": 0 } }
+    },
+    {
+      "id": 3,
+      "module": "email:ActionSendEmail",
+      "version": 6,
+      "parameters": {},
+      "mapper": {
+        "to": ["REPLACE_WITH_YOUR_EMAIL"],
+        "subject": "JobOps: {{1.title}} @ {{1.company}} processed",
+        "contentType": "text",
+        "text": "Job created and analyzed by JobOps.\n\nFit status: {{2.fit_status}}\nNotification: {{2.notification}}"
+      },
+      "metadata": { "designer": { "x": 600, "y": 0 } }
+    }
+  ],
+  "metadata": {
+    "version": 1,
+    "scenario": { "roundtrips": 1, "maxErrors": 3, "autoCommit": true },
+    "designer": { "orphans": [] }
+  }
+}

--- a/workflows/make/exports/job-intake.blueprint.json
+++ b/workflows/make/exports/job-intake.blueprint.json
@@ -13,7 +13,7 @@
       "id": 2,
       "module": "http:ActionSendData",
       "version": 3,
-      "parameters": { "handleErrors": true, "useNewZLibDeCompress": true },
+      "parameters": { "handleErrors": true, "useNewZLibDeCompress": true, "parseResponse": true },
       "mapper": {
         "url": "https://jobops-api.azurewebsites.net/api/n8n/job-intake",
         "method": "post",

--- a/workflows/make/exports/job-intake.blueprint.json
+++ b/workflows/make/exports/job-intake.blueprint.json
@@ -23,7 +23,7 @@
         ],
         "bodyType": "raw",
         "contentType": "application/json",
-        "data": "{\n  \"company\": \"{{1.company}}\",\n  \"title\": \"{{1.title}}\",\n  \"description_text\": \"{{1.description_text}}\",\n  \"job_url\": \"{{1.job_url}}\",\n  \"source\": \"make\"\n}"
+        "data": "{\n  \"company\": \"{{1.company}}\",\n  \"title\": \"{{1.title}}\",\n  \"description_text\": \"{{1.description_text}}\",\n  \"job_url\": \"{{1.job_url}}\",\n  \"resume_text\": \"{{1.resume_text}}\",\n  \"profile_text\": \"{{1.profile_text}}\",\n  \"source\": \"make\"\n}"
       },
       "metadata": { "designer": { "x": 300, "y": 0 } }
     },

--- a/workflows/make/setup.md
+++ b/workflows/make/setup.md
@@ -83,8 +83,16 @@ Replace `<MAKE_WEBHOOK_URL>` with the URL you copied in Step 5.
 The scenario should execute all three modules:
 
 1. **Custom webhook** — receives the payload, extracts `company`, `title`, `description_text`, `job_url`.
-2. **HTTP** — POSTs to the JobOps API, which creates the job record, parses the description, and runs fit scoring. The API response includes `fit_status` (e.g. `strong_fit`) and `notification` (a human-readable summary string).
-3. **Email** — sends you an email with the subject `JobOps: AI Engineer @ Acme processed` and a body showing the fit status and notification text.
+2. **HTTP** — POSTs to the JobOps API, which creates the job record and parses the description. The API returns `fit_status` and `notification`. Because the basic test payload above does not include `resume_text` or `profile_text`, the API returns `fit_status: "skipped"` with `notification: "Job created and parsed. Fit scoring can run once resume/profile context is available."` — fit scoring is skipped when there is no resume or profile context to score against.
+3. **Email** — sends you an email with the subject `JobOps: AI Engineer @ Acme processed` and a body showing `Fit status: skipped` and the notification text.
+
+> **Tip — exercising the SCORED path:** To get `fit_status: "scored"` (with a numeric fit score) instead of `"skipped"`, include `resume_text` and `profile_text` in the webhook payload. For example:
+>
+> ```bash
+> curl -X POST "<MAKE_WEBHOOK_URL>" \
+>   -H "Content-Type: application/json" \
+>   -d '{"company":"Acme","title":"AI Engineer","description_text":"Build LLM apps with Python and Azure.","job_url":"https://example.com/job/1","resume_text":"Experienced ML engineer with Python and Azure background.","profile_text":"Seeking senior AI/ML roles in cloud-native environments."}'
+> ```
 
 In Make's execution history you will see green checkmarks on all three modules. After a successful test run, click **Save** and then **Activate** the scenario.
 

--- a/workflows/make/setup.md
+++ b/workflows/make/setup.md
@@ -1,0 +1,99 @@
+# Make.com Scenario Setup Guide
+
+This guide walks you through importing the `job-intake.blueprint.json` scenario into Make.com and wiring it to the live JobOps API. Follow every step in order.
+
+---
+
+## Prerequisites
+
+- A free [Make.com](https://www.make.com) account (no paid plan required; custom webhooks and HTTP modules are available on the free tier).
+- The value of `N8N_WEBHOOK_SECRET` from `apps/api/.env` (or ask the project maintainer). This is the shared secret the API uses to authenticate incoming webhook requests via the `X-N8N-Webhook-Secret` header.
+- An email account you can connect to Make (Gmail, Outlook, or any SMTP-compatible account).
+
+---
+
+## Step 1 — Import the Blueprint
+
+1. Log in to [Make.com](https://www.make.com) and open **Scenarios** from the left sidebar.
+2. Click **Create a new scenario** (the blue `+` button in the top-right corner).
+3. Close the module picker that appears — you will import the blueprint instead of adding modules manually.
+4. Click the **three-dots menu** (⋮) in the bottom toolbar of the scenario canvas and select **Import Blueprint**.
+5. In the file picker that opens, navigate to and select `workflows/make/exports/job-intake.blueprint.json` from this repository.
+6. Make will draw three connected modules on the canvas: **Custom webhook → HTTP → Email**.
+
+---
+
+## Step 2 — Fix Module 1: Custom Webhook
+
+1. Click the **Custom webhook** module (module 1, the leftmost circle).
+2. In the webhook panel, click **Add** next to the Webhook field to create a new webhook named `JobOps job intake` (the name is pre-filled from the blueprint).
+3. Make will generate a unique webhook URL for this scenario. Copy it — you will need it for the test curl later.
+4. Click **Save**.
+
+---
+
+## Step 3 — Fix Module 2: HTTP (API Call)
+
+1. Click the **HTTP** module (module 2, the middle circle).
+2. Locate the **Headers** section. Find the header named `X-N8N-Webhook-Secret`.
+3. Replace the placeholder value `REPLACE_WITH_N8N_WEBHOOK_SECRET` with the actual secret from `apps/api/.env`.
+4. All other settings (URL, method, body) are already configured correctly from the blueprint. Verify the URL reads `https://jobops-api.azurewebsites.net/api/n8n/job-intake` and the method is `POST`.
+5. Click **OK**.
+
+---
+
+## Step 4 — Fix Module 3: Email (Notification)
+
+1. Click the **Email** module (module 3, the rightmost circle).
+2. Click the **Connection** field and select or create a connection to your email account. Make supports Gmail, Outlook/Microsoft 365, and custom SMTP.
+3. In the **To** field, replace `REPLACE_WITH_YOUR_EMAIL` with your actual email address.
+4. The subject and body use dynamic values from the earlier modules (`{{1.title}}`, `{{1.company}}`, `{{2.fit_status}}`, `{{2.notification}}`). Leave those as-is.
+5. Click **OK**.
+
+---
+
+## Step 5 — Get Your Webhook URL
+
+If you did not copy the URL in Step 2, retrieve it now:
+
+1. Click the **Custom webhook** module.
+2. The webhook URL is displayed in the module panel under the webhook name. It looks like `https://hook.eu2.make.com/abcdef123456`.
+3. Copy this URL — it is your Make scenario's public entry point.
+
+---
+
+## Step 6 — Test the Scenario
+
+Before running the test, click **Run once** in the bottom toolbar so Make listens for a single incoming request.
+
+Then, in a terminal, send a test payload using curl:
+
+```bash
+curl -X POST "<MAKE_WEBHOOK_URL>" \
+  -H "Content-Type: application/json" \
+  -d '{"company":"Acme","title":"AI Engineer","description_text":"Build LLM apps with Python and Azure.","job_url":"https://example.com/job/1"}'
+```
+
+Replace `<MAKE_WEBHOOK_URL>` with the URL you copied in Step 5.
+
+---
+
+## Expected Result
+
+The scenario should execute all three modules:
+
+1. **Custom webhook** — receives the payload, extracts `company`, `title`, `description_text`, `job_url`.
+2. **HTTP** — POSTs to the JobOps API, which creates the job record, parses the description, and runs fit scoring. The API response includes `fit_status` (e.g. `strong_fit`) and `notification` (a human-readable summary string).
+3. **Email** — sends you an email with the subject `JobOps: AI Engineer @ Acme processed` and a body showing the fit status and notification text.
+
+In Make's execution history you will see green checkmarks on all three modules. After a successful test run, click **Save** and then **Activate** the scenario.
+
+Save a screenshot of the completed scenario canvas (all three modules connected with green execution bubbles) to `docs/design/phase7/make-scenario.png`.
+
+---
+
+## Free Tier Note
+
+Make.com's free plan includes **1,000 operations per month**. Each scenario run consumes one operation per module execution — so this three-module scenario costs 3 operations per job submitted. That allows approximately 333 job intakes per month on the free tier.
+
+Custom webhooks (the `gateway:CustomWebHook` module) and HTTP requests (the `http:ActionSendData` module) are both available on the free tier. No upgrade is required to run this scenario.

--- a/workflows/zapier/README.md
+++ b/workflows/zapier/README.md
@@ -1,14 +1,35 @@
-# Zapier Companion Automations
+# Zapier Companion Sidecar
 
-Zapier is used here as the lightweight companion automation layer.
+This directory contains a **ready-to-build** Zapier sidecar: a 2-step Zap that watches a Google Sheet of tracked job applications and creates a Google Calendar follow-up reminder for each new row.
 
-## Intended Flow
+## What the Zap Does
 
-- Trigger: new CRM job record or sheet row
-- Action: create a calendar reminder
-- Action: create a Gmail draft
-- Action: send a self-notification
+```
+Google Sheets: New Spreadsheet Row  →  Google Calendar: Create Detailed Event
+```
 
-## Purpose
+1. **Trigger (Google Sheets — New Spreadsheet Row)** — fires whenever you add a new row to your Jobs tracking sheet, picking up `company`, `title`, `job_url`, `status`, `follow_up_date`, and `notes`.
+2. **Action (Google Calendar — Create Detailed Event)** — creates a calendar event with the summary `Follow up: <title> @ <company>`, the date from `follow_up_date`, and a description combining `notes` and `job_url`.
 
-Zapier is helpful for quick, business-user-friendly automations that do not need the full orchestration depth of n8n.
+## Files
+
+| File | Purpose |
+|------|---------|
+| `jobs-sheet-template.csv` | Google Sheets template with the required column headers and one sample row |
+| `setup.md` | Click-by-click guide to create the sheet, build the Zap, and activate it |
+
+## Status
+
+The Zap is **ready to build** in the Zapier GUI — no import mechanism exists for Zaps, so the guide walks through creation step by step. It is not a live running Zap. The maintainer follows `setup.md`, tests the Zap, and saves a screenshot to `docs/design/phase7/zapier-zap.png` after activation.
+
+## Free Tier Constraints That Shaped This Design
+
+Zapier's free plan has hard limits: **100 tasks/month**, **2-step Zaps only** (one trigger + one action), and **Webhooks by Zapier is a premium app** (webhook triggers require a paid plan).
+
+These constraints rule out a webhook-to-API flow on Zapier's free tier. The sidecar is therefore intentionally narrow — it covers the human scheduling layer (sheet row to calendar reminder) rather than the API-integrated intake path. Make.com handles the richer webhook scenario for free; this Zap complements it.
+
+See `docs/AUTOMATION_WORKFLOWS.md` for the full n8n / Make.com / Zapier comparison and guidance on when to use each.
+
+## Setup
+
+See [setup.md](setup.md) for the full walkthrough: sheet creation, trigger configuration, field mapping, and testing.

--- a/workflows/zapier/jobs-sheet-template.csv
+++ b/workflows/zapier/jobs-sheet-template.csv
@@ -1,0 +1,2 @@
+company,title,job_url,status,follow_up_date,notes
+Acme,AI Engineer,https://example.com/job/1,shortlisted,2026-06-17,Referred by network

--- a/workflows/zapier/setup.md
+++ b/workflows/zapier/setup.md
@@ -1,0 +1,90 @@
+# Zapier Sidecar Setup Guide
+
+This guide walks you through building the JobOps Zapier sidecar — a 2-step Zap that creates a Google Calendar reminder whenever a new row is added to your Jobs tracking spreadsheet.
+
+---
+
+## Why This Is a 2-Step Zap
+
+Zapier's free plan has two hard constraints that shape this design:
+
+- **100 tasks per month** — enough for a light job-search cadence (a few dozen applications/month).
+- **2-step Zaps only** — free accounts are limited to one trigger and one action; multi-step Zaps require a paid plan.
+- **Webhooks by Zapier is a premium app** — webhook triggers (which Make.com and n8n use freely) require a paid Zapier plan. This rules out the full API-integrated flow on the free tier.
+
+The result is a deliberately lightweight **sidecar** that handles the one job Zapier does well for free: turning a spreadsheet row into a calendar event. Make.com handles the richer webhook-to-API scenario; Zapier handles the human scheduling layer. This contrast is an intentional portfolio talking point — see `docs/AUTOMATION_WORKFLOWS.md` for the full comparison.
+
+---
+
+## Step 1 — Create Your Google Sheet
+
+1. Open [Google Sheets](https://sheets.google.com) and create a new spreadsheet named **JobOps Job Tracker** (or any name you prefer).
+2. In the first row, enter these column headers in order — the exact names matter for Zapier field mapping:
+
+   ```
+   company | title | job_url | status | follow_up_date | notes
+   ```
+
+3. Alternatively, import `workflows/zapier/jobs-sheet-template.csv` directly into Google Sheets:
+   - **File → Import → Upload** → select `jobs-sheet-template.csv` → choose **Replace current sheet**.
+   - This gives you the correct headers and one sample row.
+
+4. Note the name of the **sheet tab** (by default "Sheet1") — you will need it when configuring the Zap trigger.
+
+---
+
+## Step 2 — Create the Zap
+
+1. Log in to [Zapier](https://zapier.com) and click **Create Zap** (the `+` button).
+
+---
+
+## Step 3 — Configure the Trigger: Google Sheets → New Spreadsheet Row
+
+1. In the trigger step, search for and select **Google Sheets**.
+2. Choose the event **New Spreadsheet Row** and click **Continue**.
+3. Connect your Google account if you have not already.
+4. In the **Trigger** settings:
+   - **Spreadsheet** — select your **JobOps Job Tracker** spreadsheet.
+   - **Worksheet** — select **Sheet1** (or whichever tab you named it).
+5. Click **Test trigger**. Zapier will pull in the sample row from the sheet. Confirm you can see the `company`, `title`, `job_url`, `status`, `follow_up_date`, and `notes` fields in the sample data.
+6. Click **Continue**.
+
+---
+
+## Step 4 — Configure the Action: Google Calendar → Create Detailed Event
+
+1. In the action step, search for and select **Google Calendar**.
+2. Choose the event **Create Detailed Event** and click **Continue**.
+3. Connect your Google account (the same one or a different one — whichever calendar you want the reminders on).
+4. Map the fields as follows:
+
+   | Calendar field | Value to map |
+   |----------------|-------------|
+   | **Summary** | Type `Follow up: ` then insert the dynamic field `title`, then type ` @ `, then insert `company`. The result should read like: `Follow up: AI Engineer @ Acme`. |
+   | **Start Date & Time** | Map to `follow_up_date` from the trigger. Zapier accepts dates in YYYY-MM-DD format; the template column uses this format. |
+   | **Description** | Type `Notes: ` then insert `notes`, then a newline, then `Job URL: ` then insert `job_url`. |
+   | **Calendar** | Select whichever Google Calendar you want the event added to. |
+
+5. Leave other fields (duration, location, guests) blank.
+6. Click **Continue**.
+
+---
+
+## Step 5 — Test and Activate
+
+1. Click **Test action**. Zapier will create a test event in your Google Calendar using the sample row data.
+2. Open Google Calendar and confirm the event was created with the correct summary, date, and description.
+3. If the event looks correct, click **Publish Zap** (or **Turn on Zap**) to activate it.
+
+From this point, every time you add a new row to your Jobs spreadsheet, Zapier will automatically create a follow-up reminder in Google Calendar.
+
+Save a screenshot of the completed Zap (both trigger and action steps shown as connected and active) to `docs/design/phase7/zapier-zap.png`.
+
+---
+
+## Free Tier Note
+
+Zapier's free plan allows **100 tasks per month** (one task = one Zap run). At a typical job-search cadence of 2–5 new applications per day, 100 tasks covers 20–50 days of tracking before the monthly limit is reached — adequate for light use. If you exceed 100 tasks/month, Zapier pauses the Zap until the next billing cycle.
+
+The free plan supports **2-step Zaps only** (one trigger + one action). Google Sheets and Google Calendar are both standard free apps. No premium features are used.

--- a/workflows/zapier/setup.md
+++ b/workflows/zapier/setup.md
@@ -62,7 +62,7 @@ The result is a deliberately lightweight **sidecar** that handles the one job Za
    | Calendar field | Value to map |
    |----------------|-------------|
    | **Summary** | Type `Follow up: ` then insert the dynamic field `title`, then type ` @ `, then insert `company`. The result should read like: `Follow up: AI Engineer @ Acme`. |
-   | **Start Date & Time** | Map to `follow_up_date` from the trigger. Zapier accepts dates in YYYY-MM-DD format; the template column uses this format. |
+   | **Start Date & Time** | Map to `follow_up_date` from the trigger. Zapier accepts dates in YYYY-MM-DD format; the template column uses this format. **Note:** a date-only value creates an all-day (midnight) event. To get a timed reminder instead, append a time when you fill the spreadsheet cell — e.g. `2026-06-17 09:00`. |
    | **Description** | Type `Notes: ` then insert `notes`, then a newline, then `Job URL: ` then insert `job_url`. |
    | **Calendar** | Select whichever Google Calendar you want the event added to. |
 


### PR DESCRIPTION
Part C of the plan — the Phase 7 companion-automation artifacts. Everything *around* the flows is delivered; building the live Zaps/scenarios + screenshots is the maintainer's follow-up (C4).

## What's here
- **Make.com** (`workflows/make/`): importable `exports/job-intake.blueprint.json` (Custom webhook → HTTP POST to the authenticated `/api/n8n/job-intake` → email), a click-by-click `setup.md`, and a rewritten README. Runs the rich webhook→API scenario on Make's free tier (custom webhooks free, 1,000 ops/mo).
- **Zapier** (`workflows/zapier/`): a deliberately lightweight free-tier **2-step** sidecar — `setup.md` for Google Sheets new-row → Google Calendar reminder, plus `jobs-sheet-template.csv`. (Zapier free has no webhooks/multi-step — the contrast vs. Make/n8n is the point.)
- **Comparison docs**: `docs/AUTOMATION_WORKFLOWS.md` updated with an n8n vs Zapier vs Make decision guide; README gains an "Automation tiers" section.

## Quality
Reviewed via the two-stage subagent flow (spec ✅, code-quality ✅). The quality pass cross-checked the blueprint against the live API contract (`apps/api/src/routes/n8n.ts`) and caught two real issues, now fixed:
- `fit_status` is accurately documented as `skipped`/`scored` (not an invented value), with a tip for exercising the scored path.
- HTTP module sets `parseResponse: true` so the email's dynamic fields populate.

Phase 7 status is intentionally **left as deferred** — it flips to ✅ once the live flows are built and screenshots land in `docs/design/phase7/`.

Docs + blueprint only; no app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)