### PR TITLE
ci: reliable API deploy (self-contained package + health-check gate)

### DIFF
--- a/.github/workflows/azure-app-service.yml
+++ b/.github/workflows/azure-app-service.yml
@@ -10,9 +10,7 @@ on:
         default: all
         options:
           - all
-          - both
           - web
-          - api
           - agent
 
 permissions:
@@ -40,28 +38,18 @@ jobs:
         run: npm ci
 
       - name: Build web app
-        if: ${{ inputs.target == 'all' || inputs.target == 'both' || inputs.target == 'web' }}
+        if: ${{ inputs.target == 'all' || inputs.target == 'web' }}
         run: npm run build:web
 
-      - name: Build API
-        if: ${{ inputs.target == 'all' || inputs.target == 'both' || inputs.target == 'api' }}
-        run: npm run build:api
-
+      # API deploys live in deploy-api.yml (push-triggered + dispatch). This
+      # combined workflow covers web and the code-deploy agent path only.
       - name: Deploy web app
-        if: ${{ inputs.target == 'all' || inputs.target == 'both' || inputs.target == 'web' }}
+        if: ${{ inputs.target == 'all' || inputs.target == 'web' }}
         uses: azure/webapps-deploy@v3
         with:
           app-name: ${{ vars.AZURE_WEBAPP_NAME_WEB }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_WEB }}
           package: apps/web # workspace package root; tsconfig is self-contained
-
-      - name: Deploy API
-        if: ${{ inputs.target == 'all' || inputs.target == 'both' || inputs.target == 'api' }}
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: ${{ vars.AZURE_WEBAPP_NAME_API }}
-          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}
-          package: apps/api # workspace package root; tsconfig is self-contained
 
       # The Python agent service ships PyTorch (RAG) and is best deployed as a
       # container using services/agent/Dockerfile (App Service for Containers or

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -76,21 +76,24 @@ jobs:
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}
           package: apps/api/.deploy
 
-      - name: Health check
+      - name: Health check (readiness — proves DB connectivity)
         env:
           API_NAME: ${{ vars.AZURE_WEBAPP_NAME_API }}
         run: |
           set -euo pipefail
-          url="https://${API_NAME}.azurewebsites.net/api/health"
+          # /api/health/ready runs a real "SELECT 1", so it only reports db:ok when
+          # Postgres is actually reachable — a broken data path fails this gate
+          # instead of going green on a mode flag that only checks DATABASE_URL.
+          url="https://${API_NAME}.azurewebsites.net/api/health/ready"
           echo "Polling $url"
           for i in $(seq 1 12); do
             body="$(curl -fsS --max-time 10 "$url" || true)"
             echo "attempt $i: $body"
-            if printf '%s' "$body" | grep -Eq '"mode"[[:space:]]*:[[:space:]]*"postgres"'; then
-              echo "API healthy."
+            if printf '%s' "$body" | grep -Eq '"db"[[:space:]]*:[[:space:]]*"ok"'; then
+              echo "API ready (database reachable)."
               exit 0
             fi
             sleep 15
           done
-          echo "API did not report a healthy postgres mode in time." >&2
+          echo "API did not report a reachable database (/api/health/ready db:ok) in time." >&2
           exit 1

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,90 @@
+# Deploy the JobOps API to Azure App Service.
+#
+# Why this exists: apps/api is an npm workspace whose dependencies are hoisted to
+# the repo-root node_modules. Deploying the workspace folder directly ships no
+# node_modules, so the app crashes with "Cannot find module '@clerk/express'".
+# This workflow assembles a SELF-CONTAINED package (dist + package.json + a local
+# production install) and deploys that, then verifies the live app is healthy.
+#
+# Preconditions (already configured on the jobops-api App Service):
+#   - App setting WEBSITE_RUN_FROM_PACKAGE=1        (package mounted read-only;
+#     avoids the B1 big-node_modules extraction hang)
+#   - App setting SCM_DO_BUILD_DURING_DEPLOYMENT=false  (no Oryx rebuild)
+#   - DB / Clerk / App Insights secrets (or Key Vault references) set
+# Repo config:
+#   - Variable AZURE_WEBAPP_NAME_API
+#   - Secret   AZURE_WEBAPP_PUBLISH_PROFILE_API
+name: Deploy API (Azure)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/api/**'
+      - '.github/workflows/deploy-api.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-api
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build + deploy API
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build API
+        run: npm run build:api
+
+      - name: Assemble self-contained deploy package
+        run: |
+          set -euo pipefail
+          rm -rf apps/api/.deploy
+          mkdir -p apps/api/.deploy/dist
+          cp -r apps/api/dist/. apps/api/.deploy/dist/
+          cp apps/api/package.json apps/api/.deploy/package.json
+          ( cd apps/api/.deploy && npm install --omit=dev --no-audit --no-fund )
+          # Fail fast if any production dependency did not land in the package.
+          ( cd apps/api/.deploy && node -e "const d=require('./package.json').dependencies||{};for(const k of Object.keys(d))require.resolve(k);console.log('OK:',Object.keys(d).length,'prod deps resolve');" )
+
+      - name: Deploy to Azure App Service
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ vars.AZURE_WEBAPP_NAME_API }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}
+          package: apps/api/.deploy
+
+      - name: Health check
+        env:
+          API_NAME: ${{ vars.AZURE_WEBAPP_NAME_API }}
+        run: |
+          set -euo pipefail
+          url="https://${API_NAME}.azurewebsites.net/api/health"
+          echo "Polling $url"
+          for i in $(seq 1 12); do
+            body="$(curl -fsS --max-time 10 "$url" || true)"
+            echo "attempt $i: $body"
+            if printf '%s' "$body" | grep -Eq '"mode"[[:space:]]*:[[:space:]]*"postgres"'; then
+              echo "API healthy."
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "API did not report a healthy postgres mode in time." >&2
+          exit 1

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -59,7 +59,13 @@ jobs:
           mkdir -p apps/api/.deploy/dist
           cp -r apps/api/dist/. apps/api/.deploy/dist/
           cp apps/api/package.json apps/api/.deploy/package.json
-          ( cd apps/api/.deploy && npm install --omit=dev --no-audit --no-fund )
+          # Copy the repo-root lockfile so the packaged dependencies are the EXACT
+          # versions npm ci installed and tested in this job (deterministic) rather
+          # than a fresh semver re-resolve. npm ci honours the lockfile's pinned
+          # versions; a few hoisted peer packages (e.g. react) come along but the
+          # API never requires them, so they are inert under WEBSITE_RUN_FROM_PACKAGE.
+          cp package-lock.json apps/api/.deploy/package-lock.json
+          ( cd apps/api/.deploy && npm ci --omit=dev --no-audit --no-fund )
           # Fail fast if any production dependency did not land in the package.
           ( cd apps/api/.deploy && node -e "const d=require('./package.json').dependencies||{};for(const k of Object.keys(d))require.resolve(k);console.log('OK:',Object.keys(d).length,'prod deps resolve');" )
 

--- a/apps/api/src/lib/postgres.ts
+++ b/apps/api/src/lib/postgres.ts
@@ -35,3 +35,18 @@ export async function closePool() {
   pool = null;
   await activePool.end();
 }
+
+export async function pingDatabase(): Promise<boolean> {
+  const activePool = getPool();
+  if (!activePool) {
+    return false;
+  }
+
+  try {
+    await activePool.query('SELECT 1');
+    return true;
+  } catch (error) {
+    console.error('Database readiness ping failed:', error);
+    return false;
+  }
+}

--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeReadiness } from '@/routes/health';
+
+test('computeReadiness: file mode is ready without a database check', () => {
+  assert.deepEqual(computeReadiness('file', false), {
+    statusCode: 200,
+    body: { status: 'ready', mode: 'file', db: 'skipped' },
+  });
+});
+
+test('computeReadiness: postgres reachable is ready (db ok)', () => {
+  assert.deepEqual(computeReadiness('postgres', true), {
+    statusCode: 200,
+    body: { status: 'ready', mode: 'postgres', db: 'ok' },
+  });
+});
+
+test('computeReadiness: postgres unreachable is not ready (503, db error)', () => {
+  assert.deepEqual(computeReadiness('postgres', false), {
+    statusCode: 503,
+    body: { status: 'not_ready', mode: 'postgres', db: 'error' },
+  });
+});

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,8 +1,26 @@
 import { Router } from 'express';
 import { getStoreMode } from '@/data/job-store';
 import { isAgentEnabled } from '@/lib/agent-client';
+import { pingDatabase } from '@/lib/postgres';
 
 export const healthRouter = Router();
+
+type Readiness = {
+  statusCode: number;
+  body: { status: string; mode: string; db: string };
+};
+
+// Pure decision logic for the readiness probe, kept separate so it is unit-testable
+// without a live database.
+export function computeReadiness(mode: 'postgres' | 'file', dbReachable: boolean): Readiness {
+  if (mode !== 'postgres') {
+    return { statusCode: 200, body: { status: 'ready', mode, db: 'skipped' } };
+  }
+
+  return dbReachable
+    ? { statusCode: 200, body: { status: 'ready', mode, db: 'ok' } }
+    : { statusCode: 503, body: { status: 'not_ready', mode, db: 'error' } };
+}
 
 healthRouter.get('/health', (_request, response) => {
   response.json({
@@ -11,6 +29,15 @@ healthRouter.get('/health', (_request, response) => {
     mode: getStoreMode(),
     timestamp: new Date().toISOString(),
   });
+});
+
+// Readiness probe: unlike /health (liveness), this proves the data path actually
+// works by running a real query, so a deploy with an unreachable DB fails its gate.
+healthRouter.get('/health/ready', async (_request, response) => {
+  const mode = getStoreMode();
+  const dbReachable = mode === 'postgres' ? await pingDatabase() : false;
+  const { statusCode, body } = computeReadiness(mode, dbReachable);
+  response.status(statusCode).json(body);
 });
 
 // Richer status for the Settings page: real provider/model + integration config,

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -87,7 +87,7 @@ Why this route:
 
 Required app settings:
 
-- `SCM_DO_BUILD_DURING_DEPLOYMENT=true` on both apps so App Service installs dependencies and runs the workspace build during deployment
+- `SCM_DO_BUILD_DURING_DEPLOYMENT=false` and `WEBSITE_RUN_FROM_PACKAGE=1` on the API app: CI ships a pre-built, self-contained package (see `deploy-api.yml`), so App Service must not rebuild and instead mounts the package read-only
 - `NEXT_PUBLIC_API_BASE_URL=https://<api-app>.azurewebsites.net` on the web app
 - `DATABASE_URL=...` on the API app
 - `API_PUBLIC_BASE_URL=https://<api-app>.azurewebsites.net` on the API app
@@ -111,11 +111,17 @@ GitHub Actions inputs and secrets:
 - `secrets.AZURE_WEBAPP_PUBLISH_PROFILE_WEB`
 - `secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API`
 
-Recommended workflow:
+Deploy workflows (canonical):
 
-- run the manual Azure deployment workflow from the Actions tab
-- deploy the web app and API together after `npm run build:web` and `npm run build:api` pass
-- switch to push-based deployment later only after the App Service settings are stable
+- **API** — `.github/workflows/deploy-api.yml` runs on push to `main` under
+  `apps/api/**` (and on manual dispatch). It builds the API, assembles a
+  self-contained package (`dist` + `package.json` + a local `npm install --omit=dev`),
+  deploys it, and gates on a `/api/health` check returning `"mode":"postgres"`.
+- **Web** — `.github/workflows/deploy-web.yml` runs on push to `main` under
+  `apps/web/**` (and on manual dispatch), deploying the Next.js standalone bundle.
+- **Agent** — containerized: build `services/agent/Dockerfile`, push to ACR, then
+  `az containerapp update`. The `azure-app-service.yml` agent target is a code-deploy
+  fallback for a no-RAG agent only.
 
 ## Recommended Phase 6 Order
 

--- a/docs/superpowers/plans/2026-06-12-reliable-api-deploy.md
+++ b/docs/superpowers/plans/2026-06-12-reliable-api-deploy.md
@@ -1,0 +1,379 @@
+# Reliable API Deploy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broken `apps/api` deploy with a dedicated, push-triggered GitHub Actions workflow that ships a self-contained package and verifies the live API is healthy.
+
+**Architecture:** A new `deploy-api.yml` (mirroring `deploy-web.yml`) builds the API, assembles a self-contained `apps/api/.deploy` directory (`dist` + `package.json` + a local `npm install --omit=dev` so prod deps are no longer hoisted away), deploys it via `azure/webapps-deploy@v3`, then polls `/api/health`. The `api` target is removed from the combined `azure-app-service.yml` so there is one canonical path.
+
+**Tech Stack:** GitHub Actions, Node 22, npm workspaces, Azure App Service (`azure/webapps-deploy@v3`), publish-profile auth.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md`
+
+---
+
+## File Structure
+
+- **Create** `.github/workflows/deploy-api.yml` — canonical API deploy (push + dispatch, assemble, deploy, health check).
+- **Modify** `.github/workflows/azure-app-service.yml` — drop the `api` (and now-redundant `both`) target; leave web/agent.
+- **Modify** `docs/AZURE_DEPLOYMENT.md` — name the two dedicated workflows as canonical; correct the stale `SCM_DO_BUILD_DURING_DEPLOYMENT=true` note for the API.
+- **Scratch (not committed)** `apps/api/.deploy/` — the assembled package; already covered by the `.deploy/` entry in `.gitignore`.
+
+---
+
+## Task 1: Prove the self-contained assembly recipe locally
+
+This is the acceptance test for the workflow logic: confirm that assembling
+`dist` + `package.json` + a local prod install yields a package where every
+production dependency resolves. Run from the repo root in **Git Bash**.
+
+**Files:** none committed (verification only).
+
+- [ ] **Step 1: Build the API**
+
+Run:
+```bash
+npm ci
+npm run build:api
+```
+Expected: completes; `apps/api/dist/server.js` exists.
+
+- [ ] **Step 2: Assemble the self-contained package exactly as the workflow will**
+
+Run:
+```bash
+rm -rf apps/api/.deploy
+mkdir -p apps/api/.deploy/dist
+cp -r apps/api/dist/. apps/api/.deploy/dist/
+cp apps/api/package.json apps/api/.deploy/package.json
+( cd apps/api/.deploy && npm install --omit=dev --no-audit --no-fund )
+```
+Expected: install completes, `apps/api/.deploy/node_modules` is populated.
+
+- [ ] **Step 3: Verify every prod dependency resolves from the package**
+
+Run:
+```bash
+( cd apps/api/.deploy && node -e "const d=require('./package.json').dependencies||{};for(const k of Object.keys(d))require.resolve(k);console.log('OK:',Object.keys(d).length,'prod deps resolve');" )
+```
+Expected: prints `OK: 9 prod deps resolve` with no `MODULE_NOT_FOUND`. (This is the
+exact failure the broken `package: apps/api` deploy hits — proving it passes here
+proves the fix.)
+
+- [ ] **Step 4: Clean up the scratch dir**
+
+Run:
+```bash
+rm -rf apps/api/.deploy
+```
+Expected: removed. (No commit — this task only validates the recipe.)
+
+---
+
+## Task 2: Create the dedicated API deploy workflow
+
+**Files:**
+- Create: `.github/workflows/deploy-api.yml`
+
+- [ ] **Step 1: Write the workflow file**
+
+Create `.github/workflows/deploy-api.yml` with exactly:
+
+```yaml
+# Deploy the JobOps API to Azure App Service.
+#
+# Why this exists: apps/api is an npm workspace whose dependencies are hoisted to
+# the repo-root node_modules. Deploying the workspace folder directly ships no
+# node_modules, so the app crashes with "Cannot find module '@clerk/express'".
+# This workflow assembles a SELF-CONTAINED package (dist + package.json + a local
+# production install) and deploys that, then verifies the live app is healthy.
+#
+# Preconditions (already configured on the jobops-api App Service):
+#   - App setting WEBSITE_RUN_FROM_PACKAGE=1        (package mounted read-only;
+#     avoids the B1 big-node_modules extraction hang)
+#   - App setting SCM_DO_BUILD_DURING_DEPLOYMENT=false  (no Oryx rebuild)
+#   - DB / Clerk / App Insights secrets (or Key Vault references) set
+# Repo config:
+#   - Variable AZURE_WEBAPP_NAME_API
+#   - Secret   AZURE_WEBAPP_PUBLISH_PROFILE_API
+name: Deploy API (Azure)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/api/**'
+      - '.github/workflows/deploy-api.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-api
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build + deploy API
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build API
+        run: npm run build:api
+
+      - name: Assemble self-contained deploy package
+        run: |
+          set -euo pipefail
+          rm -rf apps/api/.deploy
+          mkdir -p apps/api/.deploy/dist
+          cp -r apps/api/dist/. apps/api/.deploy/dist/
+          cp apps/api/package.json apps/api/.deploy/package.json
+          ( cd apps/api/.deploy && npm install --omit=dev --no-audit --no-fund )
+          # Fail fast if any production dependency did not land in the package.
+          ( cd apps/api/.deploy && node -e "const d=require('./package.json').dependencies||{};for(const k of Object.keys(d))require.resolve(k);console.log('OK:',Object.keys(d).length,'prod deps resolve');" )
+
+      - name: Deploy to Azure App Service
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ vars.AZURE_WEBAPP_NAME_API }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}
+          package: apps/api/.deploy
+
+      - name: Health check
+        env:
+          API_NAME: ${{ vars.AZURE_WEBAPP_NAME_API }}
+        run: |
+          set -euo pipefail
+          url="https://${API_NAME}.azurewebsites.net/api/health"
+          echo "Polling $url"
+          for i in $(seq 1 12); do
+            body="$(curl -fsS --max-time 10 "$url" || true)"
+            echo "attempt $i: $body"
+            if printf '%s' "$body" | grep -Eq '"mode"[[:space:]]*:[[:space:]]*"postgres"'; then
+              echo "API healthy."
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "API did not report a healthy postgres mode in time." >&2
+          exit 1
+```
+
+- [ ] **Step 2: Validate the YAML parses**
+
+Run:
+```bash
+node -e "const fs=require('fs');const s=fs.readFileSync('.github/workflows/deploy-api.yml','utf8');if(!/name: Deploy API/.test(s))throw new Error('header missing');console.log('workflow file present, header OK')"
+```
+Expected: prints `workflow file present, header OK`. (If `actionlint` is installed,
+also run `actionlint .github/workflows/deploy-api.yml` and expect no errors.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/deploy-api.yml
+git commit -m "ci: dedicated reliable API deploy (self-contained package + health check)"
+```
+
+---
+
+## Task 3: Remove the API target from the combined workflow
+
+Eliminate the second, broken API path so `deploy-api.yml` is canonical. The `both`
+option (web+api) loses its meaning once API is gone, so drop it too.
+
+**Files:**
+- Modify: `.github/workflows/azure-app-service.yml`
+
+- [ ] **Step 1: Trim the target choices**
+
+In `.github/workflows/azure-app-service.yml`, replace:
+```yaml
+        options:
+          - all
+          - both
+          - web
+          - api
+          - agent
+```
+with:
+```yaml
+        options:
+          - all
+          - web
+          - agent
+```
+
+- [ ] **Step 2: Fix the web step conditions (drop `both`)**
+
+Replace the web build condition:
+```yaml
+        if: ${{ inputs.target == 'all' || inputs.target == 'both' || inputs.target == 'web' }}
+        run: npm run build:web
+```
+with:
+```yaml
+        if: ${{ inputs.target == 'all' || inputs.target == 'web' }}
+        run: npm run build:web
+```
+
+And replace the web deploy condition (the `if:` line directly above `uses: azure/webapps-deploy@v3` for `AZURE_WEBAPP_NAME_WEB`):
+```yaml
+        if: ${{ inputs.target == 'all' || inputs.target == 'both' || inputs.target == 'web' }}
+```
+with:
+```yaml
+        if: ${{ inputs.target == 'all' || inputs.target == 'web' }}
+```
+
+- [ ] **Step 3: Delete the Build API and Deploy API steps**
+
+Remove these two steps entirely:
+```yaml
+      - name: Build API
+        if: ${{ inputs.target == 'all' || inputs.target == 'both' || inputs.target == 'api' }}
+        run: npm run build:api
+```
+and
+```yaml
+      - name: Deploy API
+        if: ${{ inputs.target == 'all' || inputs.target == 'both' || inputs.target == 'api' }}
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ vars.AZURE_WEBAPP_NAME_API }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}
+          package: apps/api # workspace package root; tsconfig is self-contained
+```
+
+- [ ] **Step 4: Add a pointer comment above the `Deploy web app` step**
+
+Insert this comment line immediately before the `- name: Deploy web app` step:
+```yaml
+      # API deploys live in deploy-api.yml (push-triggered + dispatch). This
+      # combined workflow covers web and the code-deploy agent path only.
+```
+
+- [ ] **Step 5: Validate the YAML parses and no API target remains**
+
+Run:
+```bash
+node -e "const fs=require('fs');const s=fs.readFileSync('.github/workflows/azure-app-service.yml','utf8');if(/- api\b/.test(s))throw new Error('api target still present');if(/Deploy API/.test(s))throw new Error('Deploy API step still present');console.log('combined workflow trimmed OK')"
+```
+Expected: prints `combined workflow trimmed OK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/azure-app-service.yml
+git commit -m "ci: make deploy-api.yml the single API deploy path (drop api target from combined workflow)"
+```
+
+---
+
+## Task 4: Correct the deployment docs
+
+**Files:**
+- Modify: `docs/AZURE_DEPLOYMENT.md`
+
+- [ ] **Step 1: Fix the stale API app-setting note**
+
+In `docs/AZURE_DEPLOYMENT.md`, replace:
+```markdown
+- `SCM_DO_BUILD_DURING_DEPLOYMENT=true` on both apps so App Service installs dependencies and runs the workspace build during deployment
+```
+with:
+```markdown
+- `SCM_DO_BUILD_DURING_DEPLOYMENT=false` and `WEBSITE_RUN_FROM_PACKAGE=1` on the API app: CI ships a pre-built, self-contained package (see `deploy-api.yml`), so App Service must not rebuild and instead mounts the package read-only
+```
+
+- [ ] **Step 2: Replace the "Recommended workflow" bullets with the canonical paths**
+
+Replace:
+```markdown
+Recommended workflow:
+
+- run the manual Azure deployment workflow from the Actions tab
+- deploy the web app and API together after `npm run build:web` and `npm run build:api` pass
+- switch to push-based deployment later only after the App Service settings are stable
+```
+with:
+```markdown
+Deploy workflows (canonical):
+
+- **API** — `.github/workflows/deploy-api.yml` runs on push to `main` under
+  `apps/api/**` (and on manual dispatch). It builds the API, assembles a
+  self-contained package (`dist` + `package.json` + a local `npm install --omit=dev`),
+  deploys it, and gates on a `/api/health` check returning `"mode":"postgres"`.
+- **Web** — `.github/workflows/deploy-web.yml` runs on push to `main` under
+  `apps/web/**` (and on manual dispatch), deploying the Next.js standalone bundle.
+- **Agent** — containerized: build `services/agent/Dockerfile`, push to ACR, then
+  `az containerapp update`. The `azure-app-service.yml` agent target is a code-deploy
+  fallback for a no-RAG agent only.
+```
+
+- [ ] **Step 3: Verify the edits landed**
+
+Run:
+```bash
+node -e "const fs=require('fs');const s=fs.readFileSync('docs/AZURE_DEPLOYMENT.md','utf8');if(/SCM_DO_BUILD_DURING_DEPLOYMENT=true/.test(s))throw new Error('stale =true note remains');if(!/deploy-api.yml/.test(s))throw new Error('canonical path not documented');console.log('docs updated OK')"
+```
+Expected: prints `docs updated OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/AZURE_DEPLOYMENT.md
+git commit -m "docs: document deploy-api.yml as the canonical API deploy path"
+```
+
+---
+
+## Task 5: Open the PR (do not merge)
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u origin reliable-api-deploy
+```
+
+- [ ] **Step 2: Open the PR**
+
+Run:
+```bash
+gh pr create --title "ci: reliable API deploy (self-contained package + health check)" --body "<summary: root cause = hoisted workspace deps; fix = self-contained apps/api/.deploy package; new deploy-api.yml push+dispatch with /api/health gate; api target removed from combined workflow; docs corrected. Local verification: 9 prod deps resolve from the assembled package.>"
+```
+Expected: PR URL printed. Do **not** merge — the maintainer merges. The live deploy
+is exercised when the PR merges to `main` (the health-check step is the automated
+acceptance test); a manual `workflow_dispatch` run can validate sooner.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** self-contained package (Task 1 proves it, Task 2 encodes it);
+  push + dispatch triggers (Task 2); health-check gate (Task 2); single canonical
+  path / remove api target (Task 3); docs hygiene (Task 4); preconditions documented
+  in the workflow header (Task 2) and corrected in AZURE_DEPLOYMENT.md (Task 4);
+  reproducibility trade-off noted in the spec (no code impact).
+- **Assembly dir name** is `apps/api/.deploy` so it is already covered by the
+  `.deploy/` entry in `.gitignore` — no gitignore change needed.
+- **Health-check match** tolerates whitespace (`"mode"[[:space:]]*:[[:space:]]*"postgres"`),
+  matching the real `/api/health` JSON.
+- **No app-settings management** in the workflow (publish-profile only, no `az login`);
+  the required settings are documented preconditions, already set on `jobops-api`.

--- a/docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md
@@ -70,10 +70,12 @@ manual workflow so there is a single source of truth.
    - `app-name: ${{ vars.AZURE_WEBAPP_NAME_API }}`
    - `publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}`
    - `package: apps/api/deploy`
-7. Health-check gate: poll `https://${{ vars.AZURE_WEBAPP_NAME_API }}.azurewebsites.net/api/health`
-   with a bounded retry loop (e.g. up to ~12 attempts, 15s apart ≈ 3 min). Pass when
-   the response is HTTP 200 and the body contains `"mode":"postgres"`; otherwise
-   print the last response and `exit 1`.
+7. Health-check gate: poll `/api/health/ready` (a readiness probe that runs
+   `SELECT 1`) with a bounded retry loop (e.g. up to ~12 attempts, 15s apart ≈ 3 min).
+   Require HTTP 200 with `"db":"ok"`, so the gate proves the database is reachable, not
+   merely configured; otherwise print the last response and `exit 1`.
+   (Liveness endpoint `/api/health` stays unchanged — it is not touched by this
+   workflow.)
 
 **Header comment — required preconditions (already set on `jobops-api`)**
 
@@ -102,10 +104,10 @@ manual workflow so there is a single source of truth.
 push to main (apps/api/**)  ─┐
 workflow_dispatch           ─┴─►  deploy-api.yml
    checkout ─► npm ci ─► build:api ─► assemble apps/api/deploy
-        (dist + package.json + npm install --omit=dev)
+        (dist + package.json + cp package-lock.json + npm ci --omit=dev)
    ─► azure/webapps-deploy (publish profile, WEBSITE_RUN_FROM_PACKAGE=1)
-   ─► GET /api/health  ── 200 & "mode":"postgres" ──► success
-                        └─ otherwise ───────────────► fail (exit 1)
+   ─► GET /api/health/ready  ── 200 & "db":"ok" ──► success
+                              └─ otherwise ────────► fail (exit 1)
 ```
 
 ## Error handling
@@ -113,7 +115,7 @@ workflow_dispatch           ─┴─►  deploy-api.yml
 - **Missing prod dep at runtime** — root cause; eliminated by the self-contained
   `npm install --omit=dev` in the deploy dir.
 - **Bad deploy reaches production** — caught by the health-check gate; the run goes
-  red and surfaces the failing `/api/health` response.
+  red and surfaces the failing `/api/health/ready` response.
 - **Overlapping deploys** — prevented by the concurrency group.
 - **Hung run** — bounded by `timeout-minutes` and the capped health-check retries.
 
@@ -129,7 +131,8 @@ Local (no Azure creds needed), proves the package is self-contained:
 4. Lint the workflow YAML (`actionlint` if available; otherwise a YAML parse check).
 
 Live: triggered by merging an `apps/api/**` change to `main` (or manual dispatch);
-the health-check step is the automated acceptance test.
+the health-check step polls `/api/health/ready` and requires `"db":"ok"` — it is the
+automated acceptance test that proves the database is reachable.
 
 ## Reproducibility note
 

--- a/docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md
@@ -69,7 +69,7 @@ manual workflow so there is a single source of truth.
 6. Deploy with `azure/webapps-deploy@v3`:
    - `app-name: ${{ vars.AZURE_WEBAPP_NAME_API }}`
    - `publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}`
-   - `package: apps/api/deploy`
+   - `package: apps/api/.deploy`
 7. Health-check gate: poll `/api/health/ready` (a readiness probe that runs
    `SELECT 1`) with a bounded retry loop (e.g. up to ~12 attempts, 15s apart ≈ 3 min).
    Require HTTP 200 with `"db":"ok"`, so the gate proves the database is reachable, not
@@ -103,7 +103,7 @@ manual workflow so there is a single source of truth.
 ```
 push to main (apps/api/**)  ─┐
 workflow_dispatch           ─┴─►  deploy-api.yml
-   checkout ─► npm ci ─► build:api ─► assemble apps/api/deploy
+   checkout ─► npm ci ─► build:api ─► assemble apps/api/.deploy
         (dist + package.json + cp package-lock.json + npm ci --omit=dev)
    ─► azure/webapps-deploy (publish profile, WEBSITE_RUN_FROM_PACKAGE=1)
    ─► GET /api/health/ready  ── 200 & "db":"ok" ──► success
@@ -113,7 +113,7 @@ workflow_dispatch           ─┴─►  deploy-api.yml
 ## Error handling
 
 - **Missing prod dep at runtime** — root cause; eliminated by the self-contained
-  `npm install --omit=dev` in the deploy dir.
+  `npm ci --omit=dev` (lockfile-pinned) in the deploy dir.
 - **Bad deploy reaches production** — caught by the health-check gate; the run goes
   red and surfaces the failing `/api/health/ready` response.
 - **Overlapping deploys** — prevented by the concurrency group.
@@ -124,8 +124,8 @@ workflow_dispatch           ─┴─►  deploy-api.yml
 Local (no Azure creds needed), proves the package is self-contained:
 
 1. `npm ci && npm run build:api`
-2. Assemble `apps/api/deploy` exactly as the workflow does.
-3. From `apps/api/deploy`, run `node dist/server.js` and confirm it boots without a
+2. Assemble `apps/api/.deploy` exactly as the workflow does.
+3. From `apps/api/.deploy`, run `node dist/server.js` and confirm it boots without a
    `Cannot find module` error (it will then try to bind/connect — module resolution
    succeeding is the signal we care about).
 4. Lint the workflow YAML (`actionlint` if available; otherwise a YAML parse check).

--- a/docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md
@@ -63,8 +63,9 @@ manual workflow so there is a single source of truth.
    keeps it under the existing `.deploy/` `.gitignore` entry):
    - copy `apps/api/dist` → `apps/api/.deploy/dist`
    - copy `apps/api/package.json` → `apps/api/.deploy/package.json`
-   - run `npm install --omit=dev --no-audit --no-fund` **inside** `apps/api/deploy`
-     so it gets a real, un-hoisted `node_modules` with the 9 prod deps.
+   - copy the repo-root `package-lock.json` into the deploy dir and run
+     `npm ci --omit=dev` so the packaged versions match the lockfile exactly
+     (deterministic) and get a real, un-hoisted `node_modules` with the prod deps.
 6. Deploy with `azure/webapps-deploy@v3`:
    - `app-name: ${{ vars.AZURE_WEBAPP_NAME_API }}`
    - `publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}`
@@ -132,7 +133,10 @@ the health-check step is the automated acceptance test.
 
 ## Reproducibility note
 
-`npm install --omit=dev` in the assembled dir resolves transitive versions by semver
-range rather than strictly from the root lockfile. This matches the proven manual
-process and is acceptable here; direct deps are caret-pinned in `apps/api/package.json`.
-A stricter lockfile-pinned prune (e.g. a workspace-prune tool) is out of scope.
+The deploy install copies the repo-root `package-lock.json` into the assembled
+directory and runs `npm ci --omit=dev`, so the packaged dependency versions are the
+exact versions the lockfile pins (the same ones `npm ci` built and tested earlier in
+the job) rather than a fresh semver re-resolve. Because npm hoists workspace
+dependencies into a single lockfile, a few packages that belong to other workspaces
+(e.g. `react`) are installed too; the API never imports them, so they are inert and
+harmless under `WEBSITE_RUN_FROM_PACKAGE=1` (the package is mounted read-only).

--- a/docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md
@@ -59,9 +59,10 @@ manual workflow so there is a single source of truth.
 2. `actions/setup-node@v4` with `node-version: 22.x`, `cache: npm`.
 3. `npm ci` (root — installs all workspaces from the committed lockfile).
 4. `npm run build:api` → produces `apps/api/dist` (tsc + tsc-alias).
-5. Assemble the self-contained package in `apps/api/deploy/`:
-   - copy `apps/api/dist` → `apps/api/deploy/dist`
-   - copy `apps/api/package.json` → `apps/api/deploy/package.json`
+5. Assemble the self-contained package in `apps/api/.deploy/` (the leading dot
+   keeps it under the existing `.deploy/` `.gitignore` entry):
+   - copy `apps/api/dist` → `apps/api/.deploy/dist`
+   - copy `apps/api/package.json` → `apps/api/.deploy/package.json`
    - run `npm install --omit=dev --no-audit --no-fund` **inside** `apps/api/deploy`
      so it gets a real, un-hoisted `node_modules` with the 9 prod deps.
 6. Deploy with `azure/webapps-deploy@v3`:

--- a/docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md
@@ -1,0 +1,137 @@
+# Reliable API deploy (CI/CD) — design
+
+## Problem
+
+The API has no dependable automated deploy. The combined manual workflow
+(`.github/workflows/azure-app-service.yml`) deploys the API with
+`package: apps/api`, but `apps/api` is an npm **workspace** whose dependencies are
+**hoisted to the repo-root `node_modules`**. The deployed folder therefore has no
+real `node_modules`, so the running app crashes at startup with
+`Cannot find module '@clerk/express'` (and the other prod deps), returning 503.
+
+The proven manual workaround is to assemble a **self-contained** package
+(`dist` + `package.json` + a local `npm install --omit=dev`) and zipdeploy that.
+This design encodes that workaround as a first-class, automated workflow and adds a
+post-deploy health-check gate so a broken deploy fails loudly instead of silently
+leaving a crashed app.
+
+## Goals
+
+- A reliable, repeatable API deploy that ships all production dependencies.
+- Auto-deploy on merge to `main` when API code changes, plus manual dispatch.
+- A post-deploy smoke test that fails the run if the live API is unhealthy.
+- One canonical API deploy path (remove the divergent, broken one).
+
+## Non-goals
+
+- No change to the web deploy (`deploy-web.yml` already works) or the agent
+  (containerized via `services/agent/Dockerfile` → ACR → Container Apps).
+- No change to hosting model: the API stays on Azure App Service (code/package
+  deploy), not containers.
+- The workflow does **not** manage Azure app settings or run `az login`. It deploys
+  with a publish profile only. Required app settings are treated as preconditions.
+
+## Approach
+
+Mirror the existing `deploy-web.yml` pattern with a dedicated
+`.github/workflows/deploy-api.yml`, and remove the `api` target from the combined
+manual workflow so there is a single source of truth.
+
+### New file: `.github/workflows/deploy-api.yml`
+
+**Triggers**
+
+- `push` to `main` on paths `apps/api/**` and `.github/workflows/deploy-api.yml`.
+- `workflow_dispatch` (manual re-deploy).
+
+**Hardening / standards**
+
+- `permissions: contents: read` (least privilege).
+- `concurrency: { group: deploy-api, cancel-in-progress: false }` (no overlapping
+  deploys; a queued deploy waits rather than cancelling a publish in flight).
+- `timeout-minutes: 15` on the job.
+- Actions pinned at major version: `actions/checkout@v4`, `actions/setup-node@v4`
+  (npm cache), `azure/webapps-deploy@v3`.
+
+**Steps**
+
+1. `actions/checkout@v4`.
+2. `actions/setup-node@v4` with `node-version: 22.x`, `cache: npm`.
+3. `npm ci` (root — installs all workspaces from the committed lockfile).
+4. `npm run build:api` → produces `apps/api/dist` (tsc + tsc-alias).
+5. Assemble the self-contained package in `apps/api/deploy/`:
+   - copy `apps/api/dist` → `apps/api/deploy/dist`
+   - copy `apps/api/package.json` → `apps/api/deploy/package.json`
+   - run `npm install --omit=dev --no-audit --no-fund` **inside** `apps/api/deploy`
+     so it gets a real, un-hoisted `node_modules` with the 9 prod deps.
+6. Deploy with `azure/webapps-deploy@v3`:
+   - `app-name: ${{ vars.AZURE_WEBAPP_NAME_API }}`
+   - `publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}`
+   - `package: apps/api/deploy`
+7. Health-check gate: poll `https://${{ vars.AZURE_WEBAPP_NAME_API }}.azurewebsites.net/api/health`
+   with a bounded retry loop (e.g. up to ~12 attempts, 15s apart ≈ 3 min). Pass when
+   the response is HTTP 200 and the body contains `"mode":"postgres"`; otherwise
+   print the last response and `exit 1`.
+
+**Header comment — required preconditions (already set on `jobops-api`)**
+
+- `WEBSITE_RUN_FROM_PACKAGE=1` (package mounted read-only — avoids the B1
+  big-`node_modules` extraction hang).
+- `SCM_DO_BUILD_DURING_DEPLOYMENT=false` (no Oryx rebuild; we ship a built package).
+- App secrets / Key Vault references / conn strings already configured.
+- Repo config: var `AZURE_WEBAPP_NAME_API`, secret `AZURE_WEBAPP_PUBLISH_PROFILE_API`.
+
+### Edit: `.github/workflows/azure-app-service.yml`
+
+- Remove `api` from the `target` choice `options`.
+- Remove the `Build API` and `Deploy API` steps.
+- Add a comment pointing to `deploy-api.yml` as the canonical API deploy.
+- Leave the web and agent targets unchanged.
+
+### Docs
+
+- `docs/AZURE_DEPLOYMENT.md`: name `deploy-api.yml` as the canonical, reliable API
+  deploy; retire the "API path unreliable" caveat and the manual-zipdeploy
+  workaround note (kept only as historical context if useful).
+
+## Data flow
+
+```
+push to main (apps/api/**)  ─┐
+workflow_dispatch           ─┴─►  deploy-api.yml
+   checkout ─► npm ci ─► build:api ─► assemble apps/api/deploy
+        (dist + package.json + npm install --omit=dev)
+   ─► azure/webapps-deploy (publish profile, WEBSITE_RUN_FROM_PACKAGE=1)
+   ─► GET /api/health  ── 200 & "mode":"postgres" ──► success
+                        └─ otherwise ───────────────► fail (exit 1)
+```
+
+## Error handling
+
+- **Missing prod dep at runtime** — root cause; eliminated by the self-contained
+  `npm install --omit=dev` in the deploy dir.
+- **Bad deploy reaches production** — caught by the health-check gate; the run goes
+  red and surfaces the failing `/api/health` response.
+- **Overlapping deploys** — prevented by the concurrency group.
+- **Hung run** — bounded by `timeout-minutes` and the capped health-check retries.
+
+## Testing / verification
+
+Local (no Azure creds needed), proves the package is self-contained:
+
+1. `npm ci && npm run build:api`
+2. Assemble `apps/api/deploy` exactly as the workflow does.
+3. From `apps/api/deploy`, run `node dist/server.js` and confirm it boots without a
+   `Cannot find module` error (it will then try to bind/connect — module resolution
+   succeeding is the signal we care about).
+4. Lint the workflow YAML (`actionlint` if available; otherwise a YAML parse check).
+
+Live: triggered by merging an `apps/api/**` change to `main` (or manual dispatch);
+the health-check step is the automated acceptance test.
+
+## Reproducibility note
+
+`npm install --omit=dev` in the assembled dir resolves transitive versions by semver
+range rather than strictly from the root lockfile. This matches the proven manual
+process and is acceptable here; direct deps are caret-pinned in `apps/api/package.json`.
+A stricter lockfile-pinned prune (e.g. a workspace-prune tool) is out of scope.


### PR DESCRIPTION
## Problem
The API had no dependable automated deploy. The combined `azure-app-service.yml` deployed the API with `package: apps/api`, but `apps/api` is an npm **workspace** whose dependencies are **hoisted to the repo-root `node_modules`**. The deployed folder shipped no `node_modules`, so the app crashed at startup with `Cannot find module '@clerk/express'` → 503. Every API change forced a manual `zipdeploy`.

## Fix
A dedicated `deploy-api.yml` (mirroring `deploy-web.yml`) that assembles a **self-contained, deterministic** package and verifies the live data path before accepting the deploy.

- **Assemble** `apps/api/.deploy/` = `dist/` + `package.json` + the **repo-root `package-lock.json`**, then `npm ci --omit=dev` → real, un-hoisted `node_modules` whose versions exactly match the lockfile (`npm ci` built/tested in the same job). A `require.resolve` guard fails the job fast if any prod dep is missing.
- **Triggers:** push to `main` on `apps/api/**` (+ the workflow file) and `workflow_dispatch`.
- **Readiness gate:** polls `/api/health/ready` — a probe that runs `SELECT 1` and only returns `"db":"ok"` when Postgres is actually reachable — and fails the run otherwise. So a broken/unreachable `DATABASE_URL` fails the deploy instead of going green on a flag that only checks the var is set. Liveness `/api/health` is unchanged.
- **Hardening:** `permissions: contents: read`, `concurrency: deploy-api`, `timeout-minutes: 15`, `API_NAME` via `env:` (no script injection), actions pinned at major version.
- **Single canonical path:** removed the `api` (and now-redundant `both`) target from `azure-app-service.yml`; web + agent targets untouched.
- **Docs:** `AZURE_DEPLOYMENT.md` names the two dedicated workflows and corrects the stale `SCM_DO_BUILD_DURING_DEPLOYMENT=true` note (API uses `=false` + `WEBSITE_RUN_FROM_PACKAGE=1`).

## Code review (Codex) — both P2s addressed & resolved
- **Deterministic deps** (`5cb09f4`): switched the artifact install from a fresh `npm install` to lockfile-pinned `npm ci`. Verified the drift was real — a fresh install pulled `pg 8.21.0` vs the lockfile's `8.20.0`.
- **DB-connectivity gate** (`a0ac42b`): added the `/api/health/ready` readiness probe (`SELECT 1`) and gated the deploy on `"db":"ok"`; `computeReadiness` decision logic is unit-tested (3 new tests, suite **24/24 green**).

## Verification
- Assembly recipe proven on a real checkout: `OK: 9 prod deps resolve` (incl. `@clerk/express`); versions lockfile-exact.
- API build clean; full API test suite 24/24.
- Both workflows valid YAML; no dangling `api`/`both`/`Build API`/`Deploy API` references.

## Preconditions (already set on `jobops-api`)
`WEBSITE_RUN_FROM_PACKAGE=1`, `SCM_DO_BUILD_DURING_DEPLOYMENT=false`, DB/Clerk/App Insights secrets (or Key Vault refs); repo `vars.AZURE_WEBAPP_NAME_API` + `secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API`. Publish-profile auth only — no `az login`.

Spec: `docs/superpowers/specs/2026-06-12-reliable-api-deploy-design.md` · Plan: `docs/superpowers/plans/2026-06-12-reliable-api-deploy.md`

The live deploy runs when this merges to `main` (the `/api/health/ready` gate is the automated acceptance test); a manual `workflow_dispatch` run can validate sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)