### PR TITLE
feat(ops): cost controls — budget alerts + pause/resume

### DIFF
--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -146,3 +146,51 @@ For the first pass, keep the deployment small and auditable:
 - The Azure database layer is verified and live.
 - Full hosting for the web and API applications is still to come.
 - The repo now includes a repeatable bootstrap script so the cloud database can be recreated without manual SQL copy-paste.
+
+## Cost controls
+
+The deployment runs on an Azure for Students subscription with a $100 credit cap.
+Two local operator tools help avoid surprise spend — both act only via your own
+`az login` session, commit no secrets, and are never run from CI.
+
+### Budget alerts
+
+`scripts/azure/provision-budget.sh` creates a monthly Cost Management budget that
+**emails alerts** at 50/80/100% (actual) and 100% (forecast). It only alerts — it does
+not cap or stop anything.
+
+```bash
+az login
+scripts/azure/provision-budget.sh                                  # $30/mo, alerts to the Owner role
+BUDGET_EMAIL=you@example.com scripts/azure/provision-budget.sh      # also email a specific inbox
+```
+
+Override `BUDGET_AMOUNT` / `BUDGET_NAME` via env vars; re-running updates the same
+budget in place. Requires Cost Management Contributor or Owner on the subscription. If
+the Consumption API is unavailable for the offer, create it in the portal instead
+(Cost Management → Budgets).
+
+### Pause / resume the baseline
+
+`scripts/azure/lifecycle.sh` stops/starts the chargeable baseline for stretches when
+you are not using the stack:
+
+```bash
+scripts/azure/lifecycle.sh pause    # stop Postgres + scale the agent to zero
+scripts/azure/lifecycle.sh status   # show Postgres state + agent min-replicas
+scripts/azure/lifecycle.sh resume   # start Postgres back up
+```
+
+Caveats:
+
+- **While paused, the live site's database features do not work** — `resume` first.
+- **Azure auto-restarts a stopped Flexible Server after ~7 days** — re-run `pause` for
+  longer breaks.
+- **The App Service B1 plan (~$13/mo) keeps billing while paused.** Stopping the apps
+  does not reduce the plan charge. To go fully to ~$0 you must either downgrade the plan
+  to Free (`az appservice plan update -g projects -n jobops-plan --sku F1` — Free has
+  real limits: no always-on, reduced quotas, no custom-domain TLS) or delete the plan
+  (destructive). These are manual, opt-in steps; the script does not do them.
+
+`cool` vs `pause`: `demo.sh cool` only sleeps the agent (demo cost); `lifecycle.sh
+pause` sleeps the whole baseline (DB + agent) for longer idle periods.

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -161,13 +161,17 @@ not cap or stop anything.
 
 ```bash
 az login
-scripts/azure/provision-budget.sh                                  # $30/mo, alerts to the Owner role
-BUDGET_EMAIL=you@example.com scripts/azure/provision-budget.sh      # also email a specific inbox
+scripts/azure/provision-budget.sh                                  # $30/mo, emails your signed-in account
+BUDGET_EMAIL=you@example.com scripts/azure/provision-budget.sh      # send alerts to a specific inbox instead
 ```
 
-Override `BUDGET_AMOUNT` / `BUDGET_NAME` via env vars; re-running updates the same
-budget in place. Requires Cost Management Contributor or Owner on the subscription. If
-the Consumption API is unavailable for the offer, create it in the portal instead
+By default the alerts go to the email of your signed-in `az` account (read at runtime,
+never committed) plus the subscription Owner role; pass `BUDGET_EMAIL` to use a
+different inbox. A subscription-scope budget **requires at least one contact email**, so
+if none can be derived from your session the script asks you to set `BUDGET_EMAIL`.
+Override `BUDGET_AMOUNT` / `BUDGET_NAME` via env vars; re-running updates the same budget
+in place. Requires Cost Management Contributor or Owner on the subscription. If the
+Consumption API is unavailable for the offer, create it in the portal instead
 (Cost Management → Budgets).
 
 ### Pause / resume the baseline

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -92,6 +92,9 @@ scripts/azure/demo.sh cool       # back to scale-to-zero idle + remove the firew
 > (resource group `projects`, agent region `eastus`) and can be overridden with the
 > `RESOURCE_GROUP` / `AGENT_APP` / `WEB_APP` / `API_APP` / `PG_SERVER` env vars.
 
+> For longer idle periods (not just between demos), `scripts/azure/lifecycle.sh pause`
+> stops the database and agent too — see "Cost controls" in `docs/AZURE_DEPLOYMENT.md`.
+
 ## What to emphasize in the interview
 
 - Real, **provider-agnostic** LLM integration with structured output and a safe

--- a/docs/superpowers/plans/2026-06-12-cost-controls.md
+++ b/docs/superpowers/plans/2026-06-12-cost-controls.md
@@ -1,0 +1,508 @@
+# Cost Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a subscription cost budget (email alerts) and a `lifecycle.sh pause/resume/status` script so the JobOps deployment's spend is both alarmed and pausable.
+
+**Architecture:** Two local `az`-driven operator tools matching the existing `scripts/azure/*.sh` pattern: an ARM budget template deployed via `az deployment sub create`, and a bash lifecycle script that stops/starts Postgres + scales the agent. Pure dispatch logic is unit-tested; `az` side effects are verified live. No secrets; authority is the operator's `az login` only; never invoked by CI.
+
+**Tech Stack:** Bash, Azure CLI (`az deployment sub`, `az postgres flexible-server`, `az containerapp`), ARM template (`Microsoft.Consumption/budgets`).
+
+**Spec:** `docs/superpowers/specs/2026-06-12-cost-controls-design.md`
+
+---
+
+## File Structure
+
+- **Create** `scripts/azure/budget-template.json` — ARM template (subscription scope), one budget resource with 4 notifications.
+- **Create** `scripts/azure/provision-budget.sh` — deploys the template (start-date + params).
+- **Create** `scripts/azure/lifecycle.sh` — `pause`/`resume`/`status` for the baseline.
+- **Create** `scripts/azure/lifecycle.test.sh` — dispatch/usage unit tests (no Azure calls).
+- **Modify** `docs/AZURE_DEPLOYMENT.md` — add a "Cost controls" section.
+- **Modify** `docs/DEMO.md` — one-line pointer from the cost note to `lifecycle.sh pause`.
+
+---
+
+## Task 1: Budget template + provisioning script
+
+**Files:**
+- Create: `scripts/azure/budget-template.json`
+- Create: `scripts/azure/provision-budget.sh`
+
+- [ ] **Step 1: Create the ARM template**
+
+Create `scripts/azure/budget-template.json` with exactly:
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "budgetName": { "type": "string", "defaultValue": "jobops-monthly-30" },
+    "amount": { "type": "int", "defaultValue": 30 },
+    "startDate": { "type": "string" },
+    "contactEmails": { "type": "array", "defaultValue": [] }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Consumption/budgets",
+      "apiVersion": "2023-11-01",
+      "name": "[parameters('budgetName')]",
+      "properties": {
+        "category": "Cost",
+        "amount": "[parameters('amount')]",
+        "timeGrain": "Monthly",
+        "timePeriod": {
+          "startDate": "[parameters('startDate')]",
+          "endDate": "2035-12-31"
+        },
+        "notifications": {
+          "Actual_50": {
+            "enabled": true,
+            "operator": "GreaterThanOrEqualTo",
+            "threshold": 50,
+            "contactEmails": "[parameters('contactEmails')]",
+            "contactRoles": [ "Owner" ],
+            "thresholdType": "Actual"
+          },
+          "Actual_80": {
+            "enabled": true,
+            "operator": "GreaterThanOrEqualTo",
+            "threshold": 80,
+            "contactEmails": "[parameters('contactEmails')]",
+            "contactRoles": [ "Owner" ],
+            "thresholdType": "Actual"
+          },
+          "Actual_100": {
+            "enabled": true,
+            "operator": "GreaterThanOrEqualTo",
+            "threshold": 100,
+            "contactEmails": "[parameters('contactEmails')]",
+            "contactRoles": [ "Owner" ],
+            "thresholdType": "Actual"
+          },
+          "Forecast_100": {
+            "enabled": true,
+            "operator": "GreaterThanOrEqualTo",
+            "threshold": 100,
+            "contactEmails": "[parameters('contactEmails')]",
+            "contactRoles": [ "Owner" ],
+            "thresholdType": "Forecasted"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Validate the template is well-formed JSON**
+
+Run:
+```bash
+node -e "JSON.parse(require('fs').readFileSync('scripts/azure/budget-template.json','utf8')); console.log('budget template JSON ok')"
+```
+Expected: prints `budget template JSON ok`.
+
+- [ ] **Step 3: Create the provisioning script**
+
+Create `scripts/azure/provision-budget.sh` with exactly:
+
+```bash
+#!/usr/bin/env bash
+# Provision a monthly Cost Management budget for the JobOps subscription, with
+# alerts at 50/80/100% (actual) and 100% (forecast) to the Owner role (and an
+# optional explicit email).
+#
+# SECURITY: local operator tool — never run from CI. Authority is your own
+# `az login` session. No secrets/IDs are committed; BUDGET_EMAIL (if used) is a
+# deploy-time env var and is never written to the repo.
+#
+# Usage:
+#   scripts/azure/provision-budget.sh
+#   BUDGET_EMAIL=you@example.com BUDGET_AMOUNT=30 scripts/azure/provision-budget.sh
+set -euo pipefail
+export MSYS_NO_PATHCONV=1
+
+BUDGET_NAME="${BUDGET_NAME:-jobops-monthly-30}"
+BUDGET_AMOUNT="${BUDGET_AMOUNT:-30}"
+DEPLOY_LOCATION="${DEPLOY_LOCATION:-eastus}"
+BUDGET_EMAIL="${BUDGET_EMAIL:-}"
+
+# Fail early with a clear message if not logged in.
+az account show -o none
+
+START_DATE="$(date +%Y-%m-01)"
+
+if [[ -n "$BUDGET_EMAIL" ]]; then
+  EMAILS_JSON="[\"${BUDGET_EMAIL}\"]"
+else
+  EMAILS_JSON="[]"
+fi
+
+TEMPLATE="$(dirname "$0")/budget-template.json"
+
+echo "Deploying budget '$BUDGET_NAME' (\$$BUDGET_AMOUNT/mo, start $START_DATE) ..." >&2
+az deployment sub create \
+  --name "jobops-budget-deploy" \
+  --location "$DEPLOY_LOCATION" \
+  --template-file "$TEMPLATE" \
+  --parameters \
+      budgetName="$BUDGET_NAME" \
+      amount="$BUDGET_AMOUNT" \
+      startDate="$START_DATE" \
+      contactEmails="$EMAILS_JSON" \
+  -o none
+
+echo "Budget '$BUDGET_NAME' set: alerts at 50/80/100% (actual) + 100% (forecast)." >&2
+if [[ -n "$BUDGET_EMAIL" ]]; then
+  echo "Alerts go to: $BUDGET_EMAIL and the subscription Owner role." >&2
+else
+  echo "Alerts go to the subscription Owner role (set BUDGET_EMAIL=you@example.com to also email a specific inbox)." >&2
+fi
+```
+
+- [ ] **Step 4: Lint and make executable**
+
+Run:
+```bash
+bash -n scripts/azure/provision-budget.sh && echo "syntax ok"
+chmod +x scripts/azure/provision-budget.sh
+command -v shellcheck >/dev/null && shellcheck scripts/azure/provision-budget.sh || echo "shellcheck not installed; skipped"
+```
+Expected: `syntax ok`, then no shellcheck errors or the skip message.
+
+- [ ] **Step 5: Commit (set the executable bit in git explicitly)**
+
+```bash
+git add scripts/azure/budget-template.json
+git add --chmod=+x scripts/azure/provision-budget.sh
+git commit -m "feat(ops): subscription cost budget with email alerts (provision-budget.sh)"
+```
+
+---
+
+## Task 2: `lifecycle.sh` pause/resume/status + unit tests (TDD)
+
+**Files:**
+- Create: `scripts/azure/lifecycle.test.sh`
+- Create: `scripts/azure/lifecycle.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/azure/lifecycle.test.sh` with exactly:
+
+```bash
+#!/usr/bin/env bash
+# Unit tests for lifecycle.sh dispatch/usage (no Azure calls).
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Source without running main() — lifecycle.sh guards main behind a BASH_SOURCE check.
+# shellcheck source=/dev/null
+source "$DIR/lifecycle.sh"
+set +e  # lifecycle.sh enables -e; disable it so assertions can observe failures.
+
+fail=0
+bash "$DIR/lifecycle.sh" >/dev/null 2>&1; [ "$?" -eq 2 ] && echo "ok: no-arg exits 2" || { echo "FAIL: no-arg exit code"; fail=1; }
+bash "$DIR/lifecycle.sh" bogus >/dev/null 2>&1; [ "$?" -eq 1 ] && echo "ok: bad subcommand exits 1" || { echo "FAIL: bad subcommand exit code"; fail=1; }
+bash "$DIR/lifecycle.sh" --help >/dev/null 2>&1; [ "$?" -eq 0 ] && echo "ok: --help exits 0" || { echo "FAIL: --help exit code"; fail=1; }
+
+help_out="$(bash "$DIR/lifecycle.sh" --help 2>&1)"
+for sub in pause resume status; do
+  printf '%s' "$help_out" | grep -q "$sub" && echo "ok: help mentions $sub" || { echo "FAIL: help missing $sub"; fail=1; }
+done
+
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi
+```
+
+- [ ] **Step 2: Run it, confirm it FAILS**
+
+Run: `bash scripts/azure/lifecycle.test.sh`
+Expected: FAIL — `source` errors because `scripts/azure/lifecycle.sh` does not exist yet.
+
+- [ ] **Step 3: Create `scripts/azure/lifecycle.sh`**
+
+Create `scripts/azure/lifecycle.sh` with exactly:
+
+```bash
+#!/usr/bin/env bash
+#
+# lifecycle.sh — pause/resume the chargeable JobOps baseline (Postgres + agent).
+#
+# SECURITY / SAFETY
+#   - LOCAL OPERATOR TOOL. Never invoke from CI or automation that holds stored
+#     cloud credentials. All authority comes from your own `az login` session.
+#   - No secrets/IDs — only non-secret resource names (overridable via env vars).
+#
+# Usage:
+#   scripts/azure/lifecycle.sh pause    # stop Postgres + scale agent to zero
+#   scripts/azure/lifecycle.sh resume   # start Postgres back up
+#   scripts/azure/lifecycle.sh status   # read-only: DB state + agent min-replicas
+#
+set -euo pipefail
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-projects}"
+AGENT_APP="${AGENT_APP:-jobops-agent}"
+PG_RESOURCE_GROUP="${PG_RESOURCE_GROUP:-projects}"
+PG_SERVER="${PG_SERVER:-jobops}"
+
+log()  { printf '\033[1;34m[lifecycle]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[lifecycle]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[lifecycle]\033[0m %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: lifecycle.sh <pause|resume|status>
+
+  pause    Stop the Postgres server and scale the agent to min-replicas=0.
+  resume   Start the Postgres server back up.
+  status   Read-only: show the Postgres state and the agent's min-replicas.
+
+Resource names default to the live deployment and can be overridden via env vars:
+RESOURCE_GROUP, AGENT_APP, PG_RESOURCE_GROUP, PG_SERVER.
+EOF
+}
+
+require_tools() {
+  command -v az >/dev/null 2>&1 || die "Azure CLI 'az' not found. Install: https://aka.ms/azcli"
+}
+
+require_login() {
+  az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run: az login"
+}
+
+preflight() { require_tools; require_login; }
+
+# Run an az command, tolerating ONLY errors whose message matches $2 (regex);
+# die loudly on any other failure so a partial failure is never reported as success.
+#   $1 = human label, $2 = tolerate-regex, $3.. = command to run
+run_tolerating() {
+  local label="$1" tolerate="$2"; shift 2
+  local err
+  if err="$("$@" 2>&1)"; then
+    return 0
+  elif printf '%s' "$err" | grep -qiE "$tolerate"; then
+    warn "$label: already in the desired state (tolerated)."
+    return 0
+  else
+    die "$label failed: $err"
+  fi
+}
+
+cmd_pause() {
+  preflight
+  log "stopping Postgres server '$PG_SERVER' ..."
+  run_tolerating "stop Postgres" 'already.*stopp|not.*running|current state.*stopp' \
+    az postgres flexible-server stop -g "$PG_RESOURCE_GROUP" -n "$PG_SERVER"
+  log "scaling agent '$AGENT_APP' to min-replicas=0 ..."
+  az containerapp update -g "$RESOURCE_GROUP" -n "$AGENT_APP" --min-replicas 0 -o none \
+    || die "failed to scale down the agent."
+  log "PAUSED: Postgres stopped, agent scaled to zero."
+  warn "While paused, the live site's DB features will not work — run 'resume' before using/demoing it."
+  warn "Azure auto-restarts a stopped Flexible Server after ~7 days; re-run 'pause' for longer stretches."
+  warn "The App Service B1 plan (~\$13/mo) keeps billing while paused — see docs/AZURE_DEPLOYMENT.md to go fully to ~\$0."
+}
+
+cmd_resume() {
+  preflight
+  log "starting Postgres server '$PG_SERVER' ..."
+  run_tolerating "start Postgres" 'already.*runn|not.*stopp|current state.*ready' \
+    az postgres flexible-server start -g "$PG_RESOURCE_GROUP" -n "$PG_SERVER"
+  log "RESUMED: Postgres is starting (it can take a few minutes to accept connections)."
+  log "The agent stays scale-to-zero; it warms on first request, or run 'demo.sh warm' before a demo."
+}
+
+cmd_status() {
+  preflight
+  local pg_state min_replicas
+  pg_state="$(az postgres flexible-server show -g "$PG_RESOURCE_GROUP" -n "$PG_SERVER" --query state -o tsv 2>/dev/null)" \
+    || pg_state="(unknown — check name/login)"
+  min_replicas="$(az containerapp show -g "$RESOURCE_GROUP" -n "$AGENT_APP" --query properties.template.scale.minReplicas -o tsv 2>/dev/null)" \
+    || min_replicas="(unknown — check name/login)"
+  log "Postgres '$PG_SERVER' state   : ${pg_state}"
+  log "agent '$AGENT_APP' minReplicas : ${min_replicas:-0}"
+}
+
+main() {
+  case "${1:-}" in
+    pause)  cmd_pause ;;
+    resume) cmd_resume ;;
+    status) cmd_status ;;
+    -h|--help|help) usage ;;
+    "")     usage; exit 2 ;;
+    *)      usage; die "unknown subcommand: ${1}" ;;
+  esac
+}
+
+# Only run main when executed directly, so the test can source pure helpers.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi
+```
+
+- [ ] **Step 4: Make both executable**
+
+Run: `chmod +x scripts/azure/lifecycle.sh scripts/azure/lifecycle.test.sh`
+
+- [ ] **Step 5: Run the test, confirm it PASSES**
+
+Run: `bash scripts/azure/lifecycle.test.sh`
+Expected: every line `ok: ...` and final `ALL PASS`. If anything fails, fix the script (not the test) and re-run.
+
+- [ ] **Step 6: Lint**
+
+Run:
+```bash
+bash -n scripts/azure/lifecycle.sh && echo "syntax ok"
+command -v shellcheck >/dev/null && shellcheck scripts/azure/lifecycle.sh || echo "shellcheck not installed; skipped"
+```
+Expected: `syntax ok`, then no shellcheck errors or the skip message. If shellcheck flags issues, fix and re-run the unit test.
+
+- [ ] **Step 7: Commit (executable bit in git)**
+
+```bash
+git add --chmod=+x scripts/azure/lifecycle.sh scripts/azure/lifecycle.test.sh
+git commit -m "feat(ops): lifecycle.sh pause/resume/status for the chargeable baseline"
+```
+
+---
+
+## Task 3: Docs
+
+**Files:**
+- Modify: `docs/AZURE_DEPLOYMENT.md`
+- Modify: `docs/DEMO.md`
+
+- [ ] **Step 1: Append a "Cost controls" section to `docs/AZURE_DEPLOYMENT.md`**
+
+Append the following to the END of `docs/AZURE_DEPLOYMENT.md` (after the last line):
+
+````markdown
+
+## Cost controls
+
+The deployment runs on an Azure for Students subscription with a $100 credit cap.
+Two local operator tools help avoid surprise spend — both act only via your own
+`az login` session, commit no secrets, and are never run from CI.
+
+### Budget alerts
+
+`scripts/azure/provision-budget.sh` creates a monthly Cost Management budget that
+**emails alerts** at 50/80/100% (actual) and 100% (forecast). It only alerts — it does
+not cap or stop anything.
+
+```bash
+az login
+scripts/azure/provision-budget.sh                                  # $30/mo, alerts to the Owner role
+BUDGET_EMAIL=you@example.com scripts/azure/provision-budget.sh      # also email a specific inbox
+```
+
+Override `BUDGET_AMOUNT` / `BUDGET_NAME` via env vars; re-running updates the same
+budget in place. Requires Cost Management Contributor or Owner on the subscription. If
+the Consumption API is unavailable for the offer, create it in the portal instead
+(Cost Management → Budgets).
+
+### Pause / resume the baseline
+
+`scripts/azure/lifecycle.sh` stops/starts the chargeable baseline for stretches when
+you are not using the stack:
+
+```bash
+scripts/azure/lifecycle.sh pause    # stop Postgres + scale the agent to zero
+scripts/azure/lifecycle.sh status   # show Postgres state + agent min-replicas
+scripts/azure/lifecycle.sh resume   # start Postgres back up
+```
+
+Caveats:
+
+- **While paused, the live site's database features do not work** — `resume` first.
+- **Azure auto-restarts a stopped Flexible Server after ~7 days** — re-run `pause` for
+  longer breaks.
+- **The App Service B1 plan (~$13/mo) keeps billing while paused.** Stopping the apps
+  does not reduce the plan charge. To go fully to ~$0 you must either downgrade the plan
+  to Free (`az appservice plan update -g projects -n jobops-plan --sku F1` — Free has
+  real limits: no always-on, reduced quotas, no custom-domain TLS) or delete the plan
+  (destructive). These are manual, opt-in steps; the script does not do them.
+
+`cool` vs `pause`: `demo.sh cool` only sleeps the agent (demo cost); `lifecycle.sh
+pause` sleeps the whole baseline (DB + agent) for longer idle periods.
+````
+
+- [ ] **Step 2: Add a pointer in `docs/DEMO.md`**
+
+In `docs/DEMO.md`, find the cost blockquote in the "Live cloud demo" section that
+begins `> **Cost:** the agent at `min-replicas=1` bills`. Immediately after that
+blockquote's closing line (the line ending `... env vars.`), insert this new line:
+
+```markdown
+
+> For longer idle periods (not just between demos), `scripts/azure/lifecycle.sh pause`
+> stops the database and agent too — see "Cost controls" in `docs/AZURE_DEPLOYMENT.md`.
+```
+
+- [ ] **Step 3: Verify the docs edits + security guard**
+
+Run:
+```bash
+grep -q "## Cost controls" docs/AZURE_DEPLOYMENT.md && echo "azure docs ok"
+grep -q "lifecycle.sh pause" docs/DEMO.md && echo "demo docs ok"
+grep -rl -e "provision-budget.sh" -e "lifecycle.sh" .github/workflows/ && echo "FAIL: workflow references a cost script" || echo "ok: no workflow references the cost scripts"
+```
+Expected: `azure docs ok`, `demo docs ok`, `ok: no workflow references the cost scripts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/AZURE_DEPLOYMENT.md docs/DEMO.md
+git commit -m "docs: cost controls section (budget + pause/resume) and DEMO pointer"
+```
+
+---
+
+## Task 4: Final verification + open the PR
+
+**Files:** none.
+
+- [ ] **Step 1: Re-run all local verification**
+
+Run:
+```bash
+node -e "JSON.parse(require('fs').readFileSync('scripts/azure/budget-template.json','utf8')); console.log('json ok')"
+bash -n scripts/azure/provision-budget.sh && bash -n scripts/azure/lifecycle.sh && echo "syntax ok"
+bash scripts/azure/lifecycle.test.sh | tail -1
+git ls-files -s scripts/azure/provision-budget.sh scripts/azure/lifecycle.sh scripts/azure/lifecycle.test.sh
+```
+Expected: `json ok`, `syntax ok`, `ALL PASS`, and all three `.sh` files show mode `100755`.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin cost-controls
+```
+
+- [ ] **Step 3: Open the PR (do not merge)**
+
+```bash
+gh pr create --title "feat(ops): cost controls — budget alerts + pause/resume" --body "<summary: scripts/azure/provision-budget.sh deploys a \$30/mo subscription budget (alerts 50/80/100% actual + 100% forecast, Owner role + optional BUDGET_EMAIL, no email committed); scripts/azure/lifecycle.sh pause/resume/status stops/starts Postgres + scales the agent to zero, tolerating only the already-stopped/running case and failing loudly otherwise; docs cover the App Service caveat (manual F1 downgrade/delete). Security: local tools, az-login-only, no secrets, never in CI (guard-checked). Tests: budget template JSON parse, lifecycle dispatch unit tests, bash -n.>"
+```
+Expected: PR URL printed. Do **not** merge — the maintainer merges. Live verification
+(`provision-budget.sh`; `lifecycle.sh status`/`pause`/`resume`) needs `az login`.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Component A (budget) ↔ Task 1 (template + script, subscription scope,
+  4 notifications, Owner-role + optional `BUDGET_EMAIL`, idempotent); Component B
+  (pause/resume) ↔ Task 2 (`lifecycle.sh` stop Postgres + agent min=0 / start Postgres /
+  read-only status, tolerate-specific-error pattern, BASH_SOURCE guard, dispatch tests);
+  Docs ↔ Task 3 (Cost controls section incl. the three caveats + App Service manual step,
+  DEMO pointer, `cool` vs `pause`); Security ↔ no-CI grep (Task 3) + header comments +
+  env-only email; Testing ↔ JSON parse + `bash -n` + dispatch tests + no-CI grep (Tasks 1–4).
+- **No placeholders:** all template, script, test, and docs content is given in full.
+- **Name consistency:** `jobops-monthly-30`, `BUDGET_EMAIL`/`BUDGET_AMOUNT`/`BUDGET_NAME`,
+  `run_tolerating`, `cmd_pause/resume/status`, resource defaults (`projects`/`jobops`/
+  `jobops-agent`) are identical across the script, tests, and docs.
+- **Exec bit:** `git add --chmod=+x` sets `100755` directly (Windows `chmod` alone does not
+  write the git index — learned on PR #33).

--- a/docs/superpowers/specs/2026-06-12-cost-controls-design.md
+++ b/docs/superpowers/specs/2026-06-12-cost-controls-design.md
@@ -62,17 +62,21 @@ Subscription-scoped ARM template (schema
   (`thresholdType: Actual`) and `Forecast_100` (`thresholdType: Forecasted`). Each:
   `enabled: true`, `operator: GreaterThanOrEqualTo`, `threshold: <pct>`,
   `contactRoles: ["Owner"]`, `contactEmails: [contactEmails]`.
-- Because every notification has `contactRoles: ["Owner"]`, the budget is valid with an
-  **empty** `contactEmails` — so no email need ever be committed.
+- A subscription-scope budget **requires at least one `contactEmails`** entry
+  (`contactRoles` alone is rejected by the `Microsoft.Consumption/budgets` schema). The
+  script therefore defaults `contactEmails` to the signed-in operator's own email
+  (read at runtime from `az account show --query user.name`, never committed), overridable
+  via `BUDGET_EMAIL`; `contactRoles: ["Owner"]` is kept as an additional recipient.
 
 ### Script (`provision-budget.sh`)
 
 - `set -euo pipefail`; `export MSYS_NO_PATHCONV=1`; `az account show -o none` preflight
   (matches `provision-appinsights.sh`).
 - Env overrides: `BUDGET_NAME` (default `jobops-monthly-30`), `BUDGET_AMOUNT` (default
-  `30`), `BUDGET_EMAIL` (optional; if set, passed as a one-element `contactEmails`
-  array; if unset, `contactEmails=[]` and alerts go to the Owner role only),
-  `DEPLOY_LOCATION` (default `eastus`, only deployment metadata).
+  `30`), `BUDGET_EMAIL` (recipient; defaults to the signed-in account's email from
+  `az account show --query user.name`, validated to look like an email; the script
+  errors asking for `BUDGET_EMAIL` if none can be derived), `DEPLOY_LOCATION` (default
+  `eastus`, only deployment metadata).
 - Compute `START_DATE` = first day of the current month (`date +%Y-%m-01`).
 - Deploy:
   `az deployment sub create --name jobops-budget-deploy --location "$DEPLOY_LOCATION"

--- a/docs/superpowers/specs/2026-06-12-cost-controls-design.md
+++ b/docs/superpowers/specs/2026-06-12-cost-controls-design.md
@@ -1,0 +1,182 @@
+# Cost controls (budget guardrail + pause/resume) — design
+
+## Problem
+
+The deployment runs on an **Azure for Students** subscription with a hard **$100
+credit cap**. Two gaps make it easy to burn credit unintentionally:
+
+1. **No alarm.** Nothing warns when spending climbs — e.g. a forgotten warmed agent
+   (`demo.sh warm`, ~$20–30/mo) or any anomaly silently eats credit.
+2. **No off switch for the baseline.** Even fully idle, the always-on App Service B1
+   plan (~$13/mo) and the Postgres server keep billing. There is no easy, safe way to
+   put the stack to sleep during stretches when it is not used or demoed.
+
+This delivers two small, cohesive cost controls: a **budget that emails alerts**, and a
+**`pause`/`resume`** lifecycle script that safely stops/starts the chargeable baseline.
+
+## Goals
+
+- A monthly cost budget ($30) that emails alerts at 50/80/100% (actual) and 100%
+  (forecast), created reproducibly from a committed template.
+- A safe, reversible `pause` that stops the biggest clearly-stoppable baseline cost
+  (Postgres) and ensures the agent is scaled to zero; a `resume` that brings it back;
+  a read-only `status`.
+- Honest docs about what each control does and does **not** stop.
+- Safe to commit: no secrets, authority only via the operator's `az login`.
+
+## Non-goals
+
+- No automatic downgrade/deletion of the App Service plan (risky; F1 has real limits,
+  delete is destructive). Documented as an optional manual step, not scripted.
+- No change to app code, deploy workflows, or `demo.sh` (`warm`/`cool` stay as-is;
+  `pause`/`resume` are the heavier baseline-level siblings).
+- No spending *cap/enforcement* — Azure budgets only alert; they do not stop services.
+
+## Deployment targets (real, env-overridable)
+
+- Subscription: "Azure for Students" (budget is subscription-scoped).
+- Resource group **`projects`**; Postgres Flexible Server **`jobops`**; Container App
+  **`jobops-agent`**.
+
+---
+
+## Component A — Budget guardrail
+
+### Files
+
+- `scripts/azure/budget-template.json` — ARM template, **subscription deployment scope**,
+  one `Microsoft.Consumption/budgets` resource.
+- `scripts/azure/provision-budget.sh` — computes the start date and deploys the template.
+
+### Template (`budget-template.json`)
+
+Subscription-scoped ARM template (schema
+`subscriptionDeploymentTemplate.json`). Parameters: `budgetName` (default
+`jobops-monthly-30`), `amount` (default `30`), `startDate` (string, first of a month),
+`contactEmails` (array, default `[]`). One resource:
+
+- `type: Microsoft.Consumption/budgets`, `apiVersion: 2023-11-01`.
+- `properties.category: Cost`, `amount: [amount]`, `timeGrain: Monthly`,
+  `timePeriod: { startDate: [startDate], endDate: "2035-12-31" }`.
+- `notifications` (4): `Actual_50`, `Actual_80`, `Actual_100`
+  (`thresholdType: Actual`) and `Forecast_100` (`thresholdType: Forecasted`). Each:
+  `enabled: true`, `operator: GreaterThanOrEqualTo`, `threshold: <pct>`,
+  `contactRoles: ["Owner"]`, `contactEmails: [contactEmails]`.
+- Because every notification has `contactRoles: ["Owner"]`, the budget is valid with an
+  **empty** `contactEmails` — so no email need ever be committed.
+
+### Script (`provision-budget.sh`)
+
+- `set -euo pipefail`; `export MSYS_NO_PATHCONV=1`; `az account show -o none` preflight
+  (matches `provision-appinsights.sh`).
+- Env overrides: `BUDGET_NAME` (default `jobops-monthly-30`), `BUDGET_AMOUNT` (default
+  `30`), `BUDGET_EMAIL` (optional; if set, passed as a one-element `contactEmails`
+  array; if unset, `contactEmails=[]` and alerts go to the Owner role only),
+  `DEPLOY_LOCATION` (default `eastus`, only deployment metadata).
+- Compute `START_DATE` = first day of the current month (`date +%Y-%m-01`).
+- Deploy:
+  `az deployment sub create --name jobops-budget-deploy --location "$DEPLOY_LOCATION"
+   --template-file "$(dirname "$0")/budget-template.json"
+   --parameters budgetName="$BUDGET_NAME" amount="$BUDGET_AMOUNT" startDate="$START_DATE" contactEmails="$EMAILS_JSON"`
+  where `EMAILS_JSON` is `["$BUDGET_EMAIL"]` when set, else `[]`.
+- Idempotent: the budget is keyed by name; re-deploying updates it in place.
+- On success, print the budget name, amount, thresholds, and where alerts go.
+
+### Preconditions
+
+- The deployer needs **Cost Management Contributor** or **Owner** on the subscription to
+  create a budget. Documented; the script surfaces the permission error if missing.
+- Azure for Students supports Cost Management budgets. If the Consumption API is ever
+  rejected for the offer, the fallback is the portal (Cost Management → Budgets),
+  noted in the docs.
+
+---
+
+## Component B — Lifecycle pause/resume
+
+### Files
+
+- `scripts/azure/lifecycle.sh` — `pause` | `resume` | `status` subcommands.
+- `scripts/azure/lifecycle.test.sh` — unit tests for usage/dispatch (no Azure calls).
+
+### Behavior
+
+Config (env-overridable, real defaults): `RESOURCE_GROUP=projects`,
+`AGENT_APP=jobops-agent`, `PG_RESOURCE_GROUP=projects`, `PG_SERVER=jobops`. Shared
+`log`/`warn`/`die` helpers, `preflight` (require `az`; `az account show`), and a
+`BASH_SOURCE` guard so tests can source pure helpers — same conventions as `demo.sh`.
+
+- **`pause`**
+  1. `az postgres flexible-server stop -g $PG_RESOURCE_GROUP -n $PG_SERVER` — tolerate
+     only the already-stopped case; fail loudly on any other error (same
+     tolerate-specific-error pattern as `demo.sh cool`).
+  2. `az containerapp update -g $RESOURCE_GROUP -n $AGENT_APP --min-replicas 0` — ensure
+     the agent is scaled to zero.
+  3. Print what is now asleep (DB + agent) and the two caveats below.
+- **`resume`**
+  1. `az postgres flexible-server start -g $PG_RESOURCE_GROUP -n $PG_SERVER` — tolerate
+     only the already-running case; fail loudly otherwise.
+  2. Print that the DB is starting (takes a few minutes) and that the agent warms on
+     demand (or via `demo.sh warm` before a demo).
+- **`status`** (read-only)
+  - Postgres state: `az postgres flexible-server show ... --query state -o tsv`.
+  - Agent min replicas: `az containerapp show ... --query properties.template.scale.minReplicas -o tsv`.
+  - Print a per-resource line; make no changes.
+
+### Caveats (documented + printed by `pause`)
+
+1. **While paused the live site's DB features fail** — pause only when the stack is not
+   in use/being demoed; `resume` restores it.
+2. **A stopped Flexible Server auto-restarts after 7 days** (Azure behavior) — re-run
+   `pause` for longer stretches.
+3. **The App Service B1 plan (~$13/mo) keeps billing** even when paused — stopping the
+   *apps* does not reduce the *plan* charge. Fully zeroing it requires downgrading the
+   plan tier to F1 or deleting it; both have real downsides, so they are a documented
+   manual option, not scripted.
+
+---
+
+## Docs
+
+Add a "Cost controls" section to `docs/AZURE_DEPLOYMENT.md`:
+- The budget: what it alerts on, how to (re)create it (`provision-budget.sh`, optional
+  `BUDGET_EMAIL`), and that it only alerts.
+- `lifecycle.sh pause|resume|status`: what each does, the three caveats, and the
+  optional manual App Service downgrade/delete for going fully to ~$0.
+- A one-line pointer in `docs/DEMO.md` near the existing cost note linking to the budget
+  + `cool`/`pause` distinction (cool = agent only; pause = whole baseline).
+
+## Security
+
+Same model as `demo.sh` (PR #33): local operator tools, no secrets or IDs committed
+(only non-secret resource names), authority solely from the operator's `az login`
+session, never invoked by CI. `BUDGET_EMAIL` is a deploy-time env var, never committed.
+
+## Error handling
+
+- Preflight fails clearly if `az` is missing or the session is unauthenticated.
+- Budget deploy surfaces template/permission errors (e.g. missing Cost Management role).
+- `pause`/`resume` tolerate only the expected idempotent state (already
+  stopped/running) and `die` loudly on any other `az` error, so a partial failure is
+  never reported as success.
+
+## Testing / verification
+
+- `node -e "JSON.parse(require('fs').readFileSync('scripts/azure/budget-template.json','utf8'))"`
+  to confirm the template is valid JSON.
+- `bash -n` on both scripts; `shellcheck` if available.
+- `bash scripts/azure/lifecycle.test.sh` — usage/dispatch unit tests (no-arg → exit 2,
+  bad subcommand → exit 1, `--help` → exit 0).
+- `grep` guard: no workflow under `.github/workflows/` references either new script.
+- Live (maintainer, needs `az login`): `provision-budget.sh` then `az consumption budget
+  list`; `lifecycle.sh status` → `pause` → `status` (DB Stopped) → `resume` → `status`
+  (DB Ready).
+
+## Files (summary)
+
+- **Create** `scripts/azure/budget-template.json`
+- **Create** `scripts/azure/provision-budget.sh`
+- **Create** `scripts/azure/lifecycle.sh`
+- **Create** `scripts/azure/lifecycle.test.sh`
+- **Modify** `docs/AZURE_DEPLOYMENT.md` (Cost controls section)
+- **Modify** `docs/DEMO.md` (one-line cost pointer)

--- a/scripts/azure/budget-template.json
+++ b/scripts/azure/budget-template.json
@@ -5,7 +5,7 @@
     "budgetName": { "type": "string", "defaultValue": "jobops-monthly-30" },
     "amount": { "type": "int", "defaultValue": 30 },
     "startDate": { "type": "string" },
-    "contactEmails": { "type": "array", "defaultValue": [] }
+    "contactEmails": { "type": "array" }
   },
   "resources": [
     {

--- a/scripts/azure/budget-template.json
+++ b/scripts/azure/budget-template.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "budgetName": { "type": "string", "defaultValue": "jobops-monthly-30" },
+    "amount": { "type": "int", "defaultValue": 30 },
+    "startDate": { "type": "string" },
+    "contactEmails": { "type": "array", "defaultValue": [] }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Consumption/budgets",
+      "apiVersion": "2023-11-01",
+      "name": "[parameters('budgetName')]",
+      "properties": {
+        "category": "Cost",
+        "amount": "[parameters('amount')]",
+        "timeGrain": "Monthly",
+        "timePeriod": {
+          "startDate": "[parameters('startDate')]",
+          "endDate": "2035-12-31"
+        },
+        "notifications": {
+          "Actual_50": {
+            "enabled": true,
+            "operator": "GreaterThanOrEqualTo",
+            "threshold": 50,
+            "contactEmails": "[parameters('contactEmails')]",
+            "contactRoles": [ "Owner" ],
+            "thresholdType": "Actual"
+          },
+          "Actual_80": {
+            "enabled": true,
+            "operator": "GreaterThanOrEqualTo",
+            "threshold": 80,
+            "contactEmails": "[parameters('contactEmails')]",
+            "contactRoles": [ "Owner" ],
+            "thresholdType": "Actual"
+          },
+          "Actual_100": {
+            "enabled": true,
+            "operator": "GreaterThanOrEqualTo",
+            "threshold": 100,
+            "contactEmails": "[parameters('contactEmails')]",
+            "contactRoles": [ "Owner" ],
+            "thresholdType": "Actual"
+          },
+          "Forecast_100": {
+            "enabled": true,
+            "operator": "GreaterThanOrEqualTo",
+            "threshold": 100,
+            "contactEmails": "[parameters('contactEmails')]",
+            "contactRoles": [ "Owner" ],
+            "thresholdType": "Forecasted"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/scripts/azure/lifecycle.sh
+++ b/scripts/azure/lifecycle.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# lifecycle.sh — pause/resume the chargeable JobOps baseline (Postgres + agent).
+#
+# SECURITY / SAFETY
+#   - LOCAL OPERATOR TOOL. Never invoke from CI or automation that holds stored
+#     cloud credentials. All authority comes from your own `az login` session.
+#   - No secrets/IDs — only non-secret resource names (overridable via env vars).
+#
+# Usage:
+#   scripts/azure/lifecycle.sh pause    # stop Postgres + scale agent to zero
+#   scripts/azure/lifecycle.sh resume   # start Postgres back up
+#   scripts/azure/lifecycle.sh status   # read-only: DB state + agent min-replicas
+#
+set -euo pipefail
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-projects}"
+AGENT_APP="${AGENT_APP:-jobops-agent}"
+PG_RESOURCE_GROUP="${PG_RESOURCE_GROUP:-projects}"
+PG_SERVER="${PG_SERVER:-jobops}"
+
+log()  { printf '\033[1;34m[lifecycle]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[lifecycle]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[lifecycle]\033[0m %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: lifecycle.sh <pause|resume|status>
+
+  pause    Stop the Postgres server and scale the agent to min-replicas=0.
+  resume   Start the Postgres server back up.
+  status   Read-only: show the Postgres state and the agent's min-replicas.
+
+Resource names default to the live deployment and can be overridden via env vars:
+RESOURCE_GROUP, AGENT_APP, PG_RESOURCE_GROUP, PG_SERVER.
+EOF
+}
+
+require_tools() {
+  command -v az >/dev/null 2>&1 || die "Azure CLI 'az' not found. Install: https://aka.ms/azcli"
+}
+
+require_login() {
+  az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run: az login"
+}
+
+preflight() { require_tools; require_login; }
+
+# Run an az command, tolerating ONLY errors whose message matches $2 (regex);
+# die loudly on any other failure so a partial failure is never reported as success.
+#   $1 = human label, $2 = tolerate-regex, $3.. = command to run
+run_tolerating() {
+  local label="$1" tolerate="$2"; shift 2
+  local err
+  if err="$("$@" 2>&1)"; then
+    return 0
+  elif printf '%s' "$err" | grep -qiE "$tolerate"; then
+    warn "$label: already in the desired state (tolerated)."
+    return 0
+  else
+    die "$label failed: $err"
+  fi
+}
+
+cmd_pause() {
+  preflight
+  log "stopping Postgres server '$PG_SERVER' ..."
+  run_tolerating "stop Postgres" 'already.*stopp|not.*running|current state.*stopp' \
+    az postgres flexible-server stop -g "$PG_RESOURCE_GROUP" -n "$PG_SERVER"
+  log "scaling agent '$AGENT_APP' to min-replicas=0 ..."
+  az containerapp update -g "$RESOURCE_GROUP" -n "$AGENT_APP" --min-replicas 0 -o none \
+    || die "failed to scale down the agent."
+  log "PAUSED: Postgres stopped, agent scaled to zero."
+  warn "While paused, the live site's DB features will not work — run 'resume' before using/demoing it."
+  warn "Azure auto-restarts a stopped Flexible Server after ~7 days; re-run 'pause' for longer stretches."
+  warn "The App Service B1 plan (~\$13/mo) keeps billing while paused — see docs/AZURE_DEPLOYMENT.md to go fully to ~\$0."
+}
+
+cmd_resume() {
+  preflight
+  log "starting Postgres server '$PG_SERVER' ..."
+  run_tolerating "start Postgres" 'already.*runn|not.*stopp|current state.*ready' \
+    az postgres flexible-server start -g "$PG_RESOURCE_GROUP" -n "$PG_SERVER"
+  log "RESUMED: Postgres is starting (it can take a few minutes to accept connections)."
+  log "The agent stays scale-to-zero; it warms on first request, or run 'demo.sh warm' before a demo."
+}
+
+cmd_status() {
+  preflight
+  local pg_state min_replicas
+  pg_state="$(az postgres flexible-server show -g "$PG_RESOURCE_GROUP" -n "$PG_SERVER" --query state -o tsv 2>/dev/null)" \
+    || pg_state="(unknown — check name/login)"
+  min_replicas="$(az containerapp show -g "$RESOURCE_GROUP" -n "$AGENT_APP" --query properties.template.scale.minReplicas -o tsv 2>/dev/null)" \
+    || min_replicas="(unknown — check name/login)"
+  log "Postgres '$PG_SERVER' state   : ${pg_state}"
+  log "agent '$AGENT_APP' minReplicas : ${min_replicas:-0}"
+}
+
+main() {
+  case "${1:-}" in
+    pause)  cmd_pause ;;
+    resume) cmd_resume ;;
+    status) cmd_status ;;
+    -h|--help|help) usage ;;
+    "")     usage; exit 2 ;;
+    *)      usage; die "unknown subcommand: ${1}" ;;
+  esac
+}
+
+# Only run main when executed directly, so the test can source pure helpers.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/azure/lifecycle.test.sh
+++ b/scripts/azure/lifecycle.test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Unit tests for lifecycle.sh dispatch/usage (no Azure calls).
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Source without running main() — lifecycle.sh guards main behind a BASH_SOURCE check.
+# shellcheck source=/dev/null
+source "$DIR/lifecycle.sh"
+set +e  # lifecycle.sh enables -e; disable it so assertions can observe failures.
+
+fail=0
+bash "$DIR/lifecycle.sh" >/dev/null 2>&1; [ "$?" -eq 2 ] && echo "ok: no-arg exits 2" || { echo "FAIL: no-arg exit code"; fail=1; }
+bash "$DIR/lifecycle.sh" bogus >/dev/null 2>&1; [ "$?" -eq 1 ] && echo "ok: bad subcommand exits 1" || { echo "FAIL: bad subcommand exit code"; fail=1; }
+bash "$DIR/lifecycle.sh" --help >/dev/null 2>&1; [ "$?" -eq 0 ] && echo "ok: --help exits 0" || { echo "FAIL: --help exit code"; fail=1; }
+
+help_out="$(bash "$DIR/lifecycle.sh" --help 2>&1)"
+for sub in pause resume status; do
+  printf '%s' "$help_out" | grep -q "$sub" && echo "ok: help mentions $sub" || { echo "FAIL: help missing $sub"; fail=1; }
+done
+
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi

--- a/scripts/azure/provision-budget.sh
+++ b/scripts/azure/provision-budget.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # Provision a monthly Cost Management budget for the JobOps subscription, with
-# alerts at 50/80/100% (actual) and 100% (forecast) to the Owner role (and an
-# optional explicit email).
+# alerts at 50/80/100% (actual) and 100% (forecast). Subscription-scope budget
+# notifications REQUIRE at least one contact email (contactRoles alone is rejected
+# by the Microsoft.Consumption/budgets schema), so by default we use the signed-in
+# operator's own email (read at runtime, never committed) and also notify the
+# Owner role. Override the recipient with BUDGET_EMAIL.
 #
 # SECURITY: local operator tool — never run from CI. Authority is your own
-# `az login` session. No secrets/IDs are committed; BUDGET_EMAIL (if used) is a
-# deploy-time env var and is never written to the repo.
+# `az login` session. No secrets/IDs are committed; the contact email is read from
+# your live `az` session (or BUDGET_EMAIL) at deploy time and never written to the repo.
 #
 # Usage:
 #   scripts/azure/provision-budget.sh
@@ -23,11 +26,17 @@ az account show -o none
 
 START_DATE="$(date +%Y-%m-01)"
 
-if [[ -n "$BUDGET_EMAIL" ]]; then
-  EMAILS_JSON="[\"${BUDGET_EMAIL}\"]"
-else
-  EMAILS_JSON="[]"
+# A subscription-scope budget requires at least one contact email. Default to the
+# signed-in account's email (its UPN); fall back to a clear instruction otherwise.
+if [[ -z "$BUDGET_EMAIL" ]]; then
+  BUDGET_EMAIL="$(az account show --query user.name -o tsv 2>/dev/null || true)"
 fi
+if [[ -z "$BUDGET_EMAIL" || "$BUDGET_EMAIL" != *@*.* ]]; then
+  echo "ERROR: a notification email is required — subscription budgets reject empty contacts." >&2
+  echo "Could not derive one from your az session; re-run with BUDGET_EMAIL=you@example.com" >&2
+  exit 1
+fi
+EMAILS_JSON="[\"${BUDGET_EMAIL}\"]"
 
 TEMPLATE="$(dirname "$0")/budget-template.json"
 
@@ -44,8 +53,4 @@ az deployment sub create \
   -o none
 
 echo "Budget '$BUDGET_NAME' set: alerts at 50/80/100% (actual) + 100% (forecast)." >&2
-if [[ -n "$BUDGET_EMAIL" ]]; then
-  echo "Alerts go to: $BUDGET_EMAIL and the subscription Owner role." >&2
-else
-  echo "Alerts go to the subscription Owner role (set BUDGET_EMAIL=you@example.com to also email a specific inbox)." >&2
-fi
+echo "Alerts go to: $BUDGET_EMAIL (and the subscription Owner role)." >&2

--- a/scripts/azure/provision-budget.sh
+++ b/scripts/azure/provision-budget.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Provision a monthly Cost Management budget for the JobOps subscription, with
+# alerts at 50/80/100% (actual) and 100% (forecast) to the Owner role (and an
+# optional explicit email).
+#
+# SECURITY: local operator tool — never run from CI. Authority is your own
+# `az login` session. No secrets/IDs are committed; BUDGET_EMAIL (if used) is a
+# deploy-time env var and is never written to the repo.
+#
+# Usage:
+#   scripts/azure/provision-budget.sh
+#   BUDGET_EMAIL=you@example.com BUDGET_AMOUNT=30 scripts/azure/provision-budget.sh
+set -euo pipefail
+export MSYS_NO_PATHCONV=1
+
+BUDGET_NAME="${BUDGET_NAME:-jobops-monthly-30}"
+BUDGET_AMOUNT="${BUDGET_AMOUNT:-30}"
+DEPLOY_LOCATION="${DEPLOY_LOCATION:-eastus}"
+BUDGET_EMAIL="${BUDGET_EMAIL:-}"
+
+# Fail early with a clear message if not logged in.
+az account show -o none
+
+START_DATE="$(date +%Y-%m-01)"
+
+if [[ -n "$BUDGET_EMAIL" ]]; then
+  EMAILS_JSON="[\"${BUDGET_EMAIL}\"]"
+else
+  EMAILS_JSON="[]"
+fi
+
+TEMPLATE="$(dirname "$0")/budget-template.json"
+
+echo "Deploying budget '$BUDGET_NAME' (\$$BUDGET_AMOUNT/mo, start $START_DATE) ..." >&2
+az deployment sub create \
+  --name "jobops-budget-deploy" \
+  --location "$DEPLOY_LOCATION" \
+  --template-file "$TEMPLATE" \
+  --parameters \
+      budgetName="$BUDGET_NAME" \
+      amount="$BUDGET_AMOUNT" \
+      startDate="$START_DATE" \
+      contactEmails="$EMAILS_JSON" \
+  -o none
+
+echo "Budget '$BUDGET_NAME' set: alerts at 50/80/100% (actual) + 100% (forecast)." >&2
+if [[ -n "$BUDGET_EMAIL" ]]; then
+  echo "Alerts go to: $BUDGET_EMAIL and the subscription Owner role." >&2
+else
+  echo "Alerts go to the subscription Owner role (set BUDGET_EMAIL=you@example.com to also email a specific inbox)." >&2
+fi


### PR DESCRIPTION
Two small operator tools so the deployment's spend on the $100 student cap is both **alarmed** and **pausable**.

## Budget alerts
`scripts/azure/budget-template.json` (ARM, subscription scope) + `scripts/azure/provision-budget.sh`:
- Monthly **$30** Cost Management budget, email alerts at **50/80/100% (actual)** + **100% (forecast)**.
- Notifies the subscription **Owner role**, so **no email is committed**; pass `BUDGET_EMAIL=you@example.com` at deploy time to also email an inbox. `BUDGET_AMOUNT`/`BUDGET_NAME` overridable. Idempotent (updates the same budget).
- It only **alerts** — never caps or stops anything.

## Pause / resume the baseline
`scripts/azure/lifecycle.sh pause|resume|status`:
- **`pause`** stops Postgres (`az postgres flexible-server stop`) + scales the agent to `min-replicas=0`.
- **`resume`** starts Postgres back up. **`status`** is read-only (DB state + agent replicas).
- Stop/start **tolerate only the already-stopped/running case** and `die` loudly on any other error (same hardening as `demo.sh cool`), so a partial failure never reports success.

Docs (`AZURE_DEPLOYMENT.md` "Cost controls" + `DEMO.md` pointer) cover the honest caveats: paused = live DB features down; Flexible Server auto-restarts after ~7 days; the App Service B1 plan (~$13/mo) keeps billing unless you manually downgrade to F1 or delete the plan (documented, not auto-scripted). Also clarifies `cool` (agent only) vs `pause` (whole baseline).

## Security (safe to commit)
Local operator tools only; authority is your own `az login`; no secrets/IDs committed (resource names only); `BUDGET_EMAIL` is deploy-time env, never written. A guard check confirms **no workflow references either script**.

## Tests / verification
- Budget template parses as JSON; `lifecycle.sh` dispatch unit tests (`scripts/azure/lifecycle.test.sh`): **ALL PASS**.
- `bash -n` clean on both; doc fences balanced; no-CI-reference guard passes.
- Live verification (`provision-budget.sh`; `lifecycle.sh status`/`pause`/`resume`) needs `az login` and is the maintainer's step.

Spec: `docs/superpowers/specs/2026-06-12-cost-controls-design.md` · Plan: `docs/superpowers/plans/2026-06-12-cost-controls.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)