### PR TITLE
docs: blueprint architecture diagram + README badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ apps/api/data/*.tmp
 workflows/n8n/owner.env
 .playwright-mcp/
 .serena/
+.superpowers/
 tmp/
 
 .deploy/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # JobOps Copilot
 
+[![CI](https://github.com/Taleef7/jobops-copilot/actions/workflows/ci.yml/badge.svg)](https://github.com/Taleef7/jobops-copilot/actions/workflows/ci.yml)
+[![Live demo](https://img.shields.io/badge/demo-live-059669)](https://jobops-web.azurewebsites.net)
+![Next.js](https://img.shields.io/badge/Next.js-16-000?logo=nextdotjs&logoColor=white)
+![React](https://img.shields.io/badge/React-19-20232a?logo=react&logoColor=61dafb)
+![TypeScript](https://img.shields.io/badge/TypeScript-5-3178c6?logo=typescript&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3.12-3776ab?logo=python&logoColor=white)
+![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)
+![LangChain](https://img.shields.io/badge/LangChain-agents-1c3c3c?logo=langchain&logoColor=white)
+![Azure](https://img.shields.io/badge/Azure-App%20Service%20%2B%20Container%20Apps-0078d4?logo=microsoftazure&logoColor=white)
+![pgvector](https://img.shields.io/badge/Postgres-pgvector-4169e1?logo=postgresql&logoColor=white)
+![Human in the loop](https://img.shields.io/badge/AI-human--in--the--loop-7c3aed)
+
 **An AI-agent operations platform for the job search.** JobOps Copilot tracks
 opportunities in a CRM, then uses real LLMs, retrieval-augmented generation, and
 multi-step agents to analyze fit, research companies, prep interviews, plan
@@ -11,9 +23,12 @@ bot**: it drafts and recommends, but never sends or fabricates.
 
 > **Live on Azure:** dashboard → https://jobops-web.azurewebsites.net ·
 > API health → https://jobops-api.azurewebsites.net/api/health
-> (Web + API run on Azure App Service against Azure PostgreSQL. The Python
-> agent service runs locally for the full-AI demo; the cloud app degrades
-> gracefully to the deterministic analysis when the agent is not attached.)
+> (Web + API run on Azure App Service against Azure PostgreSQL; the Python agent
+> runs on Azure Container Apps, scale-to-zero, and is warmed on demand for live
+> AI demos via `scripts/azure/demo.sh warm`. When the agent is cold or
+> unattached, the cloud app degrades gracefully to the deterministic analysis.)
+
+![JobOps Copilot system architecture — browser to Next.js web to Express API to Python FastAPI agent (LangChain, RAG, telemetry) to Azure Postgres with pgvector, plus Blob Storage, Hugging Face embeddings, n8n/Make/Zapier automation, and Azure platform services](docs/architecture/architecture-blueprint.svg)
 
 ## Highlights
 
@@ -44,15 +59,11 @@ bot**: it drafts and recommends, but never sends or fabricates.
 
 ## Architecture
 
-```
-apps/web (Next.js 16 / React 19)
-        │  REST
-apps/api (Express, TypeScript) ──delegates AI──> services/agent (Python / FastAPI)
-        │                                              │  LangChain (multi-provider)
-        └──────── Azure PostgreSQL ◄───────────────────┘  + pgvector (RAG)
-                  (jobs CRM + embeddings)                  HF embeddings (PyTorch)
-                                                           pandas (telemetry)
-```
+The **system diagram at the top of this README** (source:
+[`docs/architecture/architecture-blueprint.svg`](docs/architecture/architecture-blueprint.svg))
+shows the full topology. In short: `apps/web` (Next.js) → `apps/api` (Express) →
+`services/agent` (Python/FastAPI, which owns the real AI) → Azure PostgreSQL +
+`pgvector`, with Blob Storage, automation, and Azure platform services around it.
 
 - `apps/web` — dashboard and product UI (jobs, outreach, reports, AI agents, telemetry).
 - `apps/api` — Express API: CRUD, AI proxy routes, n8n webhooks, telemetry. Delegates AI to the agent service when `AGENT_SERVICE_URL` is set, else uses a mock.

--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ bot**: it drafts and recommends, but never sends or fabricates.
 
 ![JobOps Copilot system architecture — browser to Next.js web to Express API to Python FastAPI agent (LangChain, RAG, telemetry) to Azure Postgres with pgvector, plus Blob Storage, Hugging Face embeddings, n8n/Make/Zapier automation, and Azure platform services](docs/architecture/architecture-blueprint.svg)
 
-> 🔎 **Interactive version** (pan · zoom · click any node):
-> [`/architecture`](https://jobops-web.azurewebsites.net/architecture) on the live app.
-
 ## Highlights
 
 - **Real, multi-provider LLMs** — a Python agent service routes to Anthropic

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ bot**: it drafts and recommends, but never sends or fabricates.
 
 ![JobOps Copilot system architecture — browser to Next.js web to Express API to Python FastAPI agent (LangChain, RAG, telemetry) to Azure Postgres with pgvector, plus Blob Storage, Hugging Face embeddings, n8n/Make/Zapier automation, and Azure platform services](docs/architecture/architecture-blueprint.svg)
 
+> 🔎 **Interactive version** (pan · zoom · click any node):
+> [`/architecture`](https://jobops-web.azurewebsites.net/architecture) on the live app.
+
 ## Highlights
 
 - **Real, multi-provider LLMs** — a Python agent service routes to Anthropic

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,8 +7,8 @@ CRM and orchestration; a Python service owns the real AI.
 
 ![JobOps Copilot system architecture](architecture/architecture-blueprint.svg)
 
-> An interactive version (pan, zoom, click any node) is served at `/architecture`
-> on the live app.
+> An interactive version (pan, zoom, click any node) will be available at
+> `/architecture` on the live app once the web-app page lands.
 
 ### Key decisions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,12 +5,10 @@
 JobOps Copilot is a three-service system plus Postgres. The Node API owns the
 CRM and orchestration; a Python service owns the real AI.
 
-```
-apps/web (Next.js)  ──REST──►  apps/api (Express)  ──delegates AI──►  services/agent (Python/FastAPI)
-                                      │                                     │ LangChain (multi-provider LLM)
-                                      └────── Azure PostgreSQL ◄────────────┘ + pgvector (RAG), HF embeddings,
-                                              (CRM + embeddings)               pandas (telemetry)
-```
+![JobOps Copilot system architecture](architecture/architecture-blueprint.svg)
+
+> An interactive version (pan, zoom, click any node) is served at `/architecture`
+> on the live app.
 
 ### Key decisions
 
@@ -76,6 +74,43 @@ The current backend flow is:
 - `apps/api/src/lib/weekly-report.ts` builds report snapshots and API payloads.
 - `apps/api/src/lib/report-export.ts` writes local report artifacts and uploads them to Blob Storage when configured.
 - `apps/api/scripts/db-init.ts` bootstraps the Azure PostgreSQL schema and seed data.
+
+## Request & data flow
+
+The AI pipeline (job intake → analysis), at a glance:
+
+```mermaid
+flowchart LR
+  U([User]) --> W[Web · Next.js + Clerk]
+  W -->|REST · /api/proxy| A[API · Express]
+  A -->|delegate AI| AG[Agent · FastAPI + LangChain]
+  AG -->|init_chat_model| L[(LLM provider ×4)]
+  AG -->|retrieve resume evidence| V[(Postgres + pgvector)]
+  A -->|CRM read / write| V
+  AG -->|structured JobAnalysis| A
+  A -->|persist + return| W
+```
+
+Request lifecycle for an AI call, including the graceful fallback that keeps the
+app working with or without an LLM key:
+
+```mermaid
+sequenceDiagram
+  participant W as Web (Clerk JWT)
+  participant A as API (Express)
+  participant AG as Agent (FastAPI)
+  participant DB as Postgres + pgvector
+  W->>A: POST /api/ai/score-fit
+  alt AGENT_SERVICE_URL set and agent healthy
+    A->>AG: delegate
+    AG->>DB: RAG · retrieve resume chunks
+    AG-->>A: structured fit analysis (real LLM)
+  else agent cold / unattached / no key
+    A->>A: deterministic mock analysis
+  end
+  A->>DB: persist analysis + fit_score
+  A-->>W: JobAnalysis
+```
 
 ## Data Flow
 

--- a/docs/architecture/architecture-blueprint.svg
+++ b/docs/architecture/architecture-blueprint.svg
@@ -1,0 +1,168 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 660" width="1320" height="660" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" role="img" aria-label="JobOps Copilot system architecture: browser to Next.js web to Express API to Python FastAPI agent (LangChain, multi-provider LLMs, RAG, telemetry) to Azure Postgres with pgvector, plus Blob Storage, Hugging Face embeddings, n8n/Make/Zapier automation, and Azure platform services (App Insights, Key Vault, Log Analytics).">
+  <defs>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0 L0 0 0 40" fill="none" stroke="#13314c" stroke-width="0.6"/>
+    </pattern>
+    <marker id="arrowCyan" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L6.5,3 L0,6 Z" fill="#38bdf8"/></marker>
+    <marker id="arrowTeal" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L6.5,3 L0,6 Z" fill="#5eead4"/></marker>
+  </defs>
+
+  <!-- backdrop -->
+  <rect x="0" y="0" width="1320" height="660" fill="#0a1626"/>
+  <rect x="0" y="0" width="1320" height="660" fill="url(#grid)"/>
+  <rect x="16" y="16" width="1288" height="628" fill="none" stroke="#20405e" stroke-width="1"/>
+  <line x1="16" y1="86" x2="1304" y2="86" stroke="#20405e" stroke-width="1"/>
+
+  <!-- title block -->
+  <text x="40" y="50" fill="#7dd3fc" font-size="23" font-weight="700" letter-spacing="0.5">JobOps Copilot — System Architecture</text>
+  <text x="40" y="72" fill="#5b7a99" font-size="12.5">responsible AI job-search ops · web → api → agent → data · hosted on Azure</text>
+  <text x="1280" y="46" fill="#5eead4" font-size="12" font-weight="700" text-anchor="end" letter-spacing="1">BLUEPRINT</text>
+  <text x="1280" y="64" fill="#4f6e8c" font-size="11" text-anchor="end">rev 2026-06-16</text>
+
+  <!-- ============ LLM PROVIDERS cluster ============ -->
+  <rect x="752" y="98" width="280" height="86" rx="3" fill="none" stroke="#274b66" stroke-dasharray="2 3"/>
+  <text x="762" y="114" fill="#5eead4" font-size="10.5" letter-spacing="0.8">LLM PROVIDERS ×4 · provider-agnostic</text>
+  <g fill="none" stroke="#3f6f6a">
+    <rect x="762" y="122" width="122" height="26" rx="3"/>
+    <rect x="898" y="122" width="124" height="26" rx="3"/>
+    <rect x="762" y="152" width="122" height="26" rx="3"/>
+    <rect x="898" y="152" width="124" height="26" rx="3"/>
+  </g>
+  <g fill="#9fe9da" font-size="11" text-anchor="middle">
+    <text x="823" y="139">Anthropic Claude</text>
+    <text x="960" y="139">Azure OpenAI</text>
+    <text x="823" y="169">OpenAI</text>
+    <text x="960" y="169">Google Gemini</text>
+  </g>
+
+  <!-- ============ MAIN SPINE ============ -->
+  <!-- browser -->
+  <rect x="44" y="220" width="120" height="60" rx="4" fill="#0e1f33" stroke="#38bdf8"/>
+  <text x="104" y="246" fill="#cfe8ff" font-size="12.5" text-anchor="middle">browser</text>
+  <text x="104" y="263" fill="#6f93b4" font-size="10.5" text-anchor="middle">(the user)</text>
+
+  <!-- web -->
+  <rect x="212" y="212" width="206" height="76" rx="4" fill="#0e1f33" stroke="#38bdf8"/>
+  <text x="315" y="240" fill="#cfe8ff" font-size="13.5" text-anchor="middle">web · next.js 16</text>
+  <text x="315" y="259" fill="#6f93b4" font-size="11" text-anchor="middle">react 19 · tailwind v4</text>
+  <text x="315" y="274" fill="#6f93b4" font-size="11" text-anchor="middle">shadcn · clerk auth</text>
+
+  <!-- api -->
+  <rect x="500" y="212" width="206" height="76" rx="4" fill="#0e1f33" stroke="#38bdf8"/>
+  <text x="603" y="240" fill="#cfe8ff" font-size="13.5" text-anchor="middle">api · express + ts</text>
+  <text x="603" y="259" fill="#6f93b4" font-size="11" text-anchor="middle">crud · ai proxy · n8n</text>
+  <text x="603" y="274" fill="#6f93b4" font-size="11" text-anchor="middle">webhooks · telemetry</text>
+
+  <!-- agent (AI core, teal) -->
+  <rect x="790" y="200" width="232" height="100" rx="4" fill="#0c2230" stroke="#5eead4" stroke-width="1.4"/>
+  <text x="906" y="228" fill="#b8fff0" font-size="13.5" text-anchor="middle">agent · python fastapi</text>
+  <text x="906" y="249" fill="#86c9bd" font-size="11" text-anchor="middle">langchain · provider router</text>
+  <text x="906" y="266" fill="#86c9bd" font-size="11" text-anchor="middle">RAG · multi-step agents</text>
+  <text x="906" y="283" fill="#86c9bd" font-size="11" text-anchor="middle">pandas telemetry · structured out</text>
+
+  <!-- postgres -->
+  <rect x="1104" y="212" width="180" height="76" rx="4" fill="#0e1f33" stroke="#38bdf8"/>
+  <text x="1194" y="240" fill="#cfe8ff" font-size="13.5" text-anchor="middle">azure postgres</text>
+  <text x="1194" y="259" fill="#6f93b4" font-size="11" text-anchor="middle">pgvector store</text>
+  <text x="1194" y="274" fill="#6f93b4" font-size="11" text-anchor="middle">jobs CRM + embeddings</text>
+
+  <!-- ============ SECOND ROW ============ -->
+  <!-- blob -->
+  <rect x="500" y="344" width="206" height="58" rx="4" fill="#0e1f33" stroke="#38bdf8"/>
+  <text x="603" y="369" fill="#cfe8ff" font-size="12.5" text-anchor="middle">azure blob storage</text>
+  <text x="603" y="387" fill="#6f93b4" font-size="10.5" text-anchor="middle">weekly report exports (.md/.html)</text>
+
+  <!-- embeddings (AI, teal) -->
+  <rect x="790" y="344" width="232" height="58" rx="4" fill="#0c2230" stroke="#5eead4"/>
+  <text x="906" y="369" fill="#b8fff0" font-size="12.5" text-anchor="middle">hf sentence-transformers</text>
+  <text x="906" y="387" fill="#86c9bd" font-size="10.5" text-anchor="middle">embeddings · pytorch (cpu)</text>
+
+  <!-- ============ EDGES (data = cyan, AI = teal) ============ -->
+  <g font-size="10.5" fill="#88a7c4" text-anchor="middle">
+    <!-- browser -> web -->
+    <line x1="164" y1="250" x2="206" y2="250" stroke="#38bdf8" marker-end="url(#arrowCyan)"/>
+    <text x="185" y="242">https</text>
+    <!-- web -> api -->
+    <line x1="418" y1="250" x2="494" y2="250" stroke="#38bdf8" marker-end="url(#arrowCyan)"/>
+    <text x="456" y="241">REST</text>
+    <text x="456" y="266" font-size="9.5" fill="#5b7a99">/api/proxy/*</text>
+    <!-- api -> agent (AI, teal) -->
+    <line x1="706" y1="250" x2="784" y2="250" stroke="#5eead4" marker-end="url(#arrowTeal)"/>
+    <text x="745" y="241" fill="#86c9bd">delegate AI</text>
+    <text x="745" y="266" font-size="9" fill="#5b7a99">AGENT_SERVICE_URL</text>
+    <!-- agent -> postgres (AI, teal): RAG + sql -->
+    <line x1="1022" y1="244" x2="1100" y2="244" stroke="#5eead4" marker-end="url(#arrowTeal)"/>
+    <text x="1060" y="236" fill="#86c9bd">RAG</text>
+    <!-- providers -> agent (AI, teal) -->
+    <path d="M892,184 C892,194 906,192 906,198" fill="none" stroke="#5eead4" marker-end="url(#arrowTeal)"/>
+    <text x="1006" y="192" fill="#86c9bd" font-size="9.5" text-anchor="end">init_chat_model</text>
+    <!-- agent -> embeddings (AI, teal) -->
+    <line x1="906" y1="300" x2="906" y2="340" stroke="#5eead4" marker-end="url(#arrowTeal)"/>
+    <text x="936" y="324" fill="#86c9bd" text-anchor="start">embed</text>
+    <!-- embeddings -> postgres pgvector (AI, teal) -->
+    <path d="M1022,366 C1110,366 1170,330 1184,290" fill="none" stroke="#5eead4" stroke-dasharray="5 3" marker-end="url(#arrowTeal)"/>
+    <text x="1120" y="356" fill="#86c9bd" font-size="9.5">upsert vectors</text>
+    <!-- api -> blob -->
+    <line x1="603" y1="288" x2="603" y2="340" stroke="#38bdf8" marker-end="url(#arrowCyan)"/>
+    <text x="633" y="318" text-anchor="start">exports</text>
+    <!-- api -> postgres (CRM), routed corridor -->
+    <path d="M706,264 H748 V440 H1194 V292" fill="none" stroke="#38bdf8" marker-end="url(#arrowCyan)"/>
+    <text x="980" y="432">CRM read / write (pg)</text>
+  </g>
+
+  <!-- ============ AUTOMATION band ============ -->
+  <rect x="44" y="470" width="468" height="120" rx="3" fill="none" stroke="#274b66" stroke-dasharray="2 3"/>
+  <text x="56" y="490" fill="#7dd3fc" font-size="10.5" letter-spacing="0.8">AUTOMATION · companion + orchestration</text>
+  <g fill="#0e1f33" stroke="#38bdf8">
+    <rect x="60" y="502" width="134" height="56" rx="4"/>
+    <rect x="206" y="502" width="134" height="56" rx="4"/>
+    <rect x="352" y="502" width="150" height="56" rx="4"/>
+  </g>
+  <g text-anchor="middle">
+    <text x="127" y="526" fill="#cfe8ff" font-size="12">n8n</text>
+    <text x="127" y="544" fill="#6f93b4" font-size="10">self-host orchestrator</text>
+    <text x="273" y="526" fill="#cfe8ff" font-size="12">make.com</text>
+    <text x="273" y="544" fill="#6f93b4" font-size="10">webhook → api</text>
+    <text x="427" y="526" fill="#cfe8ff" font-size="12">zapier</text>
+    <text x="427" y="544" fill="#6f93b4" font-size="10">sheet → calendar</text>
+  </g>
+  <!-- automation -> api webhook -->
+  <path d="M458,470 V300 H520 V288" fill="none" stroke="#38bdf8" marker-end="url(#arrowCyan)"/>
+  <text x="468" y="356" fill="#88a7c4" font-size="9.5" text-anchor="start">POST /api/n8n/*</text>
+  <text x="468" y="369" fill="#5b7a99" font-size="9" text-anchor="start">webhook secret</text>
+
+  <!-- ============ AZURE PLATFORM band (cross-cutting) ============ -->
+  <rect x="540" y="470" width="744" height="120" rx="3" fill="none" stroke="#274b66" stroke-dasharray="2 3"/>
+  <text x="552" y="490" fill="#7dd3fc" font-size="10.5" letter-spacing="0.8">AZURE PLATFORM · cross-cutting</text>
+  <g fill="#0e1f33" stroke="#4d77a0">
+    <rect x="556" y="502" width="210" height="44" rx="4"/>
+    <rect x="784" y="502" width="200" height="44" rx="4"/>
+    <rect x="1002" y="502" width="166" height="44" rx="4"/>
+  </g>
+  <g text-anchor="middle">
+    <text x="661" y="521" fill="#cfe8ff" font-size="12">app insights</text>
+    <text x="661" y="537" fill="#6f93b4" font-size="9.5">traces · metrics · alerts</text>
+    <text x="884" y="521" fill="#cfe8ff" font-size="12">key vault</text>
+    <text x="884" y="537" fill="#6f93b4" font-size="9.5">secrets · managed identity</text>
+    <text x="1085" y="521" fill="#cfe8ff" font-size="12">log analytics</text>
+    <text x="1085" y="537" fill="#6f93b4" font-size="9.5">1 GB/day cap</text>
+  </g>
+  <text x="552" y="572" fill="#5b7a99" font-size="9.7">App Insights instruments web · api · agent  —  Key Vault serves App Service secrets via managed identity</text>
+
+  <!-- hosting note -->
+  <text x="315" y="200" fill="#4f6e8c" font-size="9.5" text-anchor="middle">App Service</text>
+  <text x="603" y="200" fill="#4f6e8c" font-size="9.5" text-anchor="middle">App Service</text>
+  <text x="906" y="190" fill="#4f6e8c" font-size="9.5" text-anchor="middle">Container Apps · scale-to-zero</text>
+
+  <!-- ============ LEGEND ============ -->
+  <g font-size="10.5" fill="#88a7c4">
+    <line x1="56" y1="616" x2="92" y2="616" stroke="#38bdf8"/>
+    <text x="100" y="620">data / request flow</text>
+    <line x1="246" y1="616" x2="282" y2="616" stroke="#5eead4"/>
+    <text x="290" y="620" fill="#86c9bd">AI pipeline</text>
+    <rect x="400" y="609" width="16" height="14" rx="2" fill="#0e1f33" stroke="#38bdf8"/>
+    <text x="424" y="620">service</text>
+    <rect x="500" y="609" width="16" height="14" rx="2" fill="none" stroke="#274b66" stroke-dasharray="2 3"/>
+    <text x="524" y="620">logical group</text>
+  </g>
+</svg>

--- a/docs/superpowers/specs/2026-06-16-architecture-diagram-design.md
+++ b/docs/superpowers/specs/2026-06-16-architecture-diagram-design.md
@@ -1,0 +1,100 @@
+# Design — Architecture diagram + interactive /architecture page
+
+**Date:** 2026-06-16
+**Status:** Approved (user picked blueprint style "C"; delegated authority to proceed autonomously)
+
+## Goal
+
+Close the two remaining "Final Portfolio Deliverables" that involve a system
+diagram, and tighten repo presentation:
+
+1. A polished **static hero architecture diagram** (always-visible, GitHub- and
+   offline-renderable).
+2. A **modern, interactive** version on the already-deployed Next.js app.
+3. Repo presentation: README **badges**, GitHub **description + topics**, and
+   reconciliation of one stale doc line.
+4. **Verify + polish** the live Azure stack (read-only).
+
+(The user records the demo video themselves; out of scope here.)
+
+## Chosen visual direction
+
+**Engineering blueprint** — navy background with a faint grid, monospace
+(Geist Mono, already loaded) labels, dashed signal traces, cyan/teal accents.
+Picked from a 3-way browser mockup (A clean-SaaS, B dark-glow, C blueprint).
+The blueprint look carries its own dark background, so a **single SVG** renders
+correctly on both light and dark GitHub themes (no `<picture>` dual-asset needed).
+
+## Architecture of the work
+
+Two independent PRs (lower risk; the zero-risk docs PR lands even if the page
+needs iteration). I open PRs; the user merges (never me).
+
+### PR1 — docs: blueprint diagram + badges + metadata + reconciliation
+
+- `docs/architecture/architecture-blueprint.svg` — hand-authored hero SVG, full
+  topology: Web (Next.js 16 + Clerk) → API (Express) → Agent (FastAPI +
+  LangChain) → Azure Postgres + pgvector; plus Blob Storage, LLM providers ×4
+  (Anthropic / Azure OpenAI / OpenAI / Gemini), HF embeddings (PyTorch), pandas
+  telemetry, automation (n8n / Make / Zapier), App Insights, Key Vault. Labeled
+  data-flow edges (REST, delegate AI, RAG, embed, webhook, secrets, traces).
+- `README.md` — badge row (CI status, license, Next.js, React, TypeScript,
+  Python, FastAPI, Azure, LangChain, pgvector, live demo, human-in-the-loop);
+  embed hero SVG near the top; reconcile the stale blockquote that says the agent
+  "runs locally for the full-AI demo" (it is deployed on Container Apps and
+  warmable via `scripts/azure/demo.sh warm`).
+- `docs/ARCHITECTURE.md` — embed the hero SVG; add two **Mermaid** sub-diagrams
+  (job-intake data flow; request lifecycle) for maintainable, GitHub-native
+  rendering.
+- `.gitignore` — ignore `.superpowers/` (brainstorm companion artifacts).
+
+### GitHub repo metadata (direct, not via PR)
+
+`gh repo edit Taleef7/jobops-copilot` — set a crisp About **description** and add
+~18 **topics**: ai-agents, llm, rag, pgvector, langchain, nextjs, typescript,
+python, fastapi, azure, job-search, automation, n8n, human-in-the-loop,
+vector-search, react, tailwindcss, crm. Low-risk, explicitly requested, easily
+reversible; report exactly what was set.
+
+### PR2 — feat(web): interactive /architecture page (React Flow)
+
+- Add `@xyflow/react` (React Flow v12; verify React 19 / Next 16 compatibility
+  via context7 + a clean `npm run check` build before relying on it).
+- Route `apps/web/src/app/(marketing)/architecture/page.tsx` (inherits the public
+  marketing header/footer; URL `/architecture`). Server component renders a
+  `'use client'` `ArchitectureFlow` (React Flow is browser-only). Explicit
+  container height to avoid SSR measure issues.
+- Blueprint theme to match the SVG: custom node component, dashed animated edges,
+  navy grid `<Background>`, pan/zoom controls; nodes clickable → deep-link to the
+  relevant doc/live endpoint.
+- `apps/web/src/proxy.ts` — add `'/architecture(.*)'` to the public route matcher
+  so it is reachable without sign-in.
+- Marketing header — add an "Architecture" nav link.
+- `README.md` — add a "View the live interactive diagram → /architecture" link.
+
+## Constraints / risks considered
+
+- **CI is required on protected `main`** → PR2 must pass `npm run check` (lint,
+  typecheck, build) in `apps/web`. Mitigation: pin a React-19-compatible
+  `@xyflow/react`, verify via context7, build locally before pushing.
+- **GitHub README cannot run JS** → interactivity must live on the hosted app,
+  not in the README. Hence static SVG in README + interactive page on the live
+  site. (This is the core reason for the two-layer approach.)
+- **Public access** → `/architecture` must be in the Clerk public matcher; it is
+  a portfolio artifact, not gated.
+- **Cost** → live-stack verification uses only the read-only `demo.sh status`; no
+  `warm` (which would bill ~$20–30/mo) unless the user asks.
+- **PR hygiene** → branch from `main`, focused commits, open PR, user merges.
+
+## Success criteria
+
+- Hero SVG renders correctly on github.com in both themes and embedded in README.
+- `/architecture` builds clean, loads publicly, pans/zooms, nodes link out, looks
+  consistent in light/dark.
+- `npm run check` green; no new console errors.
+- Repo shows description + topics + badges.
+- Live-stack status reported (no cost incurred).
+
+## Out of scope (future / beyond plan)
+
+Demo video (user-owned), job-board ingestion, and any net-new feature work.


### PR DESCRIPTION
## Summary

Portfolio-finishing: ships the **static hero architecture diagram** (one of the two remaining "Final Deliverables" that involve a system diagram) plus README presentation polish. The interactive `/architecture` page follows in a separate PR.

### What's in here
- **Blueprint system diagram** — hand-authored `docs/architecture/architecture-blueprint.svg` in an engineering-blueprint style (navy grid, monospace, dashed traces, cyan/teal accents). Full topology: Web (Next.js + Clerk) → API (Express) → Agent (FastAPI + LangChain) → Azure Postgres + pgvector, plus Blob Storage, LLM providers ×4, HF embeddings (PyTorch), pandas telemetry, n8n/Make/Zapier, and Azure platform (App Insights, Key Vault, Log Analytics). Labeled data-flow edges; self-contained dark background so it renders on both GitHub themes.
- **README** — embed the hero diagram near the top, add a badge row (CI, live demo, Next.js/React/TypeScript/Python/FastAPI/LangChain/Azure/pgvector, human-in-the-loop), and replace the ASCII diagram with a pointer.
- **Doc reconciliation** — the stale "agent runs locally for the full-AI demo" note now reflects reality: the agent is on **Azure Container Apps (scale-to-zero)** and warmed on demand via `scripts/azure/demo.sh warm`, degrading gracefully to the deterministic analysis when cold.
- **ARCHITECTURE.md** — embed the SVG and add two **Mermaid** sub-diagrams (job-intake data flow + request lifecycle with the graceful mock fallback).
- Ignore `.superpowers/`; add the design spec under `docs/superpowers/specs/`.

### Verification
- Diagram rendered in a headless browser (Chrome) at 1× and 1.6× — all node text fits, no overlaps/clipping, edges read clearly. Screenshot reviewed.
- `git diff --cached --check` clean (no whitespace errors).
- Docs-only change; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)