### PR TITLE
feat(web): interactive /architecture page (React Flow)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@base-ui/react": "^1.5.0",
     "@clerk/nextjs": "^7.4.3",
+    "@xyflow/react": "^12.11.0",
     "applicationinsights": "^3.15.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/app/(marketing)/architecture/architecture-flow.tsx
+++ b/apps/web/src/app/(marketing)/architecture/architecture-flow.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useCallback } from 'react';
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  Handle,
+  Position,
+  ReactFlow,
+  type Edge,
+  type Node,
+  type NodeProps,
+  type NodeTypes,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+
+const REPO = 'https://github.com/Taleef7/jobops-copilot/tree/main';
+const LIVE = 'https://jobops-web.azurewebsites.net';
+
+type Kind = 'client' | 'core' | 'ai' | 'data' | 'platform' | 'automation';
+
+type BpData = {
+  title: string;
+  sub?: string;
+  kind: Kind;
+  href?: string;
+};
+
+type BpNode = Node<BpData, 'bp'>;
+
+const ACCENT: Record<Kind, string> = {
+  client: '#38bdf8',
+  core: '#38bdf8',
+  ai: '#5eead4',
+  data: '#38bdf8',
+  platform: '#4d77a0',
+  automation: '#38bdf8',
+};
+
+const handleStyle = {
+  opacity: 0,
+  width: 1,
+  height: 1,
+  minWidth: 0,
+  minHeight: 0,
+  border: 'none',
+  background: 'transparent',
+} as const;
+
+const SIDES: Array<['top' | 'right' | 'bottom' | 'left', Position]> = [
+  ['top', Position.Top],
+  ['right', Position.Right],
+  ['bottom', Position.Bottom],
+  ['left', Position.Left],
+];
+
+function BlueprintNode({ data }: NodeProps<BpNode>) {
+  const accent = ACCENT[data.kind];
+  const isAi = data.kind === 'ai';
+  return (
+    <div
+      style={{
+        width: '100%',
+        padding: '10px 12px',
+        borderRadius: 4,
+        background: isAi ? '#0c2230' : '#0e1f33',
+        border: `1px solid ${accent}`,
+        fontFamily: 'var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)',
+        cursor: data.href ? 'pointer' : 'default',
+        boxShadow: isAi ? '0 0 0 1px rgba(94,234,212,0.15)' : 'none',
+      }}
+    >
+      {SIDES.map(([id, position]) => (
+        <span key={id}>
+          <Handle id={id} type="source" position={position} style={handleStyle} isConnectable={false} />
+          <Handle id={id} type="target" position={position} style={handleStyle} isConnectable={false} />
+        </span>
+      ))}
+      <div style={{ color: isAi ? '#b8fff0' : '#cfe8ff', fontSize: 12.5, fontWeight: 600 }}>
+        {data.title}
+        {data.href ? <span style={{ color: accent, opacity: 0.7 }}> ↗</span> : null}
+      </div>
+      {data.sub ? (
+        <div style={{ color: isAi ? '#86c9bd' : '#6f93b4', fontSize: 10, marginTop: 3 }}>{data.sub}</div>
+      ) : null}
+    </div>
+  );
+}
+
+const nodeTypes: NodeTypes = { bp: BlueprintNode };
+
+const node = (
+  id: string,
+  x: number,
+  y: number,
+  width: number,
+  data: BpData,
+): BpNode => ({ id, type: 'bp', position: { x, y }, data, style: { width }, draggable: false });
+
+const nodes: BpNode[] = [
+  // providers cluster (above agent)
+  node('providers', 632, 0, 250, {
+    title: 'LLM providers ×4',
+    sub: 'anthropic · azure openai · openai · gemini',
+    kind: 'ai',
+  }),
+  // spine
+  node('browser', 0, 150, 132, { title: 'browser', sub: '(the user)', kind: 'client' }),
+  node('web', 184, 142, 182, {
+    title: 'web · next.js 16',
+    sub: 'react 19 · tailwind · clerk auth',
+    kind: 'core',
+    href: LIVE,
+  }),
+  node('api', 426, 142, 196, {
+    title: 'api · express + ts',
+    sub: 'crud · ai proxy · n8n webhooks',
+    kind: 'core',
+    href: `${REPO}/apps/api`,
+  }),
+  node('agent', 680, 130, 200, {
+    title: 'agent · python fastapi',
+    sub: 'langchain · RAG · multi-step agents',
+    kind: 'ai',
+    href: `${REPO}/services/agent`,
+  }),
+  node('postgres', 936, 142, 176, {
+    title: 'azure postgres',
+    sub: 'pgvector · jobs CRM + embeddings',
+    kind: 'data',
+    href: `${REPO}/db/migrations`,
+  }),
+  // second row
+  node('blob', 426, 300, 196, {
+    title: 'azure blob storage',
+    sub: 'weekly report exports',
+    kind: 'data',
+  }),
+  node('embeddings', 680, 300, 200, {
+    title: 'hf sentence-transformers',
+    sub: 'embeddings · pytorch (cpu)',
+    kind: 'ai',
+  }),
+  // automation
+  node('n8n', 0, 452, 150, { title: 'n8n', sub: 'self-host orchestrator', kind: 'automation', href: `${REPO}/workflows/n8n` }),
+  node('make', 168, 452, 150, { title: 'make.com', sub: 'webhook → api', kind: 'automation', href: `${REPO}/workflows/make` }),
+  node('zapier', 336, 452, 150, { title: 'zapier', sub: 'sheet → calendar', kind: 'automation', href: `${REPO}/workflows/zapier` }),
+  // azure platform
+  node('appinsights', 560, 452, 170, { title: 'app insights', sub: 'traces · metrics · alerts', kind: 'platform' }),
+  node('keyvault', 758, 452, 160, { title: 'key vault', sub: 'secrets · managed identity', kind: 'platform' }),
+  node('loganalytics', 946, 452, 150, { title: 'log analytics', sub: '1 GB/day cap', kind: 'platform' }),
+];
+
+const CYAN = '#38bdf8';
+const TEAL = '#5eead4';
+const MUTED = '#6c89a6';
+
+const edge = (
+  id: string,
+  source: string,
+  sourceHandle: string,
+  target: string,
+  targetHandle: string,
+  label: string,
+  color: string,
+  opts: { animated?: boolean; dashed?: boolean } = {},
+): Edge => ({
+  id,
+  source,
+  target,
+  sourceHandle,
+  targetHandle,
+  label,
+  type: 'smoothstep',
+  animated: opts.animated ?? false,
+  style: { stroke: color, strokeWidth: 1.4, strokeDasharray: opts.dashed ? '6 3' : undefined },
+  labelStyle: { fill: '#9fbdd8', fontFamily: 'ui-monospace, monospace', fontSize: 10 },
+  labelBgStyle: { fill: '#0a1626', fillOpacity: 0.9 },
+  labelBgPadding: [4, 2],
+  labelBgBorderRadius: 3,
+  markerEnd: undefined,
+});
+
+const edges: Edge[] = [
+  edge('e-browser-web', 'browser', 'right', 'web', 'left', 'https', CYAN),
+  edge('e-web-api', 'web', 'right', 'api', 'left', 'REST · /api/proxy', CYAN),
+  edge('e-api-agent', 'api', 'right', 'agent', 'left', 'delegate AI', TEAL, { animated: true }),
+  edge('e-agent-pg', 'agent', 'right', 'postgres', 'left', 'RAG · SQL', TEAL),
+  edge('e-prov-agent', 'providers', 'bottom', 'agent', 'top', 'init_chat_model', TEAL, { animated: true }),
+  edge('e-agent-emb', 'agent', 'bottom', 'embeddings', 'top', 'embed', TEAL),
+  edge('e-emb-pg', 'embeddings', 'right', 'postgres', 'bottom', 'upsert vectors', TEAL, { dashed: true }),
+  edge('e-api-blob', 'api', 'bottom', 'blob', 'top', 'exports', CYAN),
+  edge('e-api-pg', 'api', 'bottom', 'postgres', 'bottom', 'CRM read/write', CYAN),
+  edge('e-n8n-api', 'n8n', 'top', 'api', 'bottom', '', CYAN),
+  edge('e-make-api', 'make', 'top', 'api', 'bottom', 'POST /api/n8n/*', CYAN),
+  edge('e-zap-api', 'zapier', 'top', 'api', 'bottom', '', CYAN),
+  edge('e-ai-api', 'appinsights', 'top', 'api', 'bottom', 'telemetry', MUTED, { dashed: true }),
+  edge('e-kv-api', 'keyvault', 'top', 'api', 'bottom', 'secrets', MUTED, { dashed: true }),
+];
+
+export function ArchitectureFlow() {
+  const onNodeClick = useCallback((_event: unknown, clicked: Node) => {
+    const href = (clicked.data as BpData).href;
+    if (href) window.open(href, '_blank', 'noopener,noreferrer');
+  }, []);
+
+  return (
+    <ReactFlow
+      nodeTypes={nodeTypes}
+      defaultNodes={nodes}
+      defaultEdges={edges}
+      fitView
+      fitViewOptions={{ padding: 0.12 }}
+      colorMode="dark"
+      minZoom={0.3}
+      maxZoom={2}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      edgesFocusable={false}
+      proOptions={{ hideAttribution: false }}
+      onNodeClick={onNodeClick}
+      style={{ background: '#0a1626' }}
+    >
+      <Background variant={BackgroundVariant.Lines} gap={24} color="#13314d" />
+      <Controls showInteractive={false} />
+    </ReactFlow>
+  );
+}

--- a/apps/web/src/app/(marketing)/architecture/architecture-flow.tsx
+++ b/apps/web/src/app/(marketing)/architecture/architecture-flow.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useCallback } from 'react';
 import {
   Background,
   BackgroundVariant,
@@ -10,7 +9,6 @@ import {
   ReactFlow,
   type Edge,
   type Node,
-  type NodeMouseHandler,
   type NodeProps,
   type NodeTypes,
 } from '@xyflow/react';
@@ -59,6 +57,17 @@ const SIDES: Array<['top' | 'right' | 'bottom' | 'left', Position]> = [
 function BlueprintNode({ data }: NodeProps<BpNode>) {
   const accent = ACCENT[data.kind];
   const isAi = data.kind === 'ai';
+  const content = (
+    <>
+      <div style={{ color: isAi ? '#b8fff0' : '#cfe8ff', fontSize: 12.5, fontWeight: 600 }}>
+        {data.title}
+        {data.href ? <span style={{ color: accent, opacity: 0.7 }}> ↗</span> : null}
+      </div>
+      {data.sub ? (
+        <div style={{ color: isAi ? '#86c9bd' : '#6f93b4', fontSize: 10, marginTop: 3 }}>{data.sub}</div>
+      ) : null}
+    </>
+  );
   return (
     <div
       style={{
@@ -68,7 +77,6 @@ function BlueprintNode({ data }: NodeProps<BpNode>) {
         background: isAi ? '#0c2230' : '#0e1f33',
         border: `1px solid ${accent}`,
         fontFamily: 'var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)',
-        cursor: data.href ? 'pointer' : 'default',
         boxShadow: isAi ? '0 0 0 1px rgba(94,234,212,0.15)' : 'none',
       }}
     >
@@ -78,13 +86,22 @@ function BlueprintNode({ data }: NodeProps<BpNode>) {
           <Handle id={id} type="target" position={position} style={handleStyle} isConnectable={false} />
         </span>
       ))}
-      <div style={{ color: isAi ? '#b8fff0' : '#cfe8ff', fontSize: 12.5, fontWeight: 600 }}>
-        {data.title}
-        {data.href ? <span style={{ color: accent, opacity: 0.7 }}> ↗</span> : null}
-      </div>
-      {data.sub ? (
-        <div style={{ color: isAi ? '#86c9bd' : '#6f93b4', fontSize: 10, marginTop: 3 }}>{data.sub}</div>
-      ) : null}
+      {data.href ? (
+        // Real anchor → keyboard-focusable (Tab) and Enter-activatable, not mouse-only.
+        // nodrag/nopan keep React Flow from hijacking the interaction.
+        <a
+          href={data.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${data.title} — open source (opens in a new tab)`}
+          className="nodrag nopan"
+          style={{ display: 'block', color: 'inherit', textDecoration: 'none', cursor: 'pointer', borderRadius: 3 }}
+        >
+          {content}
+        </a>
+      ) : (
+        content
+      )}
     </div>
   );
 }
@@ -200,11 +217,6 @@ const edges: Edge[] = [
 ];
 
 export function ArchitectureFlow() {
-  const onNodeClick: NodeMouseHandler<BpNode> = useCallback((_event, clicked) => {
-    const { href } = clicked.data;
-    if (href) window.open(href, '_blank', 'noopener,noreferrer');
-  }, []);
-
   return (
     <ReactFlow
       aria-label="JobOps Copilot system architecture — interactive node diagram. A text description precedes this canvas for screen readers."
@@ -218,9 +230,10 @@ export function ArchitectureFlow() {
       maxZoom={2}
       nodesDraggable={false}
       nodesConnectable={false}
+      nodesFocusable={false}
+      elementsSelectable={false}
       edgesFocusable={false}
       proOptions={{ hideAttribution: false }}
-      onNodeClick={onNodeClick}
       style={{ background: '#0a1626' }}
     >
       <Background variant={BackgroundVariant.Lines} gap={24} color="#13314d" />

--- a/apps/web/src/app/(marketing)/architecture/architecture-flow.tsx
+++ b/apps/web/src/app/(marketing)/architecture/architecture-flow.tsx
@@ -10,6 +10,7 @@ import {
   ReactFlow,
   type Edge,
   type Node,
+  type NodeMouseHandler,
   type NodeProps,
   type NodeTypes,
 } from '@xyflow/react';
@@ -179,7 +180,6 @@ const edge = (
   labelBgStyle: { fill: '#0a1626', fillOpacity: 0.9 },
   labelBgPadding: [4, 2],
   labelBgBorderRadius: 3,
-  markerEnd: undefined,
 });
 
 const edges: Edge[] = [
@@ -200,13 +200,14 @@ const edges: Edge[] = [
 ];
 
 export function ArchitectureFlow() {
-  const onNodeClick = useCallback((_event: unknown, clicked: Node) => {
-    const href = (clicked.data as BpData).href;
+  const onNodeClick: NodeMouseHandler<BpNode> = useCallback((_event, clicked) => {
+    const { href } = clicked.data;
     if (href) window.open(href, '_blank', 'noopener,noreferrer');
   }, []);
 
   return (
     <ReactFlow
+      aria-label="JobOps Copilot system architecture — interactive node diagram. A text description precedes this canvas for screen readers."
       nodeTypes={nodeTypes}
       defaultNodes={nodes}
       defaultEdges={edges}

--- a/apps/web/src/app/(marketing)/architecture/page.tsx
+++ b/apps/web/src/app/(marketing)/architecture/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next';
+import { ArchitectureFlow } from './architecture-flow';
+
+export const metadata: Metadata = {
+  title: 'Architecture',
+  description:
+    'Interactive system architecture for JobOps Copilot — Next.js web, Express API, a Python FastAPI agent (LangChain, RAG over pgvector, telemetry), Azure data and platform services, and companion automation.',
+};
+
+export default function ArchitecturePage() {
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6">
+      <p className="text-primary text-sm font-medium">System design</p>
+      <h1 className="font-heading mt-1 text-3xl font-bold tracking-tight sm:text-4xl">
+        Architecture
+      </h1>
+      <p className="text-muted-foreground mt-3 max-w-2xl text-sm sm:text-base">
+        An interactive map of how JobOps Copilot fits together — drag to pan, scroll to
+        zoom, and click any node with an <span className="text-foreground">↗</span> to open
+        its source. The Node API owns the CRM and orchestration; a Python service owns the
+        real AI. Follow the <span className="text-teal-400">teal</span> path for the AI
+        pipeline.
+      </p>
+
+      <div className="bg-card mt-6 h-[72vh] min-h-[520px] overflow-hidden rounded-xl border">
+        <ArchitectureFlow />
+      </div>
+
+      <p className="text-muted-foreground mt-4 text-xs">
+        Prefer a static image? The same diagram lives in the{' '}
+        <a
+          className="underline underline-offset-2"
+          href="https://github.com/Taleef7/jobops-copilot#readme"
+        >
+          README
+        </a>{' '}
+        and in{' '}
+        <a
+          className="underline underline-offset-2"
+          href="https://github.com/Taleef7/jobops-copilot/blob/main/docs/ARCHITECTURE.md"
+        >
+          docs/ARCHITECTURE.md
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(marketing)/architecture/page.tsx
+++ b/apps/web/src/app/(marketing)/architecture/page.tsx
@@ -23,6 +23,15 @@ export default function ArchitecturePage() {
       </p>
 
       <div className="bg-card mt-6 h-[72vh] min-h-[520px] overflow-hidden rounded-xl border">
+        <p className="sr-only">
+          System architecture: a browser uses the Next.js web app, which calls the Express API
+          over REST. The API delegates AI work to a Python FastAPI agent (LangChain
+          multi-provider LLMs, retrieval-augmented generation, and pandas telemetry). Data is
+          stored in Azure PostgreSQL with the pgvector extension. Supporting services include
+          Azure Blob Storage for report exports, Hugging Face sentence-transformer embeddings,
+          n8n / Make / Zapier automation feeding the API webhooks, and Azure platform services
+          (Application Insights, Key Vault, and Log Analytics).
+        </p>
         <ArchitectureFlow />
       </div>
 

--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -21,7 +21,7 @@ export default async function MarketingLayout({ children }: { children: React.Re
           </Link>
           <nav className="ml-auto flex items-center gap-1.5 sm:gap-2">
             <Button
-              render={<a href="#features">Features</a>}
+              render={<Link href="/#features">Features</Link>}
               variant="ghost"
               size="sm"
               className="hidden sm:inline-flex"

--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -26,6 +26,12 @@ export default async function MarketingLayout({ children }: { children: React.Re
               size="sm"
               className="hidden sm:inline-flex"
             />
+            <Button
+              render={<Link href="/architecture">Architecture</Link>}
+              variant="ghost"
+              size="sm"
+              className="hidden sm:inline-flex"
+            />
             <ModeToggle />
             {signedIn ? (
               <>

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,7 +1,7 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
 
 // Public surface: marketing landing + architecture page + auth pages. Everything else requires sign-in.
-const isPublicRoute = createRouteMatcher(['/', '/architecture(.*)', '/sign-in(.*)', '/sign-up(.*)']);
+const isPublicRoute = createRouteMatcher(['/', '/architecture', '/sign-in(.*)', '/sign-up(.*)']);
 
 export default clerkMiddleware(async (auth, request) => {
   if (!isPublicRoute(request)) {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,7 +1,7 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
 
-// Public surface: marketing landing + auth pages. Everything else requires sign-in.
-const isPublicRoute = createRouteMatcher(['/', '/sign-in(.*)', '/sign-up(.*)']);
+// Public surface: marketing landing + architecture page + auth pages. Everything else requires sign-in.
+const isPublicRoute = createRouteMatcher(['/', '/architecture(.*)', '/sign-in(.*)', '/sign-up(.*)']);
 
 export default clerkMiddleware(async (auth, request) => {
   if (!isPublicRoute(request)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@clerk/nextjs": "^7.4.3",
+        "@xyflow/react": "^12.11.0",
         "applicationinsights": "^3.15.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -5510,6 +5511,55 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -5650,8 +5700,9 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6282,6 +6333,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
+      "integrity": "sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.77",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.77.tgz",
+      "integrity": "sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -7062,6 +7155,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -7320,6 +7419,112 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -14350,6 +14555,34 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

The "modern + interactive" companion to the static blueprint diagram in #36. Adds a public **`/architecture`** page on the live app — a pannable, zoomable, clickable system map built with **React Flow** (`@xyflow/react` v12, React 19), themed to match the blueprint hero SVG.

Pairs with #36 (static diagram + badges). The two are independent; merge order doesn't matter. To avoid a README conflict, this PR does **not** touch `README.md` — discoverability comes from a new **Architecture** nav link in the marketing header (the README link to the live page is added on #36).

### What's in here
- **`/architecture` route** under the `(marketing)` shell (public header/footer). Server component + a `'use client'` `ArchitectureFlow`.
- **Blueprint-themed canvas** — navy grid background, monospace nodes, **cyan** data path / **teal** AI path, dashed platform signals (telemetry, secrets). Mirrors the topology of the static SVG.
- **Custom node** with hidden 4-side handles so `smoothstep` edges route cleanly in every direction. Nodes with a source are **clickable** and deep-link to repo paths / the live app (open in a new tab).
- Read-only canvas (no drag/connect), `fitView`, dark `colorMode`, zoom `Controls`. React Flow attribution kept (OSS license).
- `proxy.ts`: `/architecture(.*)` added to the Clerk public matcher.
- Marketing header: **Architecture** nav link.

### Verification
- `npm run check` (web lint + typecheck + build, then API build) — **exit 0**.
- Ran the dev server and loaded `/architecture` **unauthenticated**: renders publicly, nav link works, canvas pans/zooms, nodes/edges/labels read clearly. **Zero app console errors** (only Clerk's expected dev-keys warning). Screenshot reviewed.
- New dependency installs cleanly against React 19 (no peer-dep errors).

### Notes
- The canvas is a deliberately fixed-dark "schematic" panel, so it looks consistent under both light and dark page themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)