### PR TITLE
docs: restore interactive /architecture link (page now live)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ bot**: it drafts and recommends, but never sends or fabricates.
 
 ![JobOps Copilot system architecture — browser to Next.js web to Express API to Python FastAPI agent (LangChain, RAG, telemetry) to Azure Postgres with pgvector, plus Blob Storage, Hugging Face embeddings, n8n/Make/Zapier automation, and Azure platform services](docs/architecture/architecture-blueprint.svg)
 
+> 🔎 **Interactive version** (pan · zoom · click any node):
+> [`/architecture`](https://jobops-web.azurewebsites.net/architecture) on the live app.
+
 ## Highlights
 
 - **Real, multi-provider LLMs** — a Python agent service routes to Anthropic

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,8 +7,8 @@ CRM and orchestration; a Python service owns the real AI.
 
 ![JobOps Copilot system architecture](architecture/architecture-blueprint.svg)
 
-> An interactive version (pan, zoom, click any node) will be available at
-> `/architecture` on the live app once the web-app page lands.
+> An interactive version (pan, zoom, click any node) is available at
+> [`/architecture`](https://jobops-web.azurewebsites.net/architecture) on the live app.
 
 ### Key decisions
 


### PR DESCRIPTION
## Summary

Follow-up to #36/#37 (both merged). The web has redeployed and the interactive page is live — `https://jobops-web.azurewebsites.net/architecture` returns **200** and renders publicly (verified in-browser).

Earlier I deliberately omitted the README `/architecture` hyperlink (and future-tensed the ARCHITECTURE.md note) so those docs PRs wouldn't advertise a route that didn't exist yet in isolation — Codex flagged exactly that. Now that the route is live, this restores both:

- **README** — re-adds the "Interactive version (pan · zoom · click any node) → `/architecture`" link under the hero diagram.
- **docs/ARCHITECTURE.md** — switches the note back to present tense and links the live page.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)