### PR TITLE
feat: real job ingestion — saved searches + discovery (Adzuna + fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ GMAIL_CLIENT_SECRET=
 GMAIL_DRAFTS_ENABLED=false
 GMAIL_REFRESH_TOKEN=
 N8N_WEBHOOK_SECRET=
+# Real job ingestion. Free Adzuna dev API: https://developer.adzuna.com — leave
+# blank to use the no-key Remotive fallback source. ADZUNA_COUNTRY is the 2-letter
+# market code (e.g. gb, us).
+ADZUNA_APP_ID=
+ADZUNA_APP_KEY=
+ADZUNA_COUNTRY=gb
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:4000
 # Optional shared secret for mutating API calls; set the same value in both variables.
 API_SHARED_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ N8N_WEBHOOK_SECRET=
 # market code (e.g. gb, us).
 ADZUNA_APP_ID=
 ADZUNA_APP_KEY=
-ADZUNA_COUNTRY=gb
+ADZUNA_COUNTRY=us
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:4000
 # Optional shared secret for mutating API calls; set the same value in both variables.
 API_SHARED_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Thumbs.db
 out/
 apps/api/data/jobs.json
 apps/api/data/weekly-reports.json
+apps/api/data/saved-searches.json
 apps/api/data/report-exports/
 apps/api/data/*.tmp
 workflows/n8n/owner.env

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -10,6 +10,8 @@ import { profileRouter } from '@/routes/profile';
 import { reportsRouter } from '@/routes/reports';
 import { outreachRouter } from '@/routes/outreach';
 import { telemetryRouter } from '@/routes/telemetry';
+import { discoveryRouter, discoverySweepRouter } from '@/routes/discovery';
+import { savedSearchesRouter } from '@/routes/saved-searches';
 
 const mutatingMethods = new Set(['POST', 'PATCH', 'PUT', 'DELETE']);
 
@@ -63,6 +65,11 @@ export function createApp() {
   app.use('/api/outreach', outreachRouter);
   app.use('/api/reports', reportsRouter);
   app.use('/api/telemetry', telemetryRouter);
+  app.use('/api/discovery', discoveryRouter);
+  app.use('/api/saved-searches', savedSearchesRouter);
+  // Mounted before '/api/n8n' so this more specific path wins; it inherits the
+  // shared-API-key exemption (path starts with /api/n8n) and uses the n8n secret.
+  app.use('/api/n8n/discover', discoverySweepRouter);
   app.use('/api/n8n', n8nRouter);
 
   app.use((_request, response) => {

--- a/apps/api/src/data/saved-search-store.postgres.ts
+++ b/apps/api/src/data/saved-search-store.postgres.ts
@@ -1,0 +1,66 @@
+import { randomUUID } from 'node:crypto';
+import type { CreateSavedSearchBody, SavedSearch } from '@/types';
+import { getPool } from '@/lib/postgres';
+
+type SavedSearchRow = {
+  id: string;
+  user_id: string;
+  query: string;
+  location: string | null;
+  remote_only: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+function poolOrThrow() {
+  const pool = getPool();
+  if (!pool) {
+    throw new Error('Postgres is not configured. Set DATABASE_URL to enable the database-backed store.');
+  }
+  return pool;
+}
+
+function mapRow(row: SavedSearchRow): SavedSearch {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    query: row.query,
+    location: row.location ?? undefined,
+    remoteOnly: row.remote_only,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function listSavedSearches(userId: string): Promise<SavedSearch[]> {
+  const { rows } = await poolOrThrow().query<SavedSearchRow>(
+    'select * from saved_searches where user_id = $1 order by created_at desc',
+    [userId],
+  );
+  return rows.map(mapRow);
+}
+
+export async function createSavedSearch(userId: string, body: CreateSavedSearchBody): Promise<SavedSearch> {
+  const { rows } = await poolOrThrow().query<SavedSearchRow>(
+    'insert into saved_searches (id, user_id, query, location, remote_only) values ($1,$2,$3,$4,$5) returning *',
+    [randomUUID(), userId, body.query.trim(), body.location?.trim() || null, Boolean(body.remoteOnly)],
+  );
+  const saved = rows[0];
+  if (!saved) {
+    throw new Error('Failed to create saved search');
+  }
+  return mapRow(saved);
+}
+
+export async function deleteSavedSearch(userId: string, id: string): Promise<boolean> {
+  const { rowCount } = await poolOrThrow().query(
+    'delete from saved_searches where user_id = $1 and id = $2',
+    [userId, id],
+  );
+  return (rowCount ?? 0) > 0;
+}
+
+export async function listUsersWithSavedSearches(): Promise<string[]> {
+  const { rows } = await poolOrThrow().query<{ user_id: string }>('select distinct user_id from saved_searches');
+  return rows.map((row) => row.user_id);
+}

--- a/apps/api/src/data/saved-search-store.postgres.ts
+++ b/apps/api/src/data/saved-search-store.postgres.ts
@@ -60,6 +60,10 @@ export async function deleteSavedSearch(userId: string, id: string): Promise<boo
   return (rowCount ?? 0) > 0;
 }
 
+export async function clearUserSavedSearches(userId: string): Promise<void> {
+  await poolOrThrow().query('delete from saved_searches where user_id = $1', [userId]);
+}
+
 export async function listUsersWithSavedSearches(): Promise<string[]> {
   const { rows } = await poolOrThrow().query<{ user_id: string }>('select distinct user_id from saved_searches');
   return rows.map((row) => row.user_id);

--- a/apps/api/src/data/saved-search-store.test.ts
+++ b/apps/api/src/data/saved-search-store.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  createSavedSearch,
+  deleteSavedSearch,
+  listSavedSearches,
+  listUsersWithSavedSearches,
+  resetSavedSearchStoreForTests,
+} from './saved-search-store';
+
+const USER = 'user_test';
+
+test('saved searches round-trip, trim input, and stay user-scoped', async () => {
+  const originalCwd = process.cwd();
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-saved-search-'));
+  try {
+    process.chdir(tempDir);
+    resetSavedSearchStoreForTests();
+
+    assert.equal((await listSavedSearches(USER)).length, 0);
+
+    const created = await createSavedSearch(USER, {
+      query: ' AI Engineer ',
+      location: ' Remote ',
+      remoteOnly: true,
+    });
+    assert.equal(created.query, 'AI Engineer');
+    assert.equal(created.location, 'Remote');
+    assert.equal(created.remoteOnly, true);
+
+    assert.equal((await listSavedSearches(USER)).length, 1);
+    assert.equal((await listSavedSearches('user_other')).length, 0);
+    assert.deepEqual(await listUsersWithSavedSearches(), [USER]);
+
+    // Cannot delete another user's search.
+    assert.equal(await deleteSavedSearch('user_other', created.id), false);
+    assert.equal(await deleteSavedSearch(USER, created.id), true);
+    assert.equal((await listSavedSearches(USER)).length, 0);
+  } finally {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/apps/api/src/data/saved-search-store.test.ts
+++ b/apps/api/src/data/saved-search-store.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import {
+  clearUserSavedSearches,
   createSavedSearch,
   deleteSavedSearch,
   listSavedSearches,
@@ -39,6 +40,26 @@ test('saved searches round-trip, trim input, and stay user-scoped', async () => 
     assert.equal(await deleteSavedSearch('user_other', created.id), false);
     assert.equal(await deleteSavedSearch(USER, created.id), true);
     assert.equal((await listSavedSearches(USER)).length, 0);
+  } finally {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('clearUserSavedSearches wipes only the given user', async () => {
+  const originalCwd = process.cwd();
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-saved-search-'));
+  try {
+    process.chdir(tempDir);
+    resetSavedSearchStoreForTests();
+
+    await createSavedSearch(USER, { query: 'python' });
+    await createSavedSearch('user_other', { query: 'rust' });
+
+    await clearUserSavedSearches(USER);
+
+    assert.equal((await listSavedSearches(USER)).length, 0);
+    assert.equal((await listSavedSearches('user_other')).length, 1);
   } finally {
     process.chdir(originalCwd);
     await rm(tempDir, { recursive: true, force: true });

--- a/apps/api/src/data/saved-search-store.ts
+++ b/apps/api/src/data/saved-search-store.ts
@@ -122,6 +122,17 @@ export async function listUsersWithSavedSearches(): Promise<string[]> {
   return [...new Set(all.map((entry) => entry.userId).filter((id): id is string => Boolean(id)))];
 }
 
+export async function clearUserSavedSearches(userId: string): Promise<void> {
+  if (hasPostgresConnection()) {
+    return postgresStore.clearUserSavedSearches(userId);
+  }
+  return runExclusive(async () => {
+    const all = await ensureLoaded();
+    cache = all.filter((entry) => entry.userId !== userId);
+    await persist();
+  });
+}
+
 export function resetSavedSearchStoreForTests() {
   cache = null;
   loadPromise = null;

--- a/apps/api/src/data/saved-search-store.ts
+++ b/apps/api/src/data/saved-search-store.ts
@@ -1,0 +1,129 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { CreateSavedSearchBody, SavedSearch } from '@/types';
+import { hasPostgresConnection } from '@/lib/postgres';
+import * as postgresStore from '@/data/saved-search-store.postgres';
+
+let cache: SavedSearch[] | null = null;
+let loadPromise: Promise<SavedSearch[]> | null = null;
+let mutationQueue: Promise<void> = Promise.resolve();
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function dataDir() {
+  return join(process.cwd(), 'data');
+}
+
+function dataFile() {
+  return join(dataDir(), 'saved-searches.json');
+}
+
+async function load(): Promise<SavedSearch[]> {
+  await mkdir(dataDir(), { recursive: true });
+  try {
+    const raw = await readFile(dataFile(), 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      throw new Error('Invalid saved-search store contents');
+    }
+    cache = parsed as SavedSearch[];
+  } catch {
+    cache = [];
+    await persist();
+  }
+  return cache;
+}
+
+async function ensureLoaded(): Promise<SavedSearch[]> {
+  if (cache) {
+    return cache;
+  }
+  loadPromise ??= load();
+  return loadPromise;
+}
+
+async function persist() {
+  if (!cache) {
+    return;
+  }
+  await mkdir(dataDir(), { recursive: true });
+  await writeFile(dataFile(), `${JSON.stringify(cache, null, 2)}\n`, 'utf8');
+}
+
+async function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+  const previous = mutationQueue;
+  let release!: () => void;
+  mutationQueue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
+export async function listSavedSearches(userId: string): Promise<SavedSearch[]> {
+  if (hasPostgresConnection()) {
+    return postgresStore.listSavedSearches(userId);
+  }
+  const all = await ensureLoaded();
+  return clone(
+    all
+      .filter((entry) => entry.userId === userId)
+      .sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt)),
+  );
+}
+
+export async function createSavedSearch(userId: string, body: CreateSavedSearchBody): Promise<SavedSearch> {
+  if (hasPostgresConnection()) {
+    return postgresStore.createSavedSearch(userId, body);
+  }
+  return runExclusive(async () => {
+    const all = await ensureLoaded();
+    const now = new Date().toISOString();
+    const search: SavedSearch = {
+      id: randomUUID(),
+      userId,
+      query: body.query.trim(),
+      location: body.location?.trim() || undefined,
+      remoteOnly: Boolean(body.remoteOnly),
+      createdAt: now,
+      updatedAt: now,
+    };
+    all.unshift(search);
+    await persist();
+    return clone(search);
+  });
+}
+
+export async function deleteSavedSearch(userId: string, id: string): Promise<boolean> {
+  if (hasPostgresConnection()) {
+    return postgresStore.deleteSavedSearch(userId, id);
+  }
+  return runExclusive(async () => {
+    const all = await ensureLoaded();
+    const before = all.length;
+    cache = all.filter((entry) => !(entry.id === id && entry.userId === userId));
+    await persist();
+    return cache.length < before;
+  });
+}
+
+export async function listUsersWithSavedSearches(): Promise<string[]> {
+  if (hasPostgresConnection()) {
+    return postgresStore.listUsersWithSavedSearches();
+  }
+  const all = await ensureLoaded();
+  return [...new Set(all.map((entry) => entry.userId).filter((id): id is string => Boolean(id)))];
+}
+
+export function resetSavedSearchStoreForTests() {
+  cache = null;
+  loadPromise = null;
+  mutationQueue = Promise.resolve();
+}

--- a/apps/api/src/lib/discovery.test.ts
+++ b/apps/api/src/lib/discovery.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { CreateJobBody, JobRecord, SavedSearch } from '@/types';
+import { runDiscoveryForUser, type DiscoveryDeps } from './discovery';
+import type { SourcedJob } from '@/lib/job-sources/normalize';
+
+const SEARCH: SavedSearch = {
+  id: 's1',
+  userId: 'u',
+  query: 'ai',
+  remoteOnly: false,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+};
+
+function makeDeps(
+  found: SourcedJob[],
+  existing: Partial<JobRecord>[],
+): { deps: DiscoveryDeps; created: CreateJobBody[] } {
+  const created: CreateJobBody[] = [];
+  const deps: DiscoveryDeps = {
+    source: { name: 'adzuna', search: async () => found },
+    listJobs: async () => existing as unknown as JobRecord[],
+    createJob: async (_userId, body) => {
+      created.push(body);
+      return body as unknown as JobRecord;
+    },
+    listSavedSearches: async () => [SEARCH],
+  };
+  return { deps, created };
+}
+
+function sourced(url: string, overrides: Partial<SourcedJob> = {}): SourcedJob {
+  return { source: 'adzuna', company: 'A', title: 'T', location: 'L', descriptionText: '', jobUrl: url, ...overrides };
+}
+
+test('inserts new jobs and skips duplicates of existing CRM jobs', async () => {
+  const { deps, created } = makeDeps(
+    [sourced('https://x/1'), sourced('https://x/2', { company: 'B', title: 'T2' })],
+    [{ jobUrl: 'https://x/1', company: 'A', title: 'T', location: 'L' }],
+  );
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 1);
+  assert.equal(result.skipped, 1);
+  assert.equal(result.source, 'adzuna');
+  assert.equal(created.length, 1);
+  assert.equal(created[0]?.jobUrl, 'https://x/2');
+});
+
+test('dedupes repeated postings within the same run', async () => {
+  const { deps, created } = makeDeps([sourced('https://dup/1'), sourced('https://dup/1')], []);
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 1);
+  assert.equal(result.skipped, 1);
+  assert.equal(created.length, 1);
+});

--- a/apps/api/src/lib/discovery.test.ts
+++ b/apps/api/src/lib/discovery.test.ts
@@ -58,3 +58,56 @@ test('dedupes repeated postings within the same run', async () => {
   assert.equal(result.skipped, 1);
   assert.equal(created.length, 1);
 });
+
+test('dedupes a URL-less source copy against a URL-backed CRM job', async () => {
+  const urlless: SourcedJob = { source: 'adzuna', company: 'A', title: 'T', location: 'L', descriptionText: '' };
+  const { deps, created } = makeDeps(
+    [urlless],
+    [{ jobUrl: 'https://x/1', company: 'A', title: 'T', location: 'L' }],
+  );
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 0);
+  assert.equal(result.skipped, 1);
+  assert.equal(created.length, 0);
+});
+
+test('counts a concurrent duplicate insert (Postgres 23505) as skipped', async () => {
+  const created: CreateJobBody[] = [];
+  const deps: DiscoveryDeps = {
+    source: {
+      name: 'adzuna',
+      search: async () => [sourced('https://race/1'), sourced('https://race/2', { company: 'B' })],
+    },
+    listJobs: async () => [],
+    createJob: async (_userId, body) => {
+      if (body.jobUrl === 'https://race/1') {
+        throw Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
+      }
+      created.push(body);
+      return body as unknown as JobRecord;
+    },
+    listSavedSearches: async () => [SEARCH],
+  };
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 1);
+  assert.equal(result.skipped, 1);
+  assert.equal(created.length, 1);
+  assert.equal(created[0]?.jobUrl, 'https://race/2');
+});
+
+test('propagates non-duplicate insert errors', async () => {
+  const deps: DiscoveryDeps = {
+    source: { name: 'adzuna', search: async () => [sourced('https://boom/1')] },
+    listJobs: async () => [],
+    createJob: async () => {
+      throw new Error('db down');
+    },
+    listSavedSearches: async () => [SEARCH],
+  };
+
+  await assert.rejects(runDiscoveryForUser('u', deps), /db down/);
+});

--- a/apps/api/src/lib/discovery.test.ts
+++ b/apps/api/src/lib/discovery.test.ts
@@ -73,6 +73,20 @@ test('dedupes a URL-less source copy against a URL-backed CRM job', async () => 
   assert.equal(created.length, 0);
 });
 
+test('dedupes a URL-less source copy against a URL-less CRM job (fingerprint match)', async () => {
+  const urlless: SourcedJob = { source: 'adzuna', company: 'A', title: 'T', location: 'L', descriptionText: '' };
+  const { deps, created } = makeDeps(
+    [urlless],
+    [{ company: 'A', title: 'T', location: 'L' }], // existing CRM job with no URL
+  );
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 0);
+  assert.equal(result.skipped, 1);
+  assert.equal(created.length, 0);
+});
+
 test('counts a concurrent duplicate insert (Postgres 23505) as skipped', async () => {
   const created: CreateJobBody[] = [];
   const deps: DiscoveryDeps = {

--- a/apps/api/src/lib/discovery.ts
+++ b/apps/api/src/lib/discovery.ts
@@ -1,8 +1,7 @@
-import type { JobRecord } from '@/types';
 import { createJob as createJobStore, listJobs as listJobsStore } from '@/data/job-store';
 import { listSavedSearches as listSavedSearchesStore } from '@/data/saved-search-store';
 import type { JobSource } from '@/lib/job-sources';
-import { dedupKey } from '@/lib/job-sources/normalize';
+import { dedupKey, fingerprintKey } from '@/lib/job-sources/normalize';
 
 export interface DiscoveryResult {
   inserted: number;
@@ -17,10 +16,22 @@ export interface DiscoveryDeps {
   listSavedSearches: typeof listSavedSearchesStore;
 }
 
-/** Same key derivation as `dedupKey`, for the user's already-stored jobs. */
-function existingKey(job: JobRecord): string {
-  if (job.jobUrl) return job.jobUrl.toLowerCase();
-  return [job.company, job.title, job.location].map((part) => (part ?? '').trim().toLowerCase()).join('|');
+/**
+ * Every dedup key a job occupies: its URL key (when present) *and* its
+ * `company|title|location` fingerprint. Recording both for stored jobs lets a
+ * URL-backed posting collide with a URL-less copy of the same posting (e.g. a
+ * manually tracked job vs. a source row that omits the URL).
+ */
+function keysFor(job: { jobUrl?: string; company?: string; title?: string; location?: string }): string[] {
+  const fingerprint = fingerprintKey(job);
+  return job.jobUrl ? [job.jobUrl.toLowerCase(), fingerprint] : [fingerprint];
+}
+
+/** Postgres unique-violation — a concurrent run already inserted this posting. */
+function isDuplicateKeyError(error: unknown): boolean {
+  return (
+    typeof error === 'object' && error !== null && (error as { code?: string }).code === '23505'
+  );
 }
 
 /**
@@ -30,7 +41,7 @@ function existingKey(job: JobRecord): string {
  */
 export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): Promise<DiscoveryResult> {
   const searches = await deps.listSavedSearches(userId);
-  const seen = new Set((await deps.listJobs(userId)).map(existingKey));
+  const seen = new Set((await deps.listJobs(userId)).flatMap(keysFor));
 
   let inserted = 0;
   let skipped = 0;
@@ -53,9 +64,23 @@ export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): 
         skipped += 1;
         continue;
       }
-      seen.add(key);
-      await deps.createJob(userId, job);
-      inserted += 1;
+      // Reserve every key this posting occupies so a later URL-less/URL-backed
+      // copy in the same run is recognised as a duplicate.
+      for (const k of keysFor(job)) seen.add(k);
+      try {
+        await deps.createJob(userId, job);
+        inserted += 1;
+      } catch (error) {
+        // A concurrent discovery run (manual click + n8n sweep, or two API
+        // instances) can insert the same posting between building `seen` and
+        // this insert; Postgres' per-user (user_id, job_url) unique index then
+        // rejects it. Count the race as a skip instead of failing the request.
+        if (isDuplicateKeyError(error)) {
+          skipped += 1;
+          continue;
+        }
+        throw error;
+      }
     }
   }
 

--- a/apps/api/src/lib/discovery.ts
+++ b/apps/api/src/lib/discovery.ts
@@ -1,0 +1,63 @@
+import type { JobRecord } from '@/types';
+import { createJob as createJobStore, listJobs as listJobsStore } from '@/data/job-store';
+import { listSavedSearches as listSavedSearchesStore } from '@/data/saved-search-store';
+import type { JobSource } from '@/lib/job-sources';
+import { dedupKey } from '@/lib/job-sources/normalize';
+
+export interface DiscoveryResult {
+  inserted: number;
+  skipped: number;
+  source: string;
+}
+
+export interface DiscoveryDeps {
+  source: JobSource;
+  listJobs: typeof listJobsStore;
+  createJob: typeof createJobStore;
+  listSavedSearches: typeof listSavedSearchesStore;
+}
+
+/** Same key derivation as `dedupKey`, for the user's already-stored jobs. */
+function existingKey(job: JobRecord): string {
+  if (job.jobUrl) return job.jobUrl.toLowerCase();
+  return [job.company, job.title, job.location].map((part) => (part ?? '').trim().toLowerCase()).join('|');
+}
+
+/**
+ * Run every saved search for a user against the active job source and insert the
+ * new postings into their CRM, skipping duplicates (of existing jobs and within
+ * the run). A single failing search is skipped rather than aborting the run.
+ */
+export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): Promise<DiscoveryResult> {
+  const searches = await deps.listSavedSearches(userId);
+  const seen = new Set((await deps.listJobs(userId)).map(existingKey));
+
+  let inserted = 0;
+  let skipped = 0;
+
+  for (const search of searches) {
+    let found;
+    try {
+      found = await deps.source.search(search.query, {
+        location: search.location,
+        remoteOnly: search.remoteOnly,
+        limit: 20,
+      });
+    } catch {
+      continue;
+    }
+
+    for (const job of found) {
+      const key = dedupKey(job);
+      if (seen.has(key)) {
+        skipped += 1;
+        continue;
+      }
+      seen.add(key);
+      await deps.createJob(userId, job);
+      inserted += 1;
+    }
+  }
+
+  return { inserted, skipped, source: deps.source.name };
+}

--- a/apps/api/src/lib/discovery.ts
+++ b/apps/api/src/lib/discovery.ts
@@ -27,7 +27,14 @@ function keysFor(job: { jobUrl?: string; company?: string; title?: string; locat
   return job.jobUrl ? [job.jobUrl.toLowerCase(), fingerprint] : [fingerprint];
 }
 
-/** Postgres unique-violation — a concurrent run already inserted this posting. */
+/**
+ * Postgres unique-violation — a concurrent run already inserted this posting.
+ * Safe to treat as a duplicate because `jobs_user_job_url_unique_idx`
+ * (the per-user `(user_id, job_url)` index) is the only raisable unique
+ * constraint in `createJob`'s transaction; `job_analysis` uses
+ * `on conflict do update`. Revisit this if another unique index is added to
+ * either table, or a real conflict would be silently counted as skipped.
+ */
 function isDuplicateKeyError(error: unknown): boolean {
   return (
     typeof error === 'object' && error !== null && (error as { code?: string }).code === '23505'

--- a/apps/api/src/lib/job-sources/adzuna.test.ts
+++ b/apps/api/src/lib/job-sources/adzuna.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createAdzunaSource } from './adzuna';
+
+function captureFetch() {
+  const original = globalThis.fetch;
+  let lastUrl = '';
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+    lastUrl = String(input);
+    return { ok: true, status: 200, json: async () => ({ results: [] }) } as unknown as Response;
+  }) as typeof fetch;
+  return {
+    restore: () => {
+      globalThis.fetch = original;
+    },
+    url: () => new URL(lastUrl),
+  };
+}
+
+async function withAdzunaKeys(fn: () => Promise<void>) {
+  const prevId = process.env.ADZUNA_APP_ID;
+  const prevKey = process.env.ADZUNA_APP_KEY;
+  process.env.ADZUNA_APP_ID = 'id';
+  process.env.ADZUNA_APP_KEY = 'key';
+  try {
+    await fn();
+  } finally {
+    if (prevId === undefined) delete process.env.ADZUNA_APP_ID;
+    else process.env.ADZUNA_APP_ID = prevId;
+    if (prevKey === undefined) delete process.env.ADZUNA_APP_KEY;
+    else process.env.ADZUNA_APP_KEY = prevKey;
+  }
+}
+
+test('Adzuna omits the geographic `where` for non-place locations and stays fresh', async () => {
+  const capture = captureFetch();
+  await withAdzunaKeys(async () => {
+    try {
+      await createAdzunaSource().search('python', { location: 'Remote' });
+      const url = capture.url();
+      assert.equal(url.searchParams.get('where'), null);
+      assert.equal(url.searchParams.get('what'), 'python');
+      assert.equal(url.searchParams.get('sort_by'), 'relevance');
+      assert.equal(url.searchParams.get('max_days_old'), '30');
+    } finally {
+      capture.restore();
+    }
+  });
+});
+
+test('Adzuna sends `where` for a real location and biases remote-only queries', async () => {
+  const capture = captureFetch();
+  await withAdzunaKeys(async () => {
+    try {
+      await createAdzunaSource().search('python', { location: 'Boston', remoteOnly: true });
+      const url = capture.url();
+      assert.equal(url.searchParams.get('where'), 'Boston');
+      assert.equal(url.searchParams.get('what'), 'python remote');
+    } finally {
+      capture.restore();
+    }
+  });
+});

--- a/apps/api/src/lib/job-sources/adzuna.ts
+++ b/apps/api/src/lib/job-sources/adzuna.ts
@@ -1,0 +1,32 @@
+import { normalizeAdzuna, type AdzunaRaw, type SourcedJob } from './normalize';
+import type { JobSearchOptions, JobSource } from './types';
+
+const BASE = 'https://api.adzuna.com/v1/api/jobs';
+
+/**
+ * Adzuna job source. Requires a free `ADZUNA_APP_ID`/`ADZUNA_APP_KEY`. The
+ * country is configurable via `ADZUNA_COUNTRY` (default `gb`). Throws on a
+ * non-2xx response so the composite source can fall back.
+ */
+export function createAdzunaSource(): JobSource {
+  return {
+    name: 'adzuna',
+    async search(query: string, opts: JobSearchOptions = {}): Promise<SourcedJob[]> {
+      const country = process.env.ADZUNA_COUNTRY?.trim() || 'gb';
+      const url = new URL(`${BASE}/${country}/search/1`);
+      url.searchParams.set('app_id', process.env.ADZUNA_APP_ID ?? '');
+      url.searchParams.set('app_key', process.env.ADZUNA_APP_KEY ?? '');
+      url.searchParams.set('what', query);
+      if (opts.location) url.searchParams.set('where', opts.location);
+      url.searchParams.set('results_per_page', String(opts.limit ?? 20));
+      url.searchParams.set('content-type', 'application/json');
+
+      const response = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+      if (!response.ok) {
+        throw new Error(`Adzuna request failed: ${response.status}`);
+      }
+      const data = (await response.json()) as { results?: AdzunaRaw[] };
+      return (data.results ?? []).map(normalizeAdzuna);
+    },
+  };
+}

--- a/apps/api/src/lib/job-sources/adzuna.ts
+++ b/apps/api/src/lib/job-sources/adzuna.ts
@@ -3,22 +3,39 @@ import type { JobSearchOptions, JobSource } from './types';
 
 const BASE = 'https://api.adzuna.com/v1/api/jobs';
 
+// Adzuna's `where` is a *geographic* filter — non-place values (e.g. "remote")
+// return zero results. For those we skip `where` and instead bias the keyword
+// query toward remote roles.
+const NON_GEOGRAPHIC = new Set(['remote', 'anywhere', 'worldwide', 'global']);
+
 /**
- * Adzuna job source. Requires a free `ADZUNA_APP_ID`/`ADZUNA_APP_KEY`. The
- * country is configurable via `ADZUNA_COUNTRY` (default `gb`). Throws on a
- * non-2xx response so the composite source can fall back.
+ * Adzuna job source. Requires a free `ADZUNA_APP_ID`/`ADZUNA_APP_KEY`. Country is
+ * configurable via `ADZUNA_COUNTRY` (default `us`). Sorted by date within the last
+ * 30 days for fresh, query-relevant postings. Throws on a non-2xx response so the
+ * composite source can fall back to Remotive.
  */
 export function createAdzunaSource(): JobSource {
   return {
     name: 'adzuna',
     async search(query: string, opts: JobSearchOptions = {}): Promise<SourcedJob[]> {
-      const country = process.env.ADZUNA_COUNTRY?.trim() || 'gb';
+      const country = process.env.ADZUNA_COUNTRY?.trim() || 'us';
       const url = new URL(`${BASE}/${country}/search/1`);
       url.searchParams.set('app_id', process.env.ADZUNA_APP_ID ?? '');
       url.searchParams.set('app_key', process.env.ADZUNA_APP_KEY ?? '');
-      url.searchParams.set('what', query);
-      if (opts.location) url.searchParams.set('where', opts.location);
+
+      const what = opts.remoteOnly ? `${query} remote` : query;
+      url.searchParams.set('what', what.trim());
+
+      const where = opts.location?.trim();
+      if (where && !NON_GEOGRAPHIC.has(where.toLowerCase())) {
+        url.searchParams.set('where', where);
+      }
+
       url.searchParams.set('results_per_page', String(opts.limit ?? 20));
+      // Relevance (not date) so `python developer` returns actual Python roles, not
+      // just the newest loosely-matching posting; max_days_old keeps it fresh.
+      url.searchParams.set('sort_by', 'relevance');
+      url.searchParams.set('max_days_old', '30');
       url.searchParams.set('content-type', 'application/json');
 
       const response = await fetch(url, { signal: AbortSignal.timeout(15_000) });

--- a/apps/api/src/lib/job-sources/index.test.ts
+++ b/apps/api/src/lib/job-sources/index.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getJobSource } from './index';
+
+type StubResult = { ok: boolean; status?: number; body: unknown };
+
+function stubFetch(handler: (url: string) => StubResult): () => void {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+    const result = handler(String(input));
+    return {
+      ok: result.ok,
+      status: result.status ?? (result.ok ? 200 : 500),
+      json: async () => result.body,
+    } as unknown as Response;
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+async function withEnv(vars: Record<string, string | undefined>, fn: () => Promise<void>): Promise<void> {
+  const previous: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(vars)) {
+    previous[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test('getJobSource uses Remotive when Adzuna is not configured', async () => {
+  await withEnv({ ADZUNA_APP_ID: undefined, ADZUNA_APP_KEY: undefined }, async () => {
+    const restore = stubFetch(() => ({ ok: true, body: { jobs: [{ url: 'https://r/1', title: 'T', company_name: 'C' }] } }));
+    try {
+      const source = getJobSource();
+      assert.equal(source.name, 'remotive');
+      const jobs = await source.search('engineer');
+      assert.equal(jobs.length, 1);
+      assert.equal(jobs[0]?.source, 'remotive');
+    } finally {
+      restore();
+    }
+  });
+});
+
+test('getJobSource prefers Adzuna when configured', async () => {
+  await withEnv({ ADZUNA_APP_ID: 'id', ADZUNA_APP_KEY: 'key' }, async () => {
+    const restore = stubFetch((url) =>
+      url.includes('adzuna')
+        ? { ok: true, body: { results: [{ redirect_url: 'https://a/1', title: 'AI', company: { display_name: 'Acme' } }] } }
+        : { ok: true, body: { jobs: [] } },
+    );
+    try {
+      const source = getJobSource();
+      const jobs = await source.search('ai');
+      assert.equal(source.name, 'adzuna');
+      assert.equal(jobs[0]?.source, 'adzuna');
+    } finally {
+      restore();
+    }
+  });
+});
+
+test('getJobSource falls back to Remotive when Adzuna fails', async () => {
+  await withEnv({ ADZUNA_APP_ID: 'id', ADZUNA_APP_KEY: 'key' }, async () => {
+    const restore = stubFetch((url) =>
+      url.includes('adzuna')
+        ? { ok: false, status: 429, body: {} }
+        : { ok: true, body: { jobs: [{ url: 'https://r/2', title: 'T', company_name: 'C' }] } },
+    );
+    try {
+      const source = getJobSource();
+      const jobs = await source.search('ai');
+      assert.equal(jobs.length, 1);
+      assert.equal(jobs[0]?.source, 'remotive');
+      assert.equal(source.name, 'remotive');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/apps/api/src/lib/job-sources/index.test.ts
+++ b/apps/api/src/lib/job-sources/index.test.ts
@@ -38,7 +38,7 @@ async function withEnv(vars: Record<string, string | undefined>, fn: () => Promi
 
 test('getJobSource uses Remotive when Adzuna is not configured', async () => {
   await withEnv({ ADZUNA_APP_ID: undefined, ADZUNA_APP_KEY: undefined }, async () => {
-    const restore = stubFetch(() => ({ ok: true, body: { jobs: [{ url: 'https://r/1', title: 'T', company_name: 'C' }] } }));
+    const restore = stubFetch(() => ({ ok: true, body: { jobs: [{ url: 'https://r/1', title: 'Engineer', company_name: 'C' }] } }));
     try {
       const source = getJobSource();
       assert.equal(source.name, 'remotive');
@@ -74,7 +74,7 @@ test('getJobSource falls back to Remotive when Adzuna fails', async () => {
     const restore = stubFetch((url) =>
       url.includes('adzuna')
         ? { ok: false, status: 429, body: {} }
-        : { ok: true, body: { jobs: [{ url: 'https://r/2', title: 'T', company_name: 'C' }] } },
+        : { ok: true, body: { jobs: [{ url: 'https://r/2', title: 'AI Engineer', company_name: 'C' }] } },
     );
     try {
       const source = getJobSource();

--- a/apps/api/src/lib/job-sources/index.ts
+++ b/apps/api/src/lib/job-sources/index.ts
@@ -1,0 +1,41 @@
+import { createAdzunaSource } from './adzuna';
+import { createRemotiveSource } from './remotive';
+import type { JobSource } from './types';
+
+export type { JobSource, JobSearchOptions } from './types';
+export type { SourcedJob } from './normalize';
+
+function adzunaConfigured(): boolean {
+  return Boolean(process.env.ADZUNA_APP_ID?.trim() && process.env.ADZUNA_APP_KEY?.trim());
+}
+
+/**
+ * The active job source. When Adzuna is configured it is preferred, but any
+ * failure (rate limit, 5xx, timeout) transparently falls back to Remotive — the
+ * no-key source — so discovery never hard-fails on a transient upstream error.
+ * `name` reflects the source actually used by the most recent `search`.
+ */
+export function getJobSource(): JobSource {
+  if (!adzunaConfigured()) {
+    return createRemotiveSource();
+  }
+
+  const adzuna = createAdzunaSource();
+  const remotive = createRemotiveSource();
+  let used = adzuna.name;
+
+  return {
+    get name() {
+      return used;
+    },
+    async search(query, opts) {
+      try {
+        used = adzuna.name;
+        return await adzuna.search(query, opts);
+      } catch {
+        used = remotive.name;
+        return remotive.search(query, opts);
+      }
+    },
+  };
+}

--- a/apps/api/src/lib/job-sources/normalize.test.ts
+++ b/apps/api/src/lib/job-sources/normalize.test.ts
@@ -19,6 +19,7 @@ test('normalizeAdzuna maps and trims an Adzuna result', () => {
   assert.equal(job.title, 'AI Engineer');
   assert.equal(job.location, 'Remote');
   assert.equal(job.employmentType, 'Full-time');
+  assert.equal(job.workplaceType, 'remote');
   assert.equal(job.datePosted, '2026-06-01T00:00:00Z');
   assert.equal(job.descriptionText, 'Build agents');
 });
@@ -29,8 +30,24 @@ test('normalizeAdzuna falls back to safe defaults for missing fields', () => {
   assert.equal(job.title, 'Untitled role');
   assert.equal(job.location, '');
   assert.equal(job.employmentType, 'Full-time');
+  assert.equal(job.workplaceType, 'onsite');
   assert.equal(job.jobUrl, undefined);
   assert.equal(job.descriptionText, '');
+});
+
+test('normalizeAdzuna infers workplaceType (onsite default, hybrid/remote from text)', () => {
+  assert.equal(
+    normalizeAdzuna({ title: 'Backend Engineer', location: { display_name: 'Austin, TX' } }).workplaceType,
+    'onsite',
+  );
+  assert.equal(
+    normalizeAdzuna({ title: 'Engineer (Hybrid)', location: { display_name: 'NYC' } }).workplaceType,
+    'hybrid',
+  );
+  assert.equal(
+    normalizeAdzuna({ title: 'Remote Engineer', location: { display_name: 'Anywhere' } }).workplaceType,
+    'remote',
+  );
 });
 
 test('normalizeRemotive maps a result and marks it remote', () => {

--- a/apps/api/src/lib/job-sources/normalize.test.ts
+++ b/apps/api/src/lib/job-sources/normalize.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { dedupKey, normalizeAdzuna, normalizeRemotive, type SourcedJob } from './normalize';
+
+test('normalizeAdzuna maps and trims an Adzuna result', () => {
+  const job = normalizeAdzuna({
+    redirect_url: 'https://adzuna.example/x',
+    title: '  AI Engineer ',
+    company: { display_name: ' Acme ' },
+    location: { display_name: ' Remote ' },
+    description: 'Build agents',
+    created: '2026-06-01T00:00:00Z',
+    contract_time: 'full_time',
+  });
+
+  assert.equal(job.source, 'adzuna');
+  assert.equal(job.jobUrl, 'https://adzuna.example/x');
+  assert.equal(job.company, 'Acme');
+  assert.equal(job.title, 'AI Engineer');
+  assert.equal(job.location, 'Remote');
+  assert.equal(job.employmentType, 'Full-time');
+  assert.equal(job.datePosted, '2026-06-01T00:00:00Z');
+  assert.equal(job.descriptionText, 'Build agents');
+});
+
+test('normalizeAdzuna falls back to safe defaults for missing fields', () => {
+  const job = normalizeAdzuna({});
+  assert.equal(job.company, 'Unknown');
+  assert.equal(job.title, 'Untitled role');
+  assert.equal(job.location, '');
+  assert.equal(job.employmentType, 'Full-time');
+  assert.equal(job.jobUrl, undefined);
+  assert.equal(job.descriptionText, '');
+});
+
+test('normalizeRemotive maps a result and marks it remote', () => {
+  const job = normalizeRemotive({
+    url: 'https://remotive.example/y',
+    title: 'Backend Engineer',
+    company_name: 'Globex',
+    candidate_required_location: 'Worldwide',
+    description: '<p>Do things</p>',
+    publication_date: '2026-06-02T00:00:00',
+    job_type: 'part_time',
+  });
+
+  assert.equal(job.source, 'remotive');
+  assert.equal(job.jobUrl, 'https://remotive.example/y');
+  assert.equal(job.company, 'Globex');
+  assert.equal(job.workplaceType, 'remote');
+  assert.equal(job.location, 'Worldwide');
+  assert.equal(job.employmentType, 'Part-time');
+});
+
+test('normalizeRemotive defaults location to Remote when absent', () => {
+  const job = normalizeRemotive({ title: 'X', company_name: 'Y' });
+  assert.equal(job.location, 'Remote');
+  assert.equal(job.workplaceType, 'remote');
+});
+
+test('dedupKey uses the url when present, else company|title|location', () => {
+  const withUrl: SourcedJob = {
+    jobUrl: 'https://X/A',
+    company: 'c',
+    title: 't',
+    location: 'l',
+    source: 'adzuna',
+    descriptionText: '',
+  };
+  const withoutUrl: SourcedJob = {
+    company: 'Acme',
+    title: 'AI Eng',
+    location: 'NYC',
+    source: 'adzuna',
+    descriptionText: '',
+  };
+  assert.equal(dedupKey(withUrl), 'https://x/a');
+  assert.equal(dedupKey(withoutUrl), 'acme|ai eng|nyc');
+});

--- a/apps/api/src/lib/job-sources/normalize.ts
+++ b/apps/api/src/lib/job-sources/normalize.ts
@@ -1,0 +1,75 @@
+import type { CreateJobBody } from '@/types';
+
+/** A job from an external source, shaped for `createJob`, tagged with its origin. */
+export type SourcedJob = CreateJobBody & { source: string };
+
+/** Raw Adzuna `/search` result (only the fields we use). */
+export interface AdzunaRaw {
+  redirect_url?: string;
+  title?: string;
+  company?: { display_name?: string };
+  location?: { display_name?: string };
+  description?: string;
+  created?: string;
+  contract_time?: string;
+}
+
+/** Raw Remotive `/remote-jobs` result (only the fields we use). */
+export interface RemotiveRaw {
+  url?: string;
+  title?: string;
+  company_name?: string;
+  candidate_required_location?: string;
+  description?: string;
+  publication_date?: string;
+  job_type?: string;
+}
+
+function clean(value: unknown, fallback = ''): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+/** Map a source's free-form employment string to the app's display labels. */
+function employmentLabel(raw: unknown): string {
+  const value = clean(raw).toLowerCase();
+  if (value.includes('part')) return 'Part-time';
+  if (value.includes('contract')) return 'Contract';
+  if (value.includes('intern')) return 'Internship';
+  return 'Full-time';
+}
+
+export function normalizeAdzuna(raw: AdzunaRaw): SourcedJob {
+  return {
+    jobUrl: clean(raw.redirect_url) || undefined,
+    source: 'adzuna',
+    company: clean(raw.company?.display_name, 'Unknown'),
+    title: clean(raw.title, 'Untitled role'),
+    location: clean(raw.location?.display_name),
+    employmentType: employmentLabel(raw.contract_time),
+    datePosted: clean(raw.created) || undefined,
+    descriptionText: clean(raw.description),
+  };
+}
+
+export function normalizeRemotive(raw: RemotiveRaw): SourcedJob {
+  return {
+    jobUrl: clean(raw.url) || undefined,
+    source: 'remotive',
+    company: clean(raw.company_name, 'Unknown'),
+    title: clean(raw.title, 'Untitled role'),
+    location: clean(raw.candidate_required_location, 'Remote'),
+    employmentType: employmentLabel(raw.job_type),
+    workplaceType: 'remote',
+    datePosted: clean(raw.publication_date) || undefined,
+    descriptionText: clean(raw.description),
+  };
+}
+
+/**
+ * Stable per-user dedup key: the canonical job URL when present, otherwise a
+ * `company|title|location` fingerprint so URL-less postings still dedup.
+ */
+export function dedupKey(job: SourcedJob): string {
+  if (job.jobUrl) return job.jobUrl.toLowerCase();
+  return [job.company, job.title, job.location].map((part) => clean(part).toLowerCase()).join('|');
+}

--- a/apps/api/src/lib/job-sources/normalize.ts
+++ b/apps/api/src/lib/job-sources/normalize.ts
@@ -79,10 +79,23 @@ export function normalizeRemotive(raw: RemotiveRaw): SourcedJob {
 }
 
 /**
- * Stable per-user dedup key: the canonical job URL when present, otherwise a
+ * `company|title|location` fingerprint — the URL-less dedup fallback. Exposed
+ * so callers can record it alongside the URL key for URL-backed jobs, letting a
+ * posting collide with a URL-less copy of itself.
+ */
+export function fingerprintKey(job: {
+  company?: string;
+  title?: string;
+  location?: string;
+}): string {
+  return [job.company, job.title, job.location].map((part) => clean(part).toLowerCase()).join('|');
+}
+
+/**
+ * Stable per-user dedup key: the canonical job URL when present, otherwise the
  * `company|title|location` fingerprint so URL-less postings still dedup.
  */
 export function dedupKey(job: SourcedJob): string {
   if (job.jobUrl) return job.jobUrl.toLowerCase();
-  return [job.company, job.title, job.location].map((part) => clean(part).toLowerCase()).join('|');
+  return fingerprintKey(job);
 }

--- a/apps/api/src/lib/job-sources/normalize.ts
+++ b/apps/api/src/lib/job-sources/normalize.ts
@@ -1,4 +1,4 @@
-import type { CreateJobBody } from '@/types';
+import type { CreateJobBody, JobWorkplaceType } from '@/types';
 
 /** A job from an external source, shaped for `createJob`, tagged with its origin. */
 export type SourcedJob = CreateJobBody & { source: string };
@@ -38,6 +38,18 @@ function employmentLabel(raw: unknown): string {
   return 'Full-time';
 }
 
+/**
+ * Adzuna provides no workplace field. Infer it from the text, defaulting to
+ * `onsite` — important because the job stores default an *omitted* workplaceType
+ * to `remote`, which would mislabel physical-location roles.
+ */
+function inferWorkplaceType(...fields: Array<string | undefined>): JobWorkplaceType {
+  const text = fields.map((field) => clean(field).toLowerCase()).join(' ');
+  if (text.includes('hybrid')) return 'hybrid';
+  if (/\bremote\b|work from home|\bwfh\b/.test(text)) return 'remote';
+  return 'onsite';
+}
+
 export function normalizeAdzuna(raw: AdzunaRaw): SourcedJob {
   return {
     jobUrl: clean(raw.redirect_url) || undefined,
@@ -46,6 +58,7 @@ export function normalizeAdzuna(raw: AdzunaRaw): SourcedJob {
     title: clean(raw.title, 'Untitled role'),
     location: clean(raw.location?.display_name),
     employmentType: employmentLabel(raw.contract_time),
+    workplaceType: inferWorkplaceType(raw.title, raw.location?.display_name, raw.description),
     datePosted: clean(raw.created) || undefined,
     descriptionText: clean(raw.description),
   };

--- a/apps/api/src/lib/job-sources/remotive.test.ts
+++ b/apps/api/src/lib/job-sources/remotive.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRemotiveSource } from './remotive';
+
+function stubFetch(jobs: unknown[]): () => void {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    ({ ok: true, status: 200, json: async () => ({ jobs }) }) as unknown as Response) as typeof fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+test('Remotive filters the generic feed by query terms', async () => {
+  const restore = stubFetch([
+    { url: 'https://r/1', title: 'Python Developer', company_name: 'Acme', candidate_required_location: 'USA' },
+    { url: 'https://r/2', title: 'Marketing Manager', company_name: 'Globex', candidate_required_location: 'USA' },
+  ]);
+  try {
+    const jobs = await createRemotiveSource().search('python');
+    assert.deepEqual(
+      jobs.map((job) => job.title),
+      ['Python Developer'],
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('Remotive filters by a real location but ignores remote-ish ones', async () => {
+  const feed = [
+    { url: 'https://r/1', title: 'Engineer', company_name: 'Acme', candidate_required_location: 'USA' },
+    { url: 'https://r/2', title: 'Engineer', company_name: 'Globex', candidate_required_location: 'Europe' },
+  ];
+
+  let restore = stubFetch(feed);
+  try {
+    const usOnly = await createRemotiveSource().search('engineer', { location: 'USA' });
+    assert.deepEqual(
+      usOnly.map((job) => job.location),
+      ['USA'],
+    );
+  } finally {
+    restore();
+  }
+
+  restore = stubFetch(feed);
+  try {
+    const all = await createRemotiveSource().search('engineer', { location: 'Remote' });
+    assert.equal(all.length, 2);
+  } finally {
+    restore();
+  }
+});

--- a/apps/api/src/lib/job-sources/remotive.ts
+++ b/apps/api/src/lib/job-sources/remotive.ts
@@ -1,9 +1,15 @@
 import { normalizeRemotive, type RemotiveRaw, type SourcedJob } from './normalize';
 import type { JobSearchOptions, JobSource } from './types';
 
+const NON_GEOGRAPHIC = new Set(['remote', 'anywhere', 'worldwide', 'global']);
+
 /**
  * Remotive job source — no API key required. Used as the always-available
  * fallback (and the default when Adzuna is not configured).
+ *
+ * Remotive's public API ignores the `search` and location parameters (it returns
+ * a generic recent feed), so we filter client-side to respect the saved search's
+ * query terms and location instead of inserting unrelated global-remote jobs.
  */
 export function createRemotiveSource(): JobSource {
   return {
@@ -11,14 +17,29 @@ export function createRemotiveSource(): JobSource {
     async search(query: string, opts: JobSearchOptions = {}): Promise<SourcedJob[]> {
       const url = new URL('https://remotive.com/api/remote-jobs');
       if (query) url.searchParams.set('search', query);
-      url.searchParams.set('limit', String(opts.limit ?? 20));
+      url.searchParams.set('limit', String(opts.limit ?? 50));
 
       const response = await fetch(url, { signal: AbortSignal.timeout(15_000) });
       if (!response.ok) {
         throw new Error(`Remotive request failed: ${response.status}`);
       }
       const data = (await response.json()) as { jobs?: RemotiveRaw[] };
-      return (data.jobs ?? []).map(normalizeRemotive);
+      let jobs = (data.jobs ?? []).map(normalizeRemotive);
+
+      const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+      if (terms.length > 0) {
+        jobs = jobs.filter((job) => {
+          const haystack = `${job.title} ${job.company} ${job.descriptionText}`.toLowerCase();
+          return terms.some((term) => haystack.includes(term));
+        });
+      }
+
+      const location = opts.location?.trim().toLowerCase();
+      if (location && !NON_GEOGRAPHIC.has(location)) {
+        jobs = jobs.filter((job) => (job.location ?? '').toLowerCase().includes(location));
+      }
+
+      return jobs;
     },
   };
 }

--- a/apps/api/src/lib/job-sources/remotive.ts
+++ b/apps/api/src/lib/job-sources/remotive.ts
@@ -1,0 +1,24 @@
+import { normalizeRemotive, type RemotiveRaw, type SourcedJob } from './normalize';
+import type { JobSearchOptions, JobSource } from './types';
+
+/**
+ * Remotive job source — no API key required. Used as the always-available
+ * fallback (and the default when Adzuna is not configured).
+ */
+export function createRemotiveSource(): JobSource {
+  return {
+    name: 'remotive',
+    async search(query: string, opts: JobSearchOptions = {}): Promise<SourcedJob[]> {
+      const url = new URL('https://remotive.com/api/remote-jobs');
+      if (query) url.searchParams.set('search', query);
+      url.searchParams.set('limit', String(opts.limit ?? 20));
+
+      const response = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+      if (!response.ok) {
+        throw new Error(`Remotive request failed: ${response.status}`);
+      }
+      const data = (await response.json()) as { jobs?: RemotiveRaw[] };
+      return (data.jobs ?? []).map(normalizeRemotive);
+    },
+  };
+}

--- a/apps/api/src/lib/job-sources/types.ts
+++ b/apps/api/src/lib/job-sources/types.ts
@@ -1,0 +1,13 @@
+import type { SourcedJob } from './normalize';
+
+export interface JobSearchOptions {
+  location?: string;
+  remoteOnly?: boolean;
+  limit?: number;
+}
+
+/** A pluggable external job source. `name` reflects the source actually used. */
+export interface JobSource {
+  readonly name: string;
+  search(query: string, opts?: JobSearchOptions): Promise<SourcedJob[]>;
+}

--- a/apps/api/src/routes/demo.ts
+++ b/apps/api/src/routes/demo.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { clearUserData, seedDemoData } from '@/data/job-store';
 import { clearUserReports, seedDemoReports } from '@/data/report-store';
 import { deleteUserProfile } from '@/data/profile-store';
+import { clearUserSavedSearches } from '@/data/saved-search-store';
 import { requireUser } from '@/lib/auth';
 
 export const demoRouter = Router();
@@ -27,6 +28,7 @@ demoRouter.post('/clear', async (request, response, next) => {
     await clearUserData(userId);
     await clearUserReports(userId);
     await deleteUserProfile(userId);
+    await clearUserSavedSearches(userId);
     response.json({ ok: true });
   } catch (error) {
     next(error);

--- a/apps/api/src/routes/discovery.test.ts
+++ b/apps/api/src/routes/discovery.test.ts
@@ -129,7 +129,7 @@ test('saved-search routes are user-scoped CRUD', async () => {
         method: 'DELETE',
         headers: { 'X-User-Id': 'user_test' },
       });
-      assert.equal(removed.status, 204);
+      assert.equal(removed.status, 200);
     },
   );
 });

--- a/apps/api/src/routes/discovery.test.ts
+++ b/apps/api/src/routes/discovery.test.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+import express from 'express';
+import { createDiscoveryRouter, createDiscoverySweepRouter } from './discovery';
+import { createSavedSearchesRouter } from './saved-searches';
+import type { DiscoveryResult } from '@/lib/discovery';
+import type { SavedSearch } from '@/types';
+
+function snapshotEnv(keys: string[]) {
+  const snapshot = new Map<string, string | undefined>();
+  for (const key of keys) snapshot.set(key, process.env[key]);
+  return () => {
+    for (const [key, value] of snapshot) {
+      if (typeof value === 'undefined') delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}
+
+async function withServer(mount: (app: express.Express) => void, run: (baseUrl: string) => Promise<void>) {
+  const app = express();
+  app.use(express.json());
+  // Mimic the dev-mode user resolution: trust X-User-Id for tests.
+  app.use((request, _response, next) => {
+    const header = request.header('X-User-Id');
+    if (header) request.userId = header.trim();
+    next();
+  });
+  mount(app);
+
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('Test server did not provide a usable address');
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+test('POST /api/discovery/run requires a signed-in user', async () => {
+  const router = createDiscoveryRouter({
+    runDiscovery: async () => ({ inserted: 0, skipped: 0, source: 'remotive' }),
+    listUsersWithSavedSearches: async () => [],
+  });
+  await withServer(
+    (app) => app.use('/api/discovery', router),
+    async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/discovery/run`, { method: 'POST' });
+      assert.equal(response.status, 401);
+    },
+  );
+});
+
+test('POST /api/discovery/run runs discovery for the request user', async () => {
+  const router = createDiscoveryRouter({
+    runDiscovery: async (userId) => {
+      assert.equal(userId, 'user_test');
+      return { inserted: 2, skipped: 1, source: 'adzuna' };
+    },
+    listUsersWithSavedSearches: async () => [],
+  });
+  await withServer(
+    (app) => app.use('/api/discovery', router),
+    async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/discovery/run`, {
+        method: 'POST',
+        headers: { 'X-User-Id': 'user_test' },
+      });
+      assert.equal(response.status, 200);
+      const data = (await response.json()) as DiscoveryResult;
+      assert.equal(data.inserted, 2);
+      assert.equal(data.skipped, 1);
+      assert.equal(data.source, 'adzuna');
+    },
+  );
+});
+
+test('saved-search routes are user-scoped CRUD', async () => {
+  const store: SavedSearch[] = [];
+  const router = createSavedSearchesRouter({
+    listSavedSearches: async (userId) => store.filter((entry) => entry.userId === userId),
+    createSavedSearch: async (userId, body) => {
+      const saved: SavedSearch = {
+        id: 's1',
+        userId,
+        query: body.query,
+        location: body.location,
+        remoteOnly: Boolean(body.remoteOnly),
+        createdAt: '2026-06-01T00:00:00.000Z',
+        updatedAt: '2026-06-01T00:00:00.000Z',
+      };
+      store.push(saved);
+      return saved;
+    },
+    deleteSavedSearch: async (userId, id) => {
+      const index = store.findIndex((entry) => entry.id === id && entry.userId === userId);
+      if (index < 0) return false;
+      store.splice(index, 1);
+      return true;
+    },
+  });
+
+  await withServer(
+    (app) => app.use('/api/saved-searches', router),
+    async (baseUrl) => {
+      const created = await fetch(`${baseUrl}/api/saved-searches`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-User-Id': 'user_test' },
+        body: JSON.stringify({ query: 'ai engineer' }),
+      });
+      assert.equal(created.status, 201);
+
+      const listed = await fetch(`${baseUrl}/api/saved-searches`, { headers: { 'X-User-Id': 'user_test' } });
+      const data = (await listed.json()) as { savedSearches: SavedSearch[] };
+      assert.equal(data.savedSearches.length, 1);
+
+      // Another user sees nothing.
+      const otherList = await fetch(`${baseUrl}/api/saved-searches`, { headers: { 'X-User-Id': 'user_other' } });
+      assert.equal(((await otherList.json()) as { savedSearches: SavedSearch[] }).savedSearches.length, 0);
+
+      const removed = await fetch(`${baseUrl}/api/saved-searches/s1`, {
+        method: 'DELETE',
+        headers: { 'X-User-Id': 'user_test' },
+      });
+      assert.equal(removed.status, 204);
+    },
+  );
+});
+
+test('POST /api/n8n/discover is guarded by the n8n webhook secret', async () => {
+  const restore = snapshotEnv(['N8N_WEBHOOK_SECRET']);
+  process.env.N8N_WEBHOOK_SECRET = 'n8n-secret';
+  try {
+    const router = createDiscoverySweepRouter({
+      runDiscovery: async () => ({ inserted: 1, skipped: 0, source: 'remotive' }),
+      listUsersWithSavedSearches: async () => ['u1', 'u2'],
+    });
+    await withServer(
+      (app) => app.use('/api/n8n/discover', router),
+      async (baseUrl) => {
+        const rejected = await fetch(`${baseUrl}/api/n8n/discover`, { method: 'POST' });
+        assert.equal(rejected.status, 401);
+
+        const accepted = await fetch(`${baseUrl}/api/n8n/discover`, {
+          method: 'POST',
+          headers: { 'X-N8N-Webhook-Secret': 'n8n-secret' },
+        });
+        assert.equal(accepted.status, 200);
+        const data = (await accepted.json()) as { users: number; inserted: number };
+        assert.equal(data.users, 2);
+        assert.equal(data.inserted, 2);
+      },
+    );
+  } finally {
+    restore();
+  }
+});

--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -1,0 +1,77 @@
+import { Router } from 'express';
+import { requireUser } from '@/lib/auth';
+import { createJob, listJobs } from '@/data/job-store';
+import { listSavedSearches, listUsersWithSavedSearches } from '@/data/saved-search-store';
+import { getJobSource } from '@/lib/job-sources';
+import { requireN8nWebhookSecret } from '@/lib/n8n';
+import { runDiscoveryForUser, type DiscoveryResult } from '@/lib/discovery';
+
+export interface DiscoveryRouterDeps {
+  runDiscovery: (userId: string) => Promise<DiscoveryResult>;
+  listUsersWithSavedSearches: typeof listUsersWithSavedSearches;
+}
+
+const defaultDeps: DiscoveryRouterDeps = {
+  runDiscovery: (userId) =>
+    runDiscoveryForUser(userId, { source: getJobSource(), listJobs, createJob, listSavedSearches }),
+  listUsersWithSavedSearches,
+};
+
+/** User-facing discovery: `POST /api/discovery/run`. */
+export function createDiscoveryRouter(deps: DiscoveryRouterDeps = defaultDeps) {
+  const router = Router();
+
+  router.post('/run', async (request, response, next) => {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+    try {
+      response.json(await deps.runDiscovery(userId));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+/**
+ * Service-to-service scheduled sweep: `POST /api/n8n/discover`. Mounted under
+ * `/api/n8n` so it inherits the shared-API-key exemption; guarded by the n8n
+ * webhook secret. Iterates every user with saved searches.
+ */
+export function createDiscoverySweepRouter(deps: DiscoveryRouterDeps = defaultDeps) {
+  const router = Router();
+  router.use(requireN8nWebhookSecret);
+
+  router.post('/', async (_request, response, next) => {
+    try {
+      const userIds = await deps.listUsersWithSavedSearches();
+      let inserted = 0;
+      let skipped = 0;
+      const perUser: Array<{ user_id: string } & DiscoveryResult> = [];
+
+      for (const userId of userIds) {
+        const result = await deps.runDiscovery(userId);
+        inserted += result.inserted;
+        skipped += result.skipped;
+        perUser.push({ user_id: userId, ...result });
+      }
+
+      response.json({
+        workflow: 'discover',
+        users: userIds.length,
+        inserted,
+        skipped,
+        per_user: perUser,
+        notification: `Discovery swept ${userIds.length} saved-search user(s): ${inserted} new, ${skipped} skipped.`,
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+export const discoveryRouter = createDiscoveryRouter();
+export const discoverySweepRouter = createDiscoverySweepRouter();

--- a/apps/api/src/routes/saved-searches.ts
+++ b/apps/api/src/routes/saved-searches.ts
@@ -64,7 +64,7 @@ export function createSavedSearchesRouter(deps: SavedSearchDeps = defaultDeps) {
         response.status(404).json({ error: 'Saved search not found' });
         return;
       }
-      response.status(204).end();
+      response.json({ deleted: true });
     } catch (error) {
       next(error);
     }

--- a/apps/api/src/routes/saved-searches.ts
+++ b/apps/api/src/routes/saved-searches.ts
@@ -1,0 +1,76 @@
+import { Router } from 'express';
+import { requireUser } from '@/lib/auth';
+import {
+  createSavedSearch as createSavedSearchStore,
+  deleteSavedSearch as deleteSavedSearchStore,
+  listSavedSearches as listSavedSearchesStore,
+} from '@/data/saved-search-store';
+import type { CreateSavedSearchBody } from '@/types';
+
+export interface SavedSearchDeps {
+  listSavedSearches: typeof listSavedSearchesStore;
+  createSavedSearch: typeof createSavedSearchStore;
+  deleteSavedSearch: typeof deleteSavedSearchStore;
+}
+
+const defaultDeps: SavedSearchDeps = {
+  listSavedSearches: listSavedSearchesStore,
+  createSavedSearch: createSavedSearchStore,
+  deleteSavedSearch: deleteSavedSearchStore,
+};
+
+export function createSavedSearchesRouter(deps: SavedSearchDeps = defaultDeps) {
+  const router = Router();
+
+  router.get('/', async (request, response, next) => {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+    try {
+      response.json({ savedSearches: await deps.listSavedSearches(userId) });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/', async (request, response, next) => {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
+    const body = request.body as Partial<CreateSavedSearchBody>;
+    const query = body.query?.trim();
+    if (!query) {
+      response.status(400).json({ error: 'Invalid saved search', fields: { query: 'A search query is required.' } });
+      return;
+    }
+
+    try {
+      const saved = await deps.createSavedSearch(userId, {
+        query,
+        location: body.location?.trim() || undefined,
+        remoteOnly: Boolean(body.remoteOnly),
+      });
+      response.status(201).json({ savedSearch: saved });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.delete('/:id', async (request, response, next) => {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+    try {
+      const removed = await deps.deleteSavedSearch(userId, request.params.id);
+      if (!removed) {
+        response.status(404).json({ error: 'Saved search not found' });
+        return;
+      }
+      response.status(204).end();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+export const savedSearchesRouter = createSavedSearchesRouter();

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -178,3 +178,19 @@ export interface N8nWeeklyReportBody {
 export interface N8nFollowUpRemindersBody {
   as_of?: string;
 }
+
+export interface SavedSearch {
+  id: string;
+  userId?: string;
+  query: string;
+  location?: string;
+  remoteOnly: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateSavedSearchBody {
+  query: string;
+  location?: string;
+  remoteOnly?: boolean;
+}

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Database, FileText, Webhook } from 'lucide-react';
+import { SavedSearchesManager } from '@/components/saved-searches';
 import { SectionCard } from '@/components/section-card';
 import { DemoDataActions, ExportDataButton, ResumeReupload } from '@/components/settings-actions';
 import { Badge } from '@/components/ui/badge';
@@ -72,6 +73,10 @@ export default async function SettingsPage() {
           </div>
           <ResumeReupload />
         </div>
+      </SectionCard>
+
+      <SectionCard title="Job discovery" description="Save searches, then pull real postings into your CRM.">
+        <SavedSearchesManager />
       </SectionCard>
 
       <SectionCard title="AI provider" description="Configured on the server — shown here for transparency.">

--- a/apps/web/src/components/jobs-table.tsx
+++ b/apps/web/src/components/jobs-table.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { EmptyState } from '@/components/empty-state';
 import { FitScoreRing } from '@/components/fit-score-ring';
 import { StatusPill } from '@/components/status-pill';
+import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import {
   Table,
@@ -138,6 +139,11 @@ export function JobsTable({ jobs }: { jobs: Job[] }) {
                         <span className="text-muted-foreground block truncate text-xs">
                           {job.company} · {job.location}
                         </span>
+                        {job.source === 'adzuna' || job.source === 'remotive' ? (
+                          <Badge variant="outline" className="mt-1 text-[10px] font-normal capitalize">
+                            via {job.source}
+                          </Badge>
+                        ) : null}
                       </span>
                     </Link>
                   </TableCell>

--- a/apps/web/src/components/saved-searches.tsx
+++ b/apps/web/src/components/saved-searches.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Loader2, Plus, Sparkles, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  createSavedSearch,
+  deleteSavedSearch,
+  fetchSavedSearches,
+  runDiscovery,
+  type SavedSearchItem,
+} from '@/lib/api';
+
+export function SavedSearchesManager() {
+  const router = useRouter();
+  const [searches, setSearches] = useState<SavedSearchItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState('');
+  const [location, setLocation] = useState('');
+  const [adding, setAdding] = useState(false);
+  const [discovering, setDiscovering] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchSavedSearches()
+      .then(setSearches)
+      .catch(() => toast.error('Could not load saved searches.'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function onAdd(event: React.FormEvent) {
+    event.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    setAdding(true);
+    try {
+      const created = await createSavedSearch({ query: trimmed, location: location.trim() || undefined });
+      setSearches((prev) => [created, ...prev]);
+      setQuery('');
+      setLocation('');
+      toast.success('Saved search added.');
+    } catch {
+      toast.error('Could not add the saved search.');
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function onDelete(id: string) {
+    setDeletingId(id);
+    try {
+      await deleteSavedSearch(id);
+      setSearches((prev) => prev.filter((entry) => entry.id !== id));
+    } catch {
+      toast.error('Could not delete the saved search.');
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  async function onDiscover() {
+    setDiscovering(true);
+    try {
+      const result = await runDiscovery();
+      toast.success(
+        result.inserted > 0
+          ? `Found ${result.inserted} new job${result.inserted === 1 ? '' : 's'} (${result.skipped} already tracked) via ${result.source}.`
+          : `No new jobs found (${result.skipped} already tracked).`,
+      );
+      router.refresh();
+    } catch {
+      toast.error('Discovery failed. Add at least one saved search first.');
+    } finally {
+      setDiscovering(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={onAdd} className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Role or keywords, e.g. AI engineer"
+          aria-label="Search query"
+          className="flex-1"
+        />
+        <Input
+          value={location}
+          onChange={(event) => setLocation(event.target.value)}
+          placeholder="Location (optional)"
+          aria-label="Location"
+          className="sm:w-44"
+        />
+        <Button type="submit" size="sm" disabled={adding || !query.trim()}>
+          {adding ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
+          Add
+        </Button>
+      </form>
+
+      {loading ? (
+        <p className="text-muted-foreground text-sm">Loading…</p>
+      ) : searches.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          No saved searches yet. Add one above, then run discovery to pull real postings into your CRM.
+        </p>
+      ) : (
+        <ul className="divide-border divide-y rounded-lg border">
+          {searches.map((entry) => (
+            <li key={entry.id} className="flex items-center gap-2 px-3 py-2.5">
+              <div className="mr-auto min-w-0">
+                <p className="truncate text-sm font-medium">{entry.query}</p>
+                <p className="text-muted-foreground truncate text-xs">
+                  {entry.location || 'Anywhere'}
+                  {entry.remoteOnly ? ' · remote only' : ''}
+                </p>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Delete saved search"
+                disabled={deletingId === entry.id}
+                onClick={() => void onDelete(entry.id)}
+              >
+                {deletingId === entry.id ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Trash2 className="size-4" />
+                )}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button size="sm" disabled={discovering || searches.length === 0} onClick={() => void onDiscover()}>
+          {discovering ? <Loader2 className="size-4 animate-spin" /> : <Sparkles className="size-4" />}
+          Discover now
+        </Button>
+        <p className="text-muted-foreground text-xs">
+          Pulls real postings from your sources and adds new ones to your jobs.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -369,6 +369,48 @@ export async function fetchLatestWeeklyReport(): Promise<WeeklyReport | undefine
  * we route through the same-origin Next proxy (`/api/proxy/*`) which attaches
  * auth server-side, so the token is never exposed to client code.
  */
+export interface SavedSearchItem {
+  id: string;
+  query: string;
+  location?: string;
+  remoteOnly: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function fetchSavedSearches(): Promise<SavedSearchItem[]> {
+  const response = await requestJson<{ savedSearches: SavedSearchItem[] }>('/api/saved-searches', {
+    cache: 'no-store',
+  });
+  return response.savedSearches;
+}
+
+export async function createSavedSearch(payload: {
+  query: string;
+  location?: string;
+  remoteOnly?: boolean;
+}): Promise<SavedSearchItem> {
+  const response = await requestJson<{ savedSearch: SavedSearchItem }>('/api/saved-searches', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  return response.savedSearch;
+}
+
+export async function deleteSavedSearch(id: string): Promise<void> {
+  await requestJson<{ deleted: boolean }>(`/api/saved-searches/${id}`, { method: 'DELETE' });
+}
+
+export interface DiscoveryRunResult {
+  inserted: number;
+  skipped: number;
+  source: string;
+}
+
+export async function runDiscovery(): Promise<DiscoveryRunResult> {
+  return requestJson<DiscoveryRunResult>('/api/discovery/run', { method: 'POST', body: '{}' });
+}
+
 async function apiFetch(path: string, init: RequestInit): Promise<Response> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',

--- a/db/migrations/005_saved_searches.sql
+++ b/db/migrations/005_saved_searches.sql
@@ -1,0 +1,23 @@
+-- Per-user saved job searches that drive manual ("Discover now") and scheduled
+-- job discovery. Discovered postings land in the existing per-user `jobs` table
+-- as status='discovered'; dedup is handled by the per-user (user_id, job_url)
+-- unique index already created in 004_multitenant.sql.
+
+create table if not exists saved_searches (
+  id uuid primary key,
+  user_id text not null,
+  query text not null,
+  location text,
+  remote_only boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists saved_searches_user_idx on saved_searches (user_id);
+
+drop trigger if exists saved_searches_set_updated_at on saved_searches;
+
+create trigger saved_searches_set_updated_at
+before update on saved_searches
+for each row
+execute function set_updated_at();

--- a/workflows/n8n/job-discovery.json
+++ b/workflows/n8n/job-discovery.json
@@ -1,0 +1,58 @@
+{
+  "name": "JobOps — Scheduled Job Discovery",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "hours",
+              "hoursInterval": 24
+            }
+          ]
+        }
+      },
+      "id": "schedule-trigger",
+      "name": "Every 24h",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.JOBOPS_API_BASE_URL }}/api/n8n/discover",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-N8N-Webhook-Secret",
+              "value": "={{ $env.N8N_WEBHOOK_SECRET }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "discover-request",
+      "name": "POST /api/n8n/discover",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [480, 300]
+    }
+  ],
+  "connections": {
+    "Every 24h": {
+      "main": [
+        [
+          {
+            "node": "POST /api/n8n/discover",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {},
+  "active": false
+}

--- a/workflows/n8n/job-discovery.md
+++ b/workflows/n8n/job-discovery.md
@@ -1,0 +1,24 @@
+# n8n — Scheduled Job Discovery
+
+Runs the per-user saved-search discovery sweep on a schedule, so each account's
+saved searches keep pulling fresh postings without anyone clicking "Discover now".
+
+## Import
+
+1. In n8n, **Import from File** → `job-discovery.json`.
+2. Set environment variables (or hardcode them in the HTTP Request node):
+   - `JOBOPS_API_BASE_URL` — your API base, e.g. `https://jobops-api.azurewebsites.net`.
+   - `N8N_WEBHOOK_SECRET` — must match the API's `N8N_WEBHOOK_SECRET`.
+3. Activate the workflow.
+
+## What it does
+
+Every 24h the **Every 24h** schedule fires an HTTP `POST` to `/api/n8n/discover`
+with the `X-N8N-Webhook-Secret` header. The API iterates every user with saved
+searches, pulls fresh postings from the active source (Adzuna, falling back to
+Remotive when Adzuna is unconfigured or rate-limited), dedups per user, and
+inserts new jobs as `status='discovered'`. The response summarizes
+`{ users, inserted, skipped }`.
+
+The endpoint is mounted under `/api/n8n`, so it inherits the shared-API-key
+exemption and is authenticated solely by the n8n webhook secret.


### PR DESCRIPTION
Closes #40 · Phase 1 · Workstream **F** (real data) of the production-grade AI program (epic #43).

## What this adds
Per-user **saved searches** drive discovery of **real** job postings from **Adzuna** (free dev API) with a **no-key Remotive fallback**, deduped into the existing user-scoped CRM as `status='discovered'` — manually ("Discover now") and on an n8n schedule.

### Backend (TDD, each task its own commit)
- **Migration** `005_saved_searches.sql` (reuses the per-user `(user_id, job_url)` dedup index already added in 004).
- **Sources** `lib/job-sources/*` — Adzuna + Remotive clients + `getJobSource()` with a **resilient Adzuna→Remotive fallback** on 429/5xx/timeout.
- **Saved-search store** (file + postgres), user-scoped.
- **Orchestration** `runDiscoveryForUser` with per-user + within-run dedup.
- **Routes** — `POST /api/discovery/run` (Clerk-auth'd), `GET/POST/DELETE /api/saved-searches`, and the scheduled sweep `POST /api/n8n/discover` **mounted under `/api/n8n`** so it inherits the shared-API-key exemption + webhook secret.

### Frontend + automation
- Settings **"Job discovery"** card: manage saved searches + a **"Discover now"** button (routed through `/api/proxy`, so the `/api` prefix is correct).
- A **`via <source>`** badge on discovered jobs in the jobs table.
- `ADZUNA_*` in `.env.example`; an importable **n8n scheduled-discovery** workflow + doc.

## Codex plan-review fixes carried in
All three notes from the planning-PR review are addressed: (1) **resilient composite source**; (2) **web proxy `/api` prefix** (reuses the existing client helper); (3) **sweep under `/api/n8n`** to dodge `requireSharedApiKey`.

## Verification
- **Real end-to-end smoke:** one `POST /api/discovery/run` pulled **31 live Remotive postings** into the CRM, deduped (`{inserted:31, skipped:0, source:"remotive"}`).
- `npm run check` green; **39/39 API tests pass** (new: normalize/dedup, source selection + fallback, saved-search store, discovery orchestration, and discovery/saved-search/sweep routes).
- Graceful degradation preserved: no Adzuna key → Remotive fallback.

## Not in this PR (later Phase-1 work)
Langfuse tracing (#41) and the Ragas eval harness (#42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)