### PR TITLE
feat(agent): Langfuse LLM tracing (tokens/cost/latency + trace tree)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ OPENAI_API_KEY=
 AZURE_OPENAI_ENDPOINT=
 AZURE_OPENAI_API_KEY=
 GOOGLE_GEMINI_API_KEY=
+# Langfuse LLM tracing (consumed by services/agent). Leave blank to disable
+# (tracing no-ops). Use Langfuse Cloud (free) or the local docker-compose.langfuse.yml.
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+LANGFUSE_HOST=https://cloud.langfuse.com
 GMAIL_CLIENT_ID=
 GMAIL_CLIENT_SECRET=
 # Set this to true only after you create a Gmail OAuth refresh token with gmail.compose access.

--- a/docker-compose.langfuse.yml
+++ b/docker-compose.langfuse.yml
@@ -101,7 +101,7 @@ services:
     image: docker.io/redis:7
     command: --requirepass local-redis-secret
     healthcheck:
-      test: ["CMD", "redis-cli", "AUTH", "local-redis-secret", "PING"]
+      test: ["CMD", "redis-cli", "-a", "local-redis-secret", "--no-auth-warning", "ping"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker-compose.langfuse.yml
+++ b/docker-compose.langfuse.yml
@@ -1,0 +1,112 @@
+# Local Langfuse v3 stack for LLM tracing/observability.
+#
+# This mirrors Langfuse's official self-host compose
+# (https://github.com/langfuse/langfuse/blob/main/docker-compose.yml). For the
+# live demo, Langfuse Cloud (free, https://cloud.langfuse.com) is simpler — just
+# set LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY / LANGFUSE_HOST and skip this.
+#
+#   docker compose -f docker-compose.langfuse.yml up -d
+#   open http://localhost:3000  → sign up → create a project → copy the API keys
+#   then in services/agent/.env:
+#     LANGFUSE_HOST=http://localhost:3000
+#     LANGFUSE_PUBLIC_KEY=pk-lf-...
+#     LANGFUSE_SECRET_KEY=sk-lf-...
+#
+# The placeholder secrets below are for LOCAL DEV ONLY — never reuse them.
+
+services:
+  langfuse-web:
+    image: docker.io/langfuse/langfuse:3
+    depends_on:
+      postgres: { condition: service_healthy }
+      clickhouse: { condition: service_healthy }
+      minio: { condition: service_healthy }
+      redis: { condition: service_healthy }
+    ports:
+      - "3000:3000"
+    environment: &langfuse-env
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
+      SALT: local-dev-salt-change-me
+      ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: local-dev-secret-change-me
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: clickhouse
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_AUTH: local-redis-secret
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: miniosecret
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+
+  langfuse-worker:
+    image: docker.io/langfuse/langfuse-worker:3
+    depends_on:
+      postgres: { condition: service_healthy }
+      clickhouse: { condition: service_healthy }
+      minio: { condition: service_healthy }
+      redis: { condition: service_healthy }
+    environment: *langfuse-env
+
+  postgres:
+    image: docker.io/postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - langfuse_postgres:/var/lib/postgresql/data
+
+  clickhouse:
+    image: docker.io/clickhouse/clickhouse-server
+    environment:
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: clickhouse
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8123/ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - langfuse_clickhouse:/var/lib/clickhouse
+
+  minio:
+    image: docker.io/minio/minio
+    # Pre-create the langfuse bucket (a directory under /data) before serving.
+    entrypoint: sh
+    command: -c 'mkdir -p /data/langfuse && minio server /data --console-address ":9001"'
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: miniosecret
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - langfuse_minio:/data
+
+  redis:
+    image: docker.io/redis:7
+    command: --requirepass local-redis-secret
+    healthcheck:
+      test: ["CMD", "redis-cli", "AUTH", "local-redis-secret", "PING"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  langfuse_postgres:
+  langfuse_clickhouse:
+  langfuse_minio:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,6 +136,18 @@ Jobs are the CRM source of truth. The list and detail pages read job records, an
 - GitHub Actions runs lint, typecheck, and build on push and pull request.
 - `main` is protected, so future changes should land through feature branches and PRs.
 
+## Observability
+
+LLM calls are traced with **Langfuse**. The agent attaches a Langfuse callback to
+every chain/agent `.invoke` (named per endpoint — e.g. `score-fit`,
+`agent-research` — with `langfuse_user_id` where available) and wraps RAG
+retrieval in a manual span, so each AI call appears as a trace with token usage,
+cost, latency, and the agent/tool steps. Tracing is **no-op when unconfigured**,
+so CI and key-less runs are unchanged. Enable it by setting `LANGFUSE_PUBLIC_KEY`
+/ `LANGFUSE_SECRET_KEY` / `LANGFUSE_HOST` — via Langfuse Cloud (free) or the local
+`docker-compose.langfuse.yml`. Azure Application Insights still covers
+infrastructure metrics; Langfuse adds the **LLM quality/cost** layer on top.
+
 ## Design Principles
 
 - Human-in-the-loop by default.

--- a/services/agent/.env.example
+++ b/services/agent/.env.example
@@ -26,5 +26,11 @@ DATABASE_URL=
 # Research agent web search (Phase 8, optional)
 TAVILY_API_KEY=
 
+# Langfuse LLM tracing (Phase 1 LLMOps). Leave blank to disable (tracing
+# no-ops). Use Langfuse Cloud (free) or the local docker-compose.langfuse.yml.
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+LANGFUSE_HOST=https://cloud.langfuse.com
+
 LLM_TEMPERATURE=0.2
 REQUEST_TIMEOUT=60

--- a/services/agent/app/agents/runner.py
+++ b/services/agent/app/agents/runner.py
@@ -23,8 +23,10 @@ from app.schemas import (
 )
 
 
-def _final_structured(agent, prompt: str):
-    result = agent.invoke({"messages": [{"role": "user", "content": prompt}]})
+def _final_structured(agent, prompt: str, config: dict | None = None):
+    result = agent.invoke(
+        {"messages": [{"role": "user", "content": prompt}]}, config=config or None
+    )
     return result, result["structured_response"]
 
 
@@ -36,7 +38,7 @@ def _used_a_tool(result) -> bool:
     )
 
 
-def run_interview_prep(req: InterviewPrepRequest) -> InterviewPrep:
+def run_interview_prep(req: InterviewPrepRequest, config: dict | None = None) -> InterviewPrep:
     model, _ = get_model()
     agent = create_agent(
         model,
@@ -51,11 +53,11 @@ def run_interview_prep(req: InterviewPrepRequest) -> InterviewPrep:
         parts.append(f"Role: {req.role}")
     if req.resume_text:
         parts.append(f"Candidate resume (only truthful claims):\n{req.resume_text}")
-    _, brief = _final_structured(agent, "\n\n".join(parts))
+    _, brief = _final_structured(agent, "\n\n".join(parts), config)
     return brief
 
 
-def run_skill_gap(req: SkillGapRequest) -> SkillGapPlan:
+def run_skill_gap(req: SkillGapRequest, config: dict | None = None) -> SkillGapPlan:
     model, _ = get_model()
     agent = create_agent(
         model,
@@ -68,11 +70,11 @@ def run_skill_gap(req: SkillGapRequest) -> SkillGapPlan:
         parts.append(f"Job description:\n{req.job_description}")
     if req.resume_text:
         parts.append(f"Resume:\n{req.resume_text}")
-    _, plan = _final_structured(agent, "\n\n".join(parts))
+    _, plan = _final_structured(agent, "\n\n".join(parts), config)
     return plan
 
 
-def run_research(req: ResearchRequest) -> ResearchBrief:
+def run_research(req: ResearchRequest, config: dict | None = None) -> ResearchBrief:
     model, _ = get_model()
     agent = create_agent(
         model,
@@ -86,6 +88,6 @@ def run_research(req: ResearchRequest) -> ResearchBrief:
     if req.context:
         parts.append(f"Additional context:\n{req.context}")
     parts.append("Research this company and role for an upcoming interview.")
-    result, brief = _final_structured(agent, "\n\n".join(parts))
+    result, brief = _final_structured(agent, "\n\n".join(parts), config)
     brief.used_web_search = _used_a_tool(result)
     return brief

--- a/services/agent/app/chains/draft_outreach.py
+++ b/services/agent/app/chains/draft_outreach.py
@@ -7,7 +7,7 @@ from app.prompts import OUTREACH_DRAFTER_SYSTEM
 from app.schemas import DraftOutreachRequest, OutreachDraftLLM, OutreachDraftResponse
 
 
-def draft_outreach(req: DraftOutreachRequest) -> OutreachDraftResponse:
+def draft_outreach(req: DraftOutreachRequest, config: dict | None = None) -> OutreachDraftResponse:
     model, label = get_model()
     structured = model.with_structured_output(OutreachDraftLLM)
 
@@ -27,5 +27,5 @@ def draft_outreach(req: DraftOutreachRequest) -> OutreachDraftResponse:
         parts.append("Relevant resume evidence to draw from:\n" + evidence)
 
     messages = [("system", OUTREACH_DRAFTER_SYSTEM), ("human", "\n\n".join(parts))]
-    result = structured.invoke(messages)
+    result = structured.invoke(messages, config=config or None)
     return OutreachDraftResponse(**result.model_dump(), model_used=label)

--- a/services/agent/app/chains/parse_job.py
+++ b/services/agent/app/chains/parse_job.py
@@ -7,11 +7,11 @@ from app.prompts import JOB_PARSER_SYSTEM
 from app.schemas import ParsedJob
 
 
-def parse_job(description_text: str) -> ParsedJob:
+def parse_job(description_text: str, config: dict | None = None) -> ParsedJob:
     model, _ = get_model()
     structured = model.with_structured_output(ParsedJob)
     messages = [
         ("system", JOB_PARSER_SYSTEM),
         ("human", f"Job description:\n\n{description_text}"),
     ]
-    return structured.invoke(messages)
+    return structured.invoke(messages, config=config or None)

--- a/services/agent/app/chains/score_fit.py
+++ b/services/agent/app/chains/score_fit.py
@@ -11,7 +11,7 @@ from app.prompts import FIT_SCORER_SYSTEM
 from app.schemas import FitScoreLLM, FitScoreResponse, ScoreFitRequest
 
 
-def score_fit(req: ScoreFitRequest) -> FitScoreResponse:
+def score_fit(req: ScoreFitRequest, config: dict | None = None) -> FitScoreResponse:
     model, label = get_model()
     structured = model.with_structured_output(FitScoreLLM)
 
@@ -32,5 +32,5 @@ def score_fit(req: ScoreFitRequest) -> FitScoreResponse:
         )
 
     messages = [("system", FIT_SCORER_SYSTEM), ("human", "\n\n".join(parts))]
-    result = structured.invoke(messages)
+    result = structured.invoke(messages, config=config or None)
     return FitScoreResponse(**result.model_dump(), model_used=label)

--- a/services/agent/app/chains/weekly.py
+++ b/services/agent/app/chains/weekly.py
@@ -7,7 +7,9 @@ from app.prompts import WEEKLY_RECOMMENDATIONS_SYSTEM
 from app.schemas import WeeklyRecommendationsLLM, WeeklyRecommendationsRequest
 
 
-def weekly_recommendations(req: WeeklyRecommendationsRequest) -> WeeklyRecommendationsLLM:
+def weekly_recommendations(
+    req: WeeklyRecommendationsRequest, config: dict | None = None
+) -> WeeklyRecommendationsLLM:
     model, _ = get_model()
     structured = model.with_structured_output(WeeklyRecommendationsLLM)
 
@@ -18,4 +20,4 @@ def weekly_recommendations(req: WeeklyRecommendationsRequest) -> WeeklyRecommend
         f"Most common missing skills: {missing}"
     )
     messages = [("system", WEEKLY_RECOMMENDATIONS_SYSTEM), ("human", human)]
-    return structured.invoke(messages)
+    return structured.invoke(messages, config=config or None)

--- a/services/agent/app/config.py
+++ b/services/agent/app/config.py
@@ -42,5 +42,10 @@ class Settings(BaseSettings):
     # Optional web-search tool for the research agent (Phase 8)
     tavily_api_key: str | None = None
 
+    # Langfuse tracing/observability (Phase 1 LLMOps). No-op when unset.
+    langfuse_public_key: str | None = None
+    langfuse_secret_key: str | None = None
+    langfuse_host: str = "https://cloud.langfuse.com"
+
 
 settings = Settings()

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -20,6 +20,7 @@ from app.chains.score_fit import score_fit
 from app.chains.weekly import weekly_recommendations
 from app.config import settings
 from app.llm.provider import LLMNotConfigured, llm_available, resolve_provider
+from app.obs import traced_config
 from app.rag.store import ingest_document, rag_available, retrieve, retrieve_resume_evidence
 from app.schemas import (
     DraftOutreachRequest,
@@ -129,7 +130,7 @@ def health() -> dict:
 @app.post("/parse-job", response_model=ParsedJob)
 def parse_job_endpoint(req: ParseJobRequest) -> ParsedJob:
     _require_llm()
-    return _run(parse_job, req.description_text)
+    return _run(parse_job, req.description_text, traced_config("parse-job"))
 
 
 @app.post("/score-fit", response_model=FitScoreResponse)
@@ -143,7 +144,7 @@ def score_fit_endpoint(req: ScoreFitRequest) -> FitScoreResponse:
         )
         if evidence:
             req.retrieved_context = evidence
-    return _run(score_fit, req)
+    return _run(score_fit, req, traced_config("score-fit", user_id=req.user_id))
 
 
 @app.post("/rag/ingest")
@@ -165,7 +166,7 @@ def rag_search_endpoint(req: SearchRequest) -> dict:
 @app.post("/draft-outreach", response_model=OutreachDraftResponse)
 def draft_outreach_endpoint(req: DraftOutreachRequest) -> OutreachDraftResponse:
     _require_llm()
-    return _run(draft_outreach, req)
+    return _run(draft_outreach, req, traced_config("draft-outreach"))
 
 
 @app.post("/weekly-recommendations", response_model=WeeklyRecommendationsLLM)
@@ -173,7 +174,7 @@ def weekly_recommendations_endpoint(
     req: WeeklyRecommendationsRequest,
 ) -> WeeklyRecommendationsLLM:
     _require_llm()
-    return _run(weekly_recommendations, req)
+    return _run(weekly_recommendations, req, traced_config("weekly-recommendations"))
 
 
 # --- Phase 8 agents ---------------------------------------------------------
@@ -182,19 +183,19 @@ def weekly_recommendations_endpoint(
 @app.post("/agents/interview-prep", response_model=InterviewPrep)
 def interview_prep_endpoint(req: InterviewPrepRequest) -> InterviewPrep:
     _require_llm()
-    return _run(run_interview_prep, req)
+    return _run(run_interview_prep, req, traced_config("agent-interview-prep"))
 
 
 @app.post("/agents/research", response_model=ResearchBrief)
 def research_endpoint(req: ResearchRequest) -> ResearchBrief:
     _require_llm()
-    return _run(run_research, req)
+    return _run(run_research, req, traced_config("agent-research"))
 
 
 @app.post("/agents/skill-gap", response_model=SkillGapPlan)
 def skill_gap_endpoint(req: SkillGapRequest) -> SkillGapPlan:
     _require_llm()
-    return _run(run_skill_gap, req)
+    return _run(run_skill_gap, req, traced_config("agent-skill-gap"))
 
 
 # --- Phase 11 telemetry -----------------------------------------------------

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -20,7 +20,7 @@ from app.chains.score_fit import score_fit
 from app.chains.weekly import weekly_recommendations
 from app.config import settings
 from app.llm.provider import LLMNotConfigured, llm_available, resolve_provider
-from app.obs import traced_config
+from app.obs import traced_config, traced_span
 from app.rag.store import ingest_document, rag_available, retrieve, retrieve_resume_evidence
 from app.schemas import (
     DraftOutreachRequest,
@@ -136,15 +136,19 @@ def parse_job_endpoint(req: ParseJobRequest) -> ParsedJob:
 @app.post("/score-fit", response_model=FitScoreResponse)
 def score_fit_endpoint(req: ScoreFitRequest) -> FitScoreResponse:
     _require_llm()
-    # RAG augmentation: ground the assessment in the resume chunks most relevant
-    # to this job. Best-effort — falls through to direct scoring if RAG is off.
-    if rag_available() and req.resume_text and not req.retrieved_context:
-        evidence = retrieve_resume_evidence(
-            req.resume_text, req.description_text, user_id=req.user_id
-        )
-        if evidence:
-            req.retrieved_context = evidence
-    return _run(score_fit, req, traced_config("score-fit", user_id=req.user_id))
+    # Open the score-fit observation *before* RAG so the `rag.retrieve` span
+    # nests inside this trace instead of being emitted as a separate root trace.
+    # No-op safe: `traced_span` yields None when tracing is disabled.
+    with traced_span("score-fit", user_id=req.user_id):
+        # RAG augmentation: ground the assessment in the resume chunks most
+        # relevant to this job. Best-effort — falls through to direct scoring.
+        if rag_available() and req.resume_text and not req.retrieved_context:
+            evidence = retrieve_resume_evidence(
+                req.resume_text, req.description_text, user_id=req.user_id
+            )
+            if evidence:
+                req.retrieved_context = evidence
+        return _run(score_fit, req, traced_config("score-fit", user_id=req.user_id))
 
 
 @app.post("/rag/ingest")

--- a/services/agent/app/obs/__init__.py
+++ b/services/agent/app/obs/__init__.py
@@ -1,0 +1,5 @@
+"""Observability helpers (Langfuse tracing)."""
+
+from app.obs.langfuse import traced_config
+
+__all__ = ["traced_config"]

--- a/services/agent/app/obs/__init__.py
+++ b/services/agent/app/obs/__init__.py
@@ -1,5 +1,5 @@
 """Observability helpers (Langfuse tracing)."""
 
-from app.obs.langfuse import traced_config
+from app.obs.langfuse import traced_config, traced_span
 
-__all__ = ["traced_config"]
+__all__ = ["traced_config", "traced_span"]

--- a/services/agent/app/obs/langfuse.py
+++ b/services/agent/app/obs/langfuse.py
@@ -39,17 +39,23 @@ def _handler():
         return None
 
 
-def traced_config(name: str, session_id: str | None) -> dict:
+def traced_config(name: str, session_id: str | None = None, user_id: str | None = None) -> dict:
     """Build a LangChain ``config`` that traces the run in Langfuse.
 
-    Returns an empty dict when tracing is disabled, so callers can always write
-    ``chain.invoke(messages, config=traced_config(...) or None)``.
+    ``name`` becomes the trace name; ``session_id``/``user_id`` (when given) group
+    traces in the Langfuse UI. Returns an empty dict when tracing is disabled, so
+    callers can always write ``chain.invoke(messages, config=traced_config(...) or None)``.
     """
     handler = _handler()
     if handler is None:
         return {}
 
     config: dict = {"callbacks": [handler], "run_name": name}
+    metadata: dict = {}
     if session_id:
-        config["metadata"] = {"langfuse_session_id": session_id}
+        metadata["langfuse_session_id"] = session_id
+    if user_id:
+        metadata["langfuse_user_id"] = user_id
+    if metadata:
+        config["metadata"] = metadata
     return config

--- a/services/agent/app/obs/langfuse.py
+++ b/services/agent/app/obs/langfuse.py
@@ -1,0 +1,55 @@
+"""Langfuse tracing for the agent's LLM and agent calls.
+
+No-op safe: when Langfuse keys are not configured (or the SDK is unavailable),
+``traced_config`` returns an empty config so chains run untraced and nothing
+breaks. This keeps CI and key-less local runs working unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from app.config import settings
+
+logger = logging.getLogger("jobops.agent.obs")
+
+
+def _enabled() -> bool:
+    return bool(settings.langfuse_public_key and settings.langfuse_secret_key)
+
+
+def _handler():
+    """Return a Langfuse LangChain callback handler, or ``None`` when disabled."""
+    if not _enabled():
+        return None
+    try:
+        # The agent reads .env via pydantic-settings, which does not populate
+        # os.environ; bridge the values across so the Langfuse SDK (env-based)
+        # picks them up.
+        os.environ["LANGFUSE_PUBLIC_KEY"] = settings.langfuse_public_key or ""
+        os.environ["LANGFUSE_SECRET_KEY"] = settings.langfuse_secret_key or ""
+        os.environ["LANGFUSE_HOST"] = settings.langfuse_host
+
+        from langfuse.langchain import CallbackHandler
+
+        return CallbackHandler()
+    except Exception:  # noqa: BLE001 - tracing must never break the request path
+        logger.warning("Langfuse handler unavailable; tracing disabled", exc_info=True)
+        return None
+
+
+def traced_config(name: str, session_id: str | None) -> dict:
+    """Build a LangChain ``config`` that traces the run in Langfuse.
+
+    Returns an empty dict when tracing is disabled, so callers can always write
+    ``chain.invoke(messages, config=traced_config(...) or None)``.
+    """
+    handler = _handler()
+    if handler is None:
+        return {}
+
+    config: dict = {"callbacks": [handler], "run_name": name}
+    if session_id:
+        config["metadata"] = {"langfuse_session_id": session_id}
+    return config

--- a/services/agent/app/obs/langfuse.py
+++ b/services/agent/app/obs/langfuse.py
@@ -22,10 +22,13 @@ def _enabled() -> bool:
 
 def _bridge_env() -> None:
     """The agent reads .env via pydantic-settings, which does not populate
-    os.environ; bridge the values so the env-based Langfuse SDK picks them up."""
+    os.environ; bridge the values so the env-based Langfuse SDK picks them up.
+    Both LANGFUSE_HOST and LANGFUSE_BASE_URL are set so self-hosted/region hosts
+    work regardless of which the installed SDK version reads."""
     os.environ["LANGFUSE_PUBLIC_KEY"] = settings.langfuse_public_key or ""
     os.environ["LANGFUSE_SECRET_KEY"] = settings.langfuse_secret_key or ""
     os.environ["LANGFUSE_HOST"] = settings.langfuse_host
+    os.environ["LANGFUSE_BASE_URL"] = settings.langfuse_host
 
 
 def _handler():
@@ -50,17 +53,24 @@ def traced_span(name: str, **input_attrs):
     if not _enabled():
         yield None
         return
+
+    # Set up the span. Only Langfuse *setup* failures degrade to a no-op here;
+    # exceptions from the wrapped body must propagate (catching them at `yield`
+    # would raise "generator didn't stop" and mask the real error).
     try:
         _bridge_env()
         from langfuse import get_client
 
-        with get_client().start_as_current_observation(
+        span_cm = get_client().start_as_current_observation(
             as_type="span", name=name, input=input_attrs or None
-        ) as span:
-            yield span
-    except Exception:  # noqa: BLE001 - tracing must never break the request path
-        logger.warning("Langfuse span failed; continuing without it", exc_info=True)
+        )
+    except Exception:  # noqa: BLE001 - tracing setup must never break the caller
+        logger.warning("Langfuse span setup failed; continuing without it", exc_info=True)
         yield None
+        return
+
+    with span_cm as span:
+        yield span
 
 
 def traced_config(name: str, session_id: str | None = None, user_id: str | None = None) -> dict:

--- a/services/agent/app/obs/langfuse.py
+++ b/services/agent/app/obs/langfuse.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import contextmanager
 
 from app.config import settings
 
@@ -19,24 +20,47 @@ def _enabled() -> bool:
     return bool(settings.langfuse_public_key and settings.langfuse_secret_key)
 
 
+def _bridge_env() -> None:
+    """The agent reads .env via pydantic-settings, which does not populate
+    os.environ; bridge the values so the env-based Langfuse SDK picks them up."""
+    os.environ["LANGFUSE_PUBLIC_KEY"] = settings.langfuse_public_key or ""
+    os.environ["LANGFUSE_SECRET_KEY"] = settings.langfuse_secret_key or ""
+    os.environ["LANGFUSE_HOST"] = settings.langfuse_host
+
+
 def _handler():
     """Return a Langfuse LangChain callback handler, or ``None`` when disabled."""
     if not _enabled():
         return None
     try:
-        # The agent reads .env via pydantic-settings, which does not populate
-        # os.environ; bridge the values across so the Langfuse SDK (env-based)
-        # picks them up.
-        os.environ["LANGFUSE_PUBLIC_KEY"] = settings.langfuse_public_key or ""
-        os.environ["LANGFUSE_SECRET_KEY"] = settings.langfuse_secret_key or ""
-        os.environ["LANGFUSE_HOST"] = settings.langfuse_host
-
+        _bridge_env()
         from langfuse.langchain import CallbackHandler
 
         return CallbackHandler()
     except Exception:  # noqa: BLE001 - tracing must never break the request path
         logger.warning("Langfuse handler unavailable; tracing disabled", exc_info=True)
         return None
+
+
+@contextmanager
+def traced_span(name: str, **input_attrs):
+    """Best-effort Langfuse span around custom (non-LangChain) work — e.g. RAG
+    retrieval. Yields the span object (or ``None`` when tracing is disabled or
+    unavailable) and never raises into the caller."""
+    if not _enabled():
+        yield None
+        return
+    try:
+        _bridge_env()
+        from langfuse import get_client
+
+        with get_client().start_as_current_observation(
+            as_type="span", name=name, input=input_attrs or None
+        ) as span:
+            yield span
+    except Exception:  # noqa: BLE001 - tracing must never break the request path
+        logger.warning("Langfuse span failed; continuing without it", exc_info=True)
+        yield None
 
 
 def traced_config(name: str, session_id: str | None = None, user_id: str | None = None) -> dict:

--- a/services/agent/app/rag/store.py
+++ b/services/agent/app/rag/store.py
@@ -12,6 +12,7 @@ import logging
 import uuid
 
 from app.config import settings
+from app.obs import traced_span
 from app.rag.chunk import chunk_text
 from app.rag.embeddings import embed_query, embed_texts
 
@@ -86,30 +87,35 @@ def retrieve(
     user_id: str | None = None,
 ) -> list[str]:
     """Return the ``k`` most similar chunk texts (cosine distance)."""
-    query_literal = _vector_literal(embed_query(query))
+    with traced_span("rag.retrieve", query=query[:200], k=k, source_type=source_type) as span:
+        query_literal = _vector_literal(embed_query(query))
 
-    conditions: list[str] = []
-    params: list[object] = []
-    if source_type:
-        conditions.append("source_type = %s")
-        params.append(source_type)
-    if source_id:
-        conditions.append("source_id = %s")
-        params.append(source_id)
-    if user_id is not None:
-        conditions.append("user_id = %s")
-        params.append(user_id)
-    where_sql = ("where " + " and ".join(conditions)) if conditions else ""
+        conditions: list[str] = []
+        params: list[object] = []
+        if source_type:
+            conditions.append("source_type = %s")
+            params.append(source_type)
+        if source_id:
+            conditions.append("source_id = %s")
+            params.append(source_id)
+        if user_id is not None:
+            conditions.append("user_id = %s")
+            params.append(user_id)
+        where_sql = ("where " + " and ".join(conditions)) if conditions else ""
 
-    sql = (
-        f"select chunk_text from embeddings {where_sql} "
-        "order by embedding <=> %s::vector limit %s"
-    )
-    params.extend([query_literal, k])
+        sql = (
+            f"select chunk_text from embeddings {where_sql} "
+            "order by embedding <=> %s::vector limit %s"
+        )
+        params.extend([query_literal, k])
 
-    with _connect() as conn, conn.cursor() as cur:
-        cur.execute(sql, params)
-        return [row[0] for row in cur.fetchall()]
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            chunks = [row[0] for row in cur.fetchall()]
+
+        if span is not None:
+            span.update(output={"chunk_count": len(chunks)})
+        return chunks
 
 
 def retrieve_resume_evidence(

--- a/services/agent/requirements.txt
+++ b/services/agent/requirements.txt
@@ -22,3 +22,6 @@ numpy>=1.26,<3
 
 # Observability (App Insights via OpenTelemetry)
 azure-monitor-opentelemetry>=1.6,<2
+
+# LLM tracing/observability (Phase 1 LLMOps). No-op when unconfigured.
+langfuse>=3.0,<4

--- a/services/agent/tests/test_agents.py
+++ b/services/agent/tests/test_agents.py
@@ -22,7 +22,7 @@ def test_interview_prep_endpoint(monkeypatch):
     monkeypatch.setattr(
         main,
         "run_interview_prep",
-        lambda req: InterviewPrep(
+        lambda req, config=None: InterviewPrep(
             likely_questions=["Tell me about an AI agent you built."],
             talking_points=["Built LangChain agents."],
             gaps_to_address=["Limited PyTorch production experience."],
@@ -42,7 +42,7 @@ def test_research_endpoint(monkeypatch):
     monkeypatch.setattr(
         main,
         "run_research",
-        lambda req: ResearchBrief(
+        lambda req, config=None: ResearchBrief(
             company_summary="Pebble builds electric RV trailers.",
             recent_signals=["Launched a new trailer model."],
             role_context="AI for vehicle telemetry.",
@@ -61,7 +61,7 @@ def test_skill_gap_endpoint(monkeypatch):
     monkeypatch.setattr(
         main,
         "run_skill_gap",
-        lambda req: SkillGapPlan(
+        lambda req, config=None: SkillGapPlan(
             summary="Focus on PyTorch first.",
             prioritized_skills=[
                 SkillGapItem(

--- a/services/agent/tests/test_endpoints.py
+++ b/services/agent/tests/test_endpoints.py
@@ -27,7 +27,7 @@ def test_parse_job_happy_path(monkeypatch):
     monkeypatch.setattr(
         main,
         "parse_job",
-        lambda text: ParsedJob(
+        lambda text, config=None: ParsedJob(
             title="AI Software Engineer",
             required_skills=["Python", "LangChain"],
             seniority="junior",
@@ -46,7 +46,7 @@ def test_score_fit_happy_path(monkeypatch):
     monkeypatch.setattr(
         main,
         "score_fit",
-        lambda req: FitScoreResponse(
+        lambda req, config=None: FitScoreResponse(
             fit_score=88,
             matched_skills=["Python"],
             missing_skills=[],
@@ -77,7 +77,7 @@ def test_draft_outreach_happy_path(monkeypatch):
     monkeypatch.setattr(
         main,
         "draft_outreach",
-        lambda req: OutreachDraftResponse(
+        lambda req, config=None: OutreachDraftResponse(
             subject="Excited about the AI Software Engineer role",
             draft_text="Hi, ...",
             safety_notes="Verify the team name before sending.",
@@ -109,7 +109,7 @@ def test_score_fit_skips_rag_when_disabled(monkeypatch):
     monkeypatch.setattr(
         main,
         "score_fit",
-        lambda req: FitScoreResponse(
+        lambda req, config=None: FitScoreResponse(
             fit_score=70,
             fit_summary="ok",
             recommended_resume_angle="ok",

--- a/services/agent/tests/test_obs.py
+++ b/services/agent/tests/test_obs.py
@@ -1,0 +1,32 @@
+"""Langfuse obs module: no-op safe + correct config assembly (no SDK needed)."""
+
+from app.config import settings
+from app.obs import langfuse as lf
+
+
+def test_disabled_returns_empty_config(monkeypatch):
+    monkeypatch.setattr(settings, "langfuse_public_key", None)
+    monkeypatch.setattr(settings, "langfuse_secret_key", None)
+    assert lf._enabled() is False
+    assert lf.traced_config("parse-job", "sess") == {}
+
+
+def test_enabled_assembles_callbacks_and_session(monkeypatch):
+    monkeypatch.setattr(settings, "langfuse_public_key", "pk")
+    monkeypatch.setattr(settings, "langfuse_secret_key", "sk")
+    assert lf._enabled() is True
+
+    sentinel = object()
+    monkeypatch.setattr(lf, "_handler", lambda: sentinel)
+
+    config = lf.traced_config("score-fit", "sess-123")
+    assert config["callbacks"] == [sentinel]
+    assert config["run_name"] == "score-fit"
+    assert config["metadata"]["langfuse_session_id"] == "sess-123"
+
+
+def test_enabled_without_session_omits_metadata(monkeypatch):
+    monkeypatch.setattr(lf, "_handler", lambda: object())
+    config = lf.traced_config("weekly", None)
+    assert "metadata" not in config
+    assert config["run_name"] == "weekly"

--- a/services/agent/tests/test_obs.py
+++ b/services/agent/tests/test_obs.py
@@ -30,3 +30,10 @@ def test_enabled_without_session_omits_metadata(monkeypatch):
     config = lf.traced_config("weekly", None)
     assert "metadata" not in config
     assert config["run_name"] == "weekly"
+
+
+def test_enabled_includes_user_id(monkeypatch):
+    monkeypatch.setattr(lf, "_handler", lambda: object())
+    config = lf.traced_config("score-fit", user_id="user_42")
+    assert config["metadata"]["langfuse_user_id"] == "user_42"
+    assert "langfuse_session_id" not in config["metadata"]

--- a/services/agent/tests/test_obs.py
+++ b/services/agent/tests/test_obs.py
@@ -1,5 +1,10 @@
 """Langfuse obs module: no-op safe + correct config assembly (no SDK needed)."""
 
+import sys
+import types
+
+import pytest
+
 from app.config import settings
 from app.obs import langfuse as lf
 
@@ -44,3 +49,32 @@ def test_traced_span_is_noop_when_disabled(monkeypatch):
     monkeypatch.setattr(settings, "langfuse_secret_key", None)
     with lf.traced_span("rag.retrieve", k=4) as span:
         assert span is None
+
+
+def test_traced_span_propagates_body_errors_when_enabled(monkeypatch):
+    """A failure in the wrapped work must propagate, not be masked by tracing."""
+    monkeypatch.setattr(settings, "langfuse_public_key", "pk")
+    monkeypatch.setattr(settings, "langfuse_secret_key", "sk")
+
+    class _FakeSpan:
+        def update(self, **_kwargs):
+            pass
+
+    class _FakeObservation:
+        def __enter__(self):
+            return _FakeSpan()
+
+        def __exit__(self, *_exc):
+            return False  # never suppress exceptions
+
+    class _FakeClient:
+        def start_as_current_observation(self, **_kwargs):
+            return _FakeObservation()
+
+    fake_langfuse = types.ModuleType("langfuse")
+    fake_langfuse.get_client = lambda: _FakeClient()
+    monkeypatch.setitem(sys.modules, "langfuse", fake_langfuse)
+
+    with pytest.raises(ValueError, match="boom"):
+        with lf.traced_span("rag.retrieve"):
+            raise ValueError("boom")

--- a/services/agent/tests/test_obs.py
+++ b/services/agent/tests/test_obs.py
@@ -37,3 +37,10 @@ def test_enabled_includes_user_id(monkeypatch):
     config = lf.traced_config("score-fit", user_id="user_42")
     assert config["metadata"]["langfuse_user_id"] == "user_42"
     assert "langfuse_session_id" not in config["metadata"]
+
+
+def test_traced_span_is_noop_when_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "langfuse_public_key", None)
+    monkeypatch.setattr(settings, "langfuse_secret_key", None)
+    with lf.traced_span("rag.retrieve", k=4) as span:
+        assert span is None

--- a/services/agent/tests/test_tracing.py
+++ b/services/agent/tests/test_tracing.py
@@ -1,0 +1,40 @@
+"""B2: chains forward the trace config into the underlying .invoke()."""
+
+from app.chains import parse_job as parse_mod
+from app.schemas import ParsedJob
+
+
+class _FakeStructured:
+    def __init__(self, sink: dict):
+        self._sink = sink
+
+    def invoke(self, messages, config=None):
+        self._sink["config"] = config
+        return ParsedJob(title="X")
+
+
+class _FakeModel:
+    def __init__(self, sink: dict):
+        self._sink = sink
+
+    def with_structured_output(self, _schema):
+        return _FakeStructured(self._sink)
+
+
+def test_parse_job_forwards_trace_config(monkeypatch):
+    sink: dict = {}
+    monkeypatch.setattr(parse_mod, "get_model", lambda: (_FakeModel(sink), "fake-model"))
+
+    cfg = {"callbacks": ["handler"], "run_name": "parse-job"}
+    parse_mod.parse_job("a job description", cfg)
+
+    assert sink["config"] == cfg
+
+
+def test_parse_job_empty_config_passes_none(monkeypatch):
+    sink: dict = {}
+    monkeypatch.setattr(parse_mod, "get_model", lambda: (_FakeModel(sink), "fake-model"))
+
+    parse_mod.parse_job("a job description", {})
+
+    assert sink["config"] is None


### PR DESCRIPTION
Closes #41 · Phase 1 · Workstream **B** (LLM observability) of the production-grade AI program (epic #43).

## What this adds
Every agent AI call is traced in **Langfuse** — token usage, cost, latency, and the full agent/tool step tree — turning the agent from a black box into something you can debug and cost-account. **No-op when unconfigured**, so CI and key-less runs are unchanged.

### B1 — no-op-safe obs module
`app/obs/langfuse.traced_config(name, session_id, user_id)` builds a LangChain `config` that traces the run (v3 `from langfuse.langchain import CallbackHandler`); returns `{}` when keys are unset or the SDK is unavailable. Bridges pydantic-settings (`.env`) → the env vars the Langfuse SDK reads. `langfuse>=3` added to `requirements.txt`.

### B2 — threaded through chains, agents, endpoints
Each chain (parse/score/outreach/weekly) and agent (interview-prep/research/skill-gap) accepts an optional `config` and forwards it to `.invoke`. `main.py` builds `traced_config(run_name)` per endpoint (e.g. `score-fit`, `agent-research`), attaching `langfuse_user_id` on score-fit.

### B3 — manual RAG span
A no-op-safe `traced_span` context manager (v3 `get_client().start_as_current_observation`) wraps the pgvector `retrieve` query, capturing query/k/source + returned chunk count. Never raises into the caller.

### B4 — setup
`LANGFUSE_*` in `.env.example`; a `docker-compose.langfuse.yml` (local Langfuse v3 stack, mirroring Langfuse's official self-host compose); an Observability section in `docs/ARCHITECTURE.md`. **Langfuse Cloud (free) is the recommended path** for the live demo.

## Verification
- Full agent suite green (`pytest`, 40 tests incl. new no-op + config-forwarding + user-id-metadata + span no-op tests) and `ruff` clean — **all without the Langfuse SDK installed locally** (the no-op design never imports it on the disabled path).
- API contract unchanged; graceful degradation preserved.
- **Not yet done:** verifying real traces render in a Langfuse project (needs `LANGFUSE_*` keys). Happy to wire Langfuse Cloud (free) keys and confirm traces appear, the same way we did for Adzuna — just say the word.

## Not in this PR
The Ragas eval harness (#42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)