### PR TITLE
feat(agent): Phase 2 · H — strip contact-PII before LLM + mask in traces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ GOOGLE_GEMINI_API_KEY=
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_SECRET_KEY=
 LANGFUSE_HOST=https://cloud.langfuse.com
+# PII handling (services/agent, Phase 2 · H). Strip contact-PII (email/phone/URL/SSN)
+# before LLM calls and mask it in Langfuse traces. On by default; set to false to opt out.
+PII_REDACTION_ENABLED=true
 GMAIL_CLIENT_ID=
 GMAIL_CLIENT_SECRET=
 # Set this to true only after you create a Gmail OAuth refresh token with gmail.compose access.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -169,6 +169,15 @@ The Express API protects the expensive AI paths (Phase 2 · Workstream G):
 All guards degrade gracefully: the usage store falls back to in-memory without a
 database, and budget accounting fails open so a store hiccup never blocks AI calls.
 
+## Privacy & PII
+
+The agent strips high-precision **contact-PII** (email / phone / URL / SSN) from
+resume, profile, and job text **before** it reaches a third-party LLM, and masks the same
+data in Langfuse traces — skills and experience (what scoring needs) are preserved.
+Implemented in `services/agent/app/safety/pii.py`, applied across the parse/score/outreach
+chains and the Langfuse `mask`, and toggled by `PII_REDACTION_ENABLED` (default on). Full
+details and retention stance: [`docs/PRIVACY.md`](PRIVACY.md).
+
 ## Design Principles
 
 - Human-in-the-loop by default.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,53 @@
+# Privacy & PII handling
+
+JobOps Copilot processes resumes, profiles, and job descriptions — text that can contain
+personal data. This note documents how that data is handled (Phase 2 · Workstream H).
+
+## What is collected
+
+- **Resume / profile text** supplied by the user (skills, experience, and often contact
+  details).
+- **Job descriptions** ingested from Adzuna / Remotive or entered manually.
+
+These power parsing, fit scoring, and outreach drafting. The fit assessment only needs a
+candidate's *skills and experience*, not their contact details.
+
+## Contact-PII is stripped before third-party LLMs
+
+Before any text is sent to an LLM provider, the agent redacts high-precision **contact
+PII** — email addresses, phone numbers, URLs, and US SSNs — replacing them with
+placeholders (`[EMAIL]`, `[PHONE]`, `[URL]`, `[SSN]`). Skills, employers, dates, and
+narrative experience are preserved, so analysis quality is unaffected.
+
+- Implemented in `services/agent/app/safety/pii.py` (`redact_contact_pii`) and applied in
+  the parse-job, score-fit, and draft-outreach chains.
+- Phone matching is **digit-count filtered (10–15 digits)** so ISO dates, salaries, and
+  ZIP-like numbers are not mistaken for phone numbers.
+- **Out of scope (by design):** free-form street addresses and names are *not*
+  auto-redacted — pattern-based detection there is low-precision and would harm analysis.
+  Microsoft **Presidio** is the documented upgrade path if NER-grade redaction is needed.
+
+## PII is masked in traces and logs
+
+When Langfuse tracing is enabled, a `mask` function (`app/obs/langfuse.py` → the same
+redactor, recursively over trace inputs/outputs) scrubs contact-PII before any trace
+leaves the process, so observability never persists raw contact details.
+
+## Toggle
+
+Redaction is on by default and controlled by `PII_REDACTION_ENABLED` (default `true`).
+Set it to `false` only in trusted/offline contexts where redaction is not wanted.
+
+## Retention
+
+- The app stores the user's own job records, analyses, and outreach drafts (the CRM) —
+  this is the product's purpose and is scoped per user.
+- No **separate** long-term store of raw resume text is introduced by Phase 2; resume
+  text lives with the user's profile/records and is removed when those are deleted.
+- Third-party LLM providers receive only the **redacted** text described above. Configure
+  provider-side data-retention/zero-retention settings as appropriate for your deployment.
+
+## No automated sending
+
+Generated outreach is always **human-reviewed** before any send; the app never
+auto-applies or auto-sends. See `docs/HUMAN_IN_THE_LOOP_POLICY.md`.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -15,12 +15,16 @@ candidate's *skills and experience*, not their contact details.
 ## Contact-PII is stripped before third-party LLMs
 
 Before any text is sent to an LLM provider, the agent redacts high-precision **contact
-PII** — email addresses, phone numbers, URLs, and US SSNs — replacing them with
+PII** — email addresses, phone numbers, URLs (including bare profile links like
+`linkedin.com/in/...` and `github.com/...`), and US SSNs — replacing them with
 placeholders (`[EMAIL]`, `[PHONE]`, `[URL]`, `[SSN]`). Skills, employers, dates, and
 narrative experience are preserved, so analysis quality is unaffected.
 
 - Implemented in `services/agent/app/safety/pii.py` (`redact_contact_pii`) and applied in
-  the parse-job, score-fit, and draft-outreach chains.
+  the parse-job, score-fit, and draft-outreach chains **and** the Phase 8 agents
+  (interview-prep, research, skill-gap) — every path that sends resume/JD text to the LLM.
+- Bare-URL matching uses a web-TLD allowlist and requires a path, so tech terms like
+  `Node.js/Express` or `React.js` are not mistaken for URLs.
 - Phone matching is **digit-count filtered (10–15 digits)** so ISO dates, salaries, and
   ZIP-like numbers are not mistaken for phone numbers.
 - **Out of scope (by design):** free-form street addresses and names are *not*

--- a/services/agent/app/agents/runner.py
+++ b/services/agent/app/agents/runner.py
@@ -13,6 +13,7 @@ from langchain.agents.structured_output import ToolStrategy
 from app.agents.tools import web_search
 from app.llm.provider import get_model
 from app.prompts import INTERVIEW_PREP_SYSTEM, RESEARCH_SYSTEM, SKILL_GAP_SYSTEM
+from app.safety.pii import maybe_redact
 from app.schemas import (
     InterviewPrep,
     InterviewPrepRequest,
@@ -46,13 +47,13 @@ def run_interview_prep(req: InterviewPrepRequest, config: dict | None = None) ->
         system_prompt=INTERVIEW_PREP_SYSTEM,
         response_format=ToolStrategy(InterviewPrep),
     )
-    parts = [f"Job description:\n{req.job_description}"]
+    parts = [f"Job description:\n{maybe_redact(req.job_description)}"]
     if req.company:
         parts.append(f"Company: {req.company}")
     if req.role:
         parts.append(f"Role: {req.role}")
     if req.resume_text:
-        parts.append(f"Candidate resume (only truthful claims):\n{req.resume_text}")
+        parts.append(f"Candidate resume (only truthful claims):\n{maybe_redact(req.resume_text)}")
     _, brief = _final_structured(agent, "\n\n".join(parts), config)
     return brief
 
@@ -67,9 +68,9 @@ def run_skill_gap(req: SkillGapRequest, config: dict | None = None) -> SkillGapP
     )
     parts = ["Missing skills: " + (", ".join(req.missing_skills) or "none provided")]
     if req.job_description:
-        parts.append(f"Job description:\n{req.job_description}")
+        parts.append(f"Job description:\n{maybe_redact(req.job_description)}")
     if req.resume_text:
-        parts.append(f"Resume:\n{req.resume_text}")
+        parts.append(f"Resume:\n{maybe_redact(req.resume_text)}")
     _, plan = _final_structured(agent, "\n\n".join(parts), config)
     return plan
 
@@ -86,7 +87,7 @@ def run_research(req: ResearchRequest, config: dict | None = None) -> ResearchBr
     if req.role:
         parts.append(f"Role: {req.role}")
     if req.context:
-        parts.append(f"Additional context:\n{req.context}")
+        parts.append(f"Additional context:\n{maybe_redact(req.context)}")
     parts.append("Research this company and role for an upcoming interview.")
     result, brief = _final_structured(agent, "\n\n".join(parts), config)
     brief.used_web_search = _used_a_tool(result)

--- a/services/agent/app/chains/draft_outreach.py
+++ b/services/agent/app/chains/draft_outreach.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from app.llm.provider import get_model
 from app.prompts import OUTREACH_DRAFTER_SYSTEM
+from app.safety.pii import maybe_redact
 from app.schemas import DraftOutreachRequest, OutreachDraftLLM, OutreachDraftResponse
 
 
@@ -19,11 +20,12 @@ def draft_outreach(req: DraftOutreachRequest, config: dict | None = None) -> Out
     if req.company:
         parts.append(f"Company: {req.company}")
     if req.job_context:
-        parts.append(f"Job context:\n{req.job_context}")
+        parts.append(f"Job context:\n{maybe_redact(req.job_context)}")
     if req.resume_summary:
-        parts.append(f"Resume summary (only truthful claims allowed):\n{req.resume_summary}")
+        summary = maybe_redact(req.resume_summary)
+        parts.append(f"Resume summary (only truthful claims allowed):\n{summary}")
     if req.retrieved_context:
-        evidence = "\n".join(f"- {chunk}" for chunk in req.retrieved_context)
+        evidence = "\n".join(f"- {maybe_redact(chunk)}" for chunk in req.retrieved_context)
         parts.append("Relevant resume evidence to draw from:\n" + evidence)
 
     messages = [("system", OUTREACH_DRAFTER_SYSTEM), ("human", "\n\n".join(parts))]

--- a/services/agent/app/chains/parse_job.py
+++ b/services/agent/app/chains/parse_job.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from app.llm.provider import get_model
 from app.prompts import JOB_PARSER_SYSTEM
+from app.safety.pii import maybe_redact
 from app.schemas import ParsedJob
 
 
@@ -12,6 +13,6 @@ def parse_job(description_text: str, config: dict | None = None) -> ParsedJob:
     structured = model.with_structured_output(ParsedJob)
     messages = [
         ("system", JOB_PARSER_SYSTEM),
-        ("human", f"Job description:\n\n{description_text}"),
+        ("human", f"Job description:\n\n{maybe_redact(description_text)}"),
     ]
     return structured.invoke(messages, config=config or None)

--- a/services/agent/app/chains/score_fit.py
+++ b/services/agent/app/chains/score_fit.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from app.llm.provider import get_model
 from app.prompts import FIT_SCORER_SYSTEM
+from app.safety.pii import maybe_redact
 from app.schemas import FitScoreLLM, FitScoreResponse, ScoreFitRequest
 
 
@@ -16,16 +17,16 @@ def score_fit(req: ScoreFitRequest, config: dict | None = None) -> FitScoreRespo
     structured = model.with_structured_output(FitScoreLLM)
 
     parts = [
-        f"Job description:\n{req.description_text}",
-        f"Resume:\n{req.resume_text}",
-        f"Profile / extra context:\n{req.profile_text}",
+        f"Job description:\n{maybe_redact(req.description_text)}",
+        f"Resume:\n{maybe_redact(req.resume_text)}",
+        f"Profile / extra context:\n{maybe_redact(req.profile_text)}",
     ]
     if req.required_skills:
         parts.append("Known required skills: " + ", ".join(req.required_skills))
     if req.preferred_skills:
         parts.append("Known preferred skills: " + ", ".join(req.preferred_skills))
     if req.retrieved_context:
-        evidence = "\n".join(f"- {chunk}" for chunk in req.retrieved_context)
+        evidence = "\n".join(f"- {maybe_redact(chunk)}" for chunk in req.retrieved_context)
         parts.append(
             "Retrieved resume evidence (ground matched_skills and the summary in these):\n"
             + evidence

--- a/services/agent/app/config.py
+++ b/services/agent/app/config.py
@@ -47,5 +47,9 @@ class Settings(BaseSettings):
     langfuse_secret_key: str | None = None
     langfuse_host: str = "https://cloud.langfuse.com"
 
+    # PII handling (Phase 2 · Workstream H). Strip contact-PII before LLM calls and
+    # mask it in Langfuse traces. On by default; set PII_REDACTION_ENABLED=false to opt out.
+    pii_redaction_enabled: bool = True
+
 
 settings = Settings()

--- a/services/agent/app/obs/langfuse.py
+++ b/services/agent/app/obs/langfuse.py
@@ -12,12 +12,51 @@ import os
 from contextlib import contextmanager
 
 from app.config import settings
+from app.safety.pii import redact_pii_in_obj
 
 logger = logging.getLogger("jobops.agent.obs")
 
 
 def _enabled() -> bool:
     return bool(settings.langfuse_public_key and settings.langfuse_secret_key)
+
+
+def _mask(*, data, **_kwargs):
+    """Langfuse ``mask`` callback (Phase 2 · Workstream H): scrub contact-PII from trace
+    inputs/outputs before they leave the process. Gated by the same redaction toggle and
+    never raises into the SDK."""
+    if not settings.pii_redaction_enabled:
+        return data
+    try:
+        return redact_pii_in_obj(data)
+    except Exception:  # noqa: BLE001 - masking must never break tracing
+        return data
+
+
+_client_ready = False
+
+
+def _ensure_client():
+    """Initialize the singleton Langfuse client with PII masking, once, and return it.
+
+    Returns ``None`` when tracing is disabled or the SDK is unavailable. Constructing
+    ``Langfuse(mask=...)`` registers the global client that ``get_client()`` and the
+    LangChain ``CallbackHandler`` reuse, so the mask applies to every trace; keys/host
+    are read from the env bridged by ``_bridge_env`` to avoid SDK-version kwarg drift."""
+    global _client_ready
+    if not _enabled():
+        return None
+    try:
+        _bridge_env()
+        from langfuse import Langfuse, get_client
+
+        if not _client_ready:
+            Langfuse(mask=_mask)
+            _client_ready = True
+        return get_client()
+    except Exception:  # noqa: BLE001 - tracing must never break the request path
+        logger.warning("Langfuse client unavailable; tracing disabled", exc_info=True)
+        return None
 
 
 def _bridge_env() -> None:
@@ -32,11 +71,13 @@ def _bridge_env() -> None:
 
 
 def _handler():
-    """Return a Langfuse LangChain callback handler, or ``None`` when disabled."""
-    if not _enabled():
+    """Return a Langfuse LangChain callback handler, or ``None`` when disabled.
+
+    Routes through ``_ensure_client`` first so the PII-masking client is the singleton
+    the handler attaches to."""
+    if _ensure_client() is None:
         return None
     try:
-        _bridge_env()
         from langfuse.langchain import CallbackHandler
 
         return CallbackHandler()
@@ -50,7 +91,8 @@ def traced_span(name: str, **input_attrs):
     """Best-effort Langfuse span around custom (non-LangChain) work — e.g. RAG
     retrieval. Yields the span object (or ``None`` when tracing is disabled or
     unavailable) and never raises into the caller."""
-    if not _enabled():
+    client = _ensure_client()
+    if client is None:
         yield None
         return
 
@@ -58,10 +100,7 @@ def traced_span(name: str, **input_attrs):
     # exceptions from the wrapped body must propagate (catching them at `yield`
     # would raise "generator didn't stop" and mask the real error).
     try:
-        _bridge_env()
-        from langfuse import get_client
-
-        span_cm = get_client().start_as_current_observation(
+        span_cm = client.start_as_current_observation(
             as_type="span", name=name, input=input_attrs or None
         )
     except Exception:  # noqa: BLE001 - tracing setup must never break the caller

--- a/services/agent/app/safety/__init__.py
+++ b/services/agent/app/safety/__init__.py
@@ -1,0 +1,1 @@
+"""Safety utilities for the agent: PII redaction (Phase 2 · Workstream H)."""

--- a/services/agent/app/safety/pii.py
+++ b/services/agent/app/safety/pii.py
@@ -1,0 +1,69 @@
+"""Contact-PII redaction (Phase 2 · Workstream H).
+
+Scoped to high-precision identifiers — email, URL, phone, SSN — that are NOT needed for
+parse/score, so a candidate's skills and experience are preserved while contact details
+are stripped before text reaches a third-party LLM or a Langfuse trace.
+
+Phone matching is digit-count filtered (10-15 digits) so ISO dates, salaries, and
+ZIP-like numbers are not mistaken for phone numbers. Street addresses are intentionally
+out of scope to keep precision high; Microsoft Presidio is the documented heavier-NER
+upgrade path.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.config import settings
+
+_EMAIL = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_URL = re.compile(r"https?://\S+")
+_SSN = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+# Candidate phone-like run; confirmed by digit count in the replacer below.
+_PHONE_CANDIDATE = re.compile(r"\+?\d[\d ().\-]{7,}\d")
+
+
+def redact_contact_pii(text: str) -> tuple[str, dict[str, int]]:
+    """Return ``(redacted_text, counts_by_kind)``. Idempotent and never raises."""
+    counts = {"email": 0, "url": 0, "ssn": 0, "phone": 0}
+    if not text:
+        return text, counts
+
+    out, counts["email"] = _EMAIL.subn("[EMAIL]", text)
+    out, counts["url"] = _URL.subn("[URL]", out)
+    out, counts["ssn"] = _SSN.subn("[SSN]", out)
+
+    def _phone(match: re.Match[str]) -> str:
+        digits = sum(ch.isdigit() for ch in match.group(0))
+        if 10 <= digits <= 15:
+            counts["phone"] += 1
+            return "[PHONE]"
+        return match.group(0)
+
+    out = _PHONE_CANDIDATE.sub(_phone, out)
+    return out, counts
+
+
+def redact_pii_in_obj(data: Any) -> Any:
+    """Recursively redact contact-PII in strings within dicts/lists/tuples.
+
+    Used as the Langfuse trace ``mask`` so trace inputs/outputs are scrubbed. Non-string
+    leaves are returned unchanged; the result stays JSON-serializable when the input was.
+    """
+    if isinstance(data, str):
+        return redact_contact_pii(data)[0]
+    if isinstance(data, dict):
+        return {key: redact_pii_in_obj(value) for key, value in data.items()}
+    if isinstance(data, list):
+        return [redact_pii_in_obj(value) for value in data]
+    if isinstance(data, tuple):
+        return tuple(redact_pii_in_obj(value) for value in data)
+    return data
+
+
+def maybe_redact(text: str | None) -> str | None:
+    """Redact contact-PII when redaction is enabled (default on); a no-op otherwise."""
+    if text is None or not settings.pii_redaction_enabled:
+        return text
+    return redact_contact_pii(text)[0]

--- a/services/agent/app/safety/pii.py
+++ b/services/agent/app/safety/pii.py
@@ -18,7 +18,12 @@ from typing import Any
 from app.config import settings
 
 _EMAIL = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
-_URL = re.compile(r"https?://\S+")
+_URL = re.compile(r"(?:https?://|www\.)\S+", re.IGNORECASE)
+# Bare profile URLs (e.g. linkedin.com/in/jane, github.com/jane): a domain on a known web
+# TLD *with a path*. The TLD allowlist + required "/path" keep tech terms like
+# "Node.js/Express" or "React.js" from being mistaken for URLs.
+_TLD = r"(?:com|net|org|io|dev|ai|co|me|app|xyz|info|us|uk|ca|edu|gov)"
+_BARE_URL = re.compile(rf"\b[a-z0-9][a-z0-9-]*(?:\.[a-z0-9-]+)*\.{_TLD}/[^\s,;]+", re.IGNORECASE)
 _SSN = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
 # Candidate phone-like run; confirmed by digit count in the replacer below.
 _PHONE_CANDIDATE = re.compile(r"\+?\d[\d ().\-]{7,}\d")
@@ -32,6 +37,8 @@ def redact_contact_pii(text: str) -> tuple[str, dict[str, int]]:
 
     out, counts["email"] = _EMAIL.subn("[EMAIL]", text)
     out, counts["url"] = _URL.subn("[URL]", out)
+    out, bare_urls = _BARE_URL.subn("[URL]", out)
+    counts["url"] += bare_urls
     out, counts["ssn"] = _SSN.subn("[SSN]", out)
 
     def _phone(match: re.Match[str]) -> str:

--- a/services/agent/tests/test_pii.py
+++ b/services/agent/tests/test_pii.py
@@ -1,0 +1,132 @@
+"""Phase 2 · H — contact-PII redaction (pure redactor + redaction before LLM calls)."""
+
+from app.safety.pii import maybe_redact, redact_contact_pii, redact_pii_in_obj
+
+# --- H1: the redactor --------------------------------------------------------
+
+
+def test_redacts_email_phone_url_ssn():
+    clean, counts = redact_contact_pii(
+        "Reach me at a.b@x.com or +1 (415) 555-2671, portfolio https://me.dev, SSN 123-45-6789."
+    )
+    assert "a.b@x.com" not in clean and "[EMAIL]" in clean
+    assert "555-2671" not in clean and "[PHONE]" in clean
+    assert "https://me.dev" not in clean and "[URL]" in clean
+    assert "123-45-6789" not in clean and "[SSN]" in clean
+    assert counts == {"email": 1, "url": 1, "ssn": 1, "phone": 1}
+
+
+def test_preserves_skills_dates_and_salaries():
+    # ISO dates (8 digits) and salaries must NOT be mistaken for phone numbers.
+    text = "5 years of Python and RAG; employed 2021-06-01 to 2026-06-17; salary 120000."
+    clean, counts = redact_contact_pii(text)
+    assert clean == text
+    assert sum(counts.values()) == 0
+
+
+def test_redact_pii_in_obj_recurses():
+    masked = redact_pii_in_obj({"a": "mail a@b.com", "b": ["x", "call 415-555-2671 now"], "n": 3})
+    assert masked["a"] == "mail [EMAIL]"
+    assert masked["b"][1] == "call [PHONE] now"
+    assert masked["n"] == 3  # non-strings untouched
+
+
+# --- H2: redaction toggle ----------------------------------------------------
+
+
+def test_maybe_redact_respects_toggle(monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "pii_redaction_enabled", True)
+    assert maybe_redact("a@b.com") == "[EMAIL]"
+    monkeypatch.setattr(settings, "pii_redaction_enabled", False)
+    assert maybe_redact("a@b.com") == "a@b.com"
+    assert maybe_redact(None) is None
+
+
+# --- H2: chains strip PII before the LLM call --------------------------------
+
+
+class _FakeStructured:
+    def __init__(self, sink, result):
+        self._sink = sink
+        self._result = result
+
+    def invoke(self, messages, config=None):
+        self._sink["messages"] = messages
+        return self._result
+
+
+class _FakeModel:
+    def __init__(self, sink, result):
+        self._sink = sink
+        self._result = result
+
+    def with_structured_output(self, _schema):
+        return _FakeStructured(self._sink, self._result)
+
+
+def _human_text(sink) -> str:
+    # messages are (role, content) tuples; return the concatenated human content.
+    return "\n".join(content for role, content in sink["messages"] if role == "human")
+
+
+def test_score_fit_redacts_pii_before_llm(monkeypatch):
+    from app.chains import score_fit as sf
+    from app.config import settings
+    from app.schemas import FitScoreLLM, ScoreFitRequest
+
+    monkeypatch.setattr(settings, "pii_redaction_enabled", True)
+    sink: dict = {}
+    fake = _FakeModel(sink, FitScoreLLM(fit_score=50))
+    monkeypatch.setattr(sf, "get_model", lambda: (fake, "fake"))
+
+    sf.score_fit(
+        ScoreFitRequest(
+            description_text="Role at Acme",
+            resume_text="Jane Doe jane@doe.com +1 (415) 555-2671",
+            profile_text="see https://jane.dev",
+            retrieved_context=["contact me at jane@doe.com"],
+        )
+    )
+    human = _human_text(sink)
+    assert "jane@doe.com" not in human and "[EMAIL]" in human
+    assert "555-2671" not in human and "[PHONE]" in human
+    assert "https://jane.dev" not in human and "[URL]" in human
+
+
+def test_parse_job_redacts_pii_before_llm(monkeypatch):
+    from app.chains import parse_job as pj
+    from app.config import settings
+    from app.schemas import ParsedJob
+
+    monkeypatch.setattr(settings, "pii_redaction_enabled", True)
+    sink: dict = {}
+    monkeypatch.setattr(pj, "get_model", lambda: (_FakeModel(sink, ParsedJob(title="X")), "fake"))
+
+    pj.parse_job("Apply via recruiter@acme.com or call 415-555-2671")
+    human = _human_text(sink)
+    assert "recruiter@acme.com" not in human and "[EMAIL]" in human
+    assert "555-2671" not in human and "[PHONE]" in human
+
+
+# --- H3: Langfuse trace mask -------------------------------------------------
+
+
+def test_langfuse_mask_redacts_nested_when_enabled(monkeypatch):
+    from app.config import settings
+    from app.obs.langfuse import _mask
+
+    monkeypatch.setattr(settings, "pii_redaction_enabled", True)
+    masked = _mask(data={"input": "email a@b.com", "items": ["call 415-555-2671"]})
+    assert masked["input"] == "email [EMAIL]"
+    assert masked["items"][0] == "call [PHONE]"
+
+
+def test_langfuse_mask_noop_when_disabled(monkeypatch):
+    from app.config import settings
+    from app.obs.langfuse import _mask
+
+    monkeypatch.setattr(settings, "pii_redaction_enabled", False)
+    payload = {"input": "email a@b.com"}
+    assert _mask(data=payload) == payload

--- a/services/agent/tests/test_pii.py
+++ b/services/agent/tests/test_pii.py
@@ -130,3 +130,42 @@ def test_langfuse_mask_noop_when_disabled(monkeypatch):
     monkeypatch.setattr(settings, "pii_redaction_enabled", False)
     payload = {"input": "email a@b.com"}
     assert _mask(data=payload) == payload
+
+
+# --- review fix: bare profile URLs + Phase 8 agent prompts --------------------
+
+
+def test_redacts_bare_profile_urls():
+    clean, counts = redact_contact_pii("Profiles: linkedin.com/in/jane-doe and github.com/jane")
+    assert "linkedin.com/in/jane-doe" not in clean
+    assert "github.com/jane" not in clean
+    assert clean.count("[URL]") == 2 and counts["url"] == 2
+
+
+def test_bare_url_does_not_redact_tech_terms():
+    # No path / non-web TLD -> not a URL; tech stacks must survive.
+    text = "Stack: Node.js, React.js, socket.io and TypeScript"
+    clean, counts = redact_contact_pii(text)
+    assert clean == text and counts["url"] == 0
+
+
+def test_interview_prep_agent_redacts_pii_before_llm(monkeypatch):
+    from app.agents import runner
+    from app.config import settings
+    from app.schemas import InterviewPrep, InterviewPrepRequest
+
+    monkeypatch.setattr(settings, "pii_redaction_enabled", True)
+    sink: dict = {}
+
+    class _FakeAgent:
+        def invoke(self, payload, config=None):
+            sink["content"] = payload["messages"][0]["content"]
+            return {"messages": [], "structured_response": InterviewPrep()}
+
+    monkeypatch.setattr(runner, "create_agent", lambda *a, **k: _FakeAgent())
+    monkeypatch.setattr(runner, "get_model", lambda: (object(), "fake"))
+
+    runner.run_interview_prep(
+        InterviewPrepRequest(job_description="Role at Acme", resume_text="Jane jane@doe.com")
+    )
+    assert "jane@doe.com" not in sink["content"] and "[EMAIL]" in sink["content"]


### PR DESCRIPTION
Closes #48. Part of Phase 2 epic #51.

Keeps user PII out of third-party LLMs and observability, without harming analysis.

## What
- **`app/safety/pii.py`** — high-precision contact-PII redactor (email / URL / phone / SSN). Phone matching is **digit-count filtered (10–15 digits)** so ISO dates, salaries, and ZIP-like numbers are preserved. Skills/experience are untouched.
- **Redact before the LLM** — applied in `parse_job`, `score_fit`, `draft_outreach` (description, resume, profile, retrieved evidence, outreach context).
- **Mask in traces** — the same redactor backs a Langfuse `mask` (`app/obs/langfuse.py`), recursing over trace inputs/outputs so contact details never leave the process.
- **Toggle** — `PII_REDACTION_ENABLED` (default on); fully no-op safe (no Langfuse / no provider unaffected).
- **Docs** — `docs/PRIVACY.md` (collection, redaction, masking, retention stance, Presidio as the NER upgrade path) + ARCHITECTURE link.

## Design notes
- We **don't** blanket-redact: fit scoring needs skills/experience, only *contact* PII is removed.
- Street addresses/names are intentionally out of scope (low-precision patterns would hurt analysis) — Presidio is the documented upgrade path.

## Tests / checks
- New `tests/test_pii.py`: redactor (incl. dates/salaries preserved), recursive object mask, toggle, and chain-level "no raw PII reaches the LLM" via a fake model. Full agent suite **68 passing**, `ruff` clean.
- The Evals workflow runs on this PR and **skips cleanly** (no provider key on PRs, by Phase 1's security model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)