### PR TITLE
feat(evals): Phase 2 · J — two-tier eval gate + full EVALS.md

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,9 +1,12 @@
 name: Evals
 
-# Report-only LLM eval job (Phase 1 · Workstream A). Scores parse-job + score-fit
-# on a small real gold set and publishes the report to the run summary. It never
-# blocks a merge — gating is deferred to Phase 2. With no OPENAI_API_KEY secret
-# set, the run skips cleanly (and stays green).
+# Two-tier eval gate (Phase 2 · Workstream J). Scores parse-job + score-fit on a small
+# real gold set and publishes the report to the run summary. On push-to-main / manual
+# dispatch the provider key is injected and the run is GATED (`--gate`): it fails the job
+# when a metric drops below evals/thresholds.json (Ragas regressions are flagged as
+# warnings). On pull_request no key is injected, so the run skips and stays green — the
+# key-free PR gate lives in the `agent` pytest job (gold-set integrity + mock-model smoke).
+# With no OPENAI_API_KEY secret set at all, every run skips cleanly.
 
 on:
   # Keyed (real) eval runs only on trusted events — see the secret guard below.
@@ -51,9 +54,8 @@ jobs:
           pip install -r requirements-dev.txt
           pip install -r requirements-evals.txt
 
-      - name: Run evals (skips cleanly without a provider key)
+      - name: Run evals (gated on push-to-main; skips cleanly without a key)
         id: run
-        continue-on-error: true
         env:
           # Inject the key ONLY on trusted events (push to main / manual dispatch).
           # On pull_request the value is empty, so the run skips — PR-controlled
@@ -61,7 +63,9 @@ jobs:
           # (Absent secret also -> empty -> the run resolves no provider and skips.)
           OPENAI_API_KEY: ${{ github.event_name != 'pull_request' && secrets.OPENAI_API_KEY || '' }}
           OPENAI_MODEL: ${{ vars.JUDGE_MODEL || 'gpt-4o-mini' }}
-        run: python -m evals.run
+        # --gate fails the job when a keyed run drops below evals/thresholds.json.
+        # No continue-on-error: a skipped (no-key) run still exits 0, so PRs stay green.
+        run: python -m evals.run --gate
 
       - name: Publish report to job summary
         if: always()

--- a/EVALS.md
+++ b/EVALS.md
@@ -1,13 +1,12 @@
 # Evaluations
 
 JobOps Copilot measures the quality of its two core LLM steps — **parse-job** and
-**score-fit** — against a small, hand-labeled gold set drawn from **real ingested
-job descriptions** (pulled through the live Adzuna source) plus one sample resume.
+**score-fit** — against a small, hand-labeled gold set drawn from **real ingested job
+descriptions** (pulled through the live Adzuna source) plus one sample resume, and
+**gates** on those numbers in CI.
 
-This is Phase 1 of the LLMOps work: real data in → every call traced
-([Langfuse](services/agent/app/obs/langfuse.py)) → quality measured here. CI gating
-on these numbers is intentionally deferred to Phase 2; today the eval job is
-**report-only**.
+Real data in → every call traced ([Langfuse](services/agent/app/obs/langfuse.py)) →
+quality measured and gated here.
 
 ## What's measured
 
@@ -17,67 +16,89 @@ on these numbers is intentionally deferred to Phase 2; today the eval job is
 - **Title accuracy / seniority accuracy** — exact (case-insensitive) match.
 
 **score-fit** (`evals/metrics/ragas_fit.py`)
-- **Fit-vs-label Spearman** — rank correlation between the model's `fit_score`
-  (0–100) and the hand-assigned `fit_label`. Deterministic; the headline number
-  for "does the model rank candidates the way a human would?".
-- **Ragas faithfulness** — is the fit summary grounded in the resume evidence?
+- **Fit-vs-label Spearman** — rank correlation between the model's `fit_score` (0–100)
+  and the hand-assigned `fit_label`. Deterministic; the headline "does the model rank
+  candidates the way a human would?" number.
+- **Ragas faithfulness** — is the fit summary grounded in the resume/JD evidence?
 - **Ragas answer-relevance** — does the summary actually address the role?
-- **Ragas context-recall** — did the resume evidence cover the reference rationale?
+- **Ragas context-recall** — did the evidence cover the reference rationale?
 
-  Ragas uses an LLM judge plus the agent's existing sentence-transformers
-  embeddings (no extra provider needed).
+  Ragas uses an LLM judge plus the agent's existing sentence-transformers embeddings (no
+  extra provider needed).
+
+## Gold set
+
+- `evals/data/parse_job.jsonl` — 17 real JDs with expected skills / title / seniority.
+- `evals/data/fit_score.jsonl` — 16 real JDs with an expected `fit_label` (spread 10–85)
+  and a short reference rationale.
+- `evals/data/sample_resume.txt` — one candidate, scored against every posting.
+
+## Baseline & thresholds
+
+Measured with `gpt-4o-mini` as both generator and judge (2026-06). Numbers move with the
+model, the gold set, and judge variance — `evals/baseline.json` records them for
+regression detection, and `evals/thresholds.json` sets the **hard CI minimums** (baseline
+minus a margin for variance).
+
+| step | metric | baseline | gate threshold |
+| --- | --- | --- | --- |
+| parse-job | skill F1 | 0.59 | **≥ 0.50** |
+| parse-job | title accuracy | 0.76 | **≥ 0.65** |
+| parse-job | seniority accuracy | 0.53 | **≥ 0.40** |
+| score-fit | fit-vs-label Spearman | 0.68 | **≥ 0.45** |
+| score-fit | faithfulness | 0.80 | regression-flag only |
+| score-fit | context recall | 0.51 | regression-flag only |
+| score-fit | answer relevance | 0.20 | regression-flag only |
+
+The deterministic + rank metrics are **hard-gated**. The Ragas LLM-judge metrics carry
+real variance, so they are tracked for **regression** (flagged as warnings when they drop
+more than 0.1 below baseline) rather than hard-gated. Faithfulness grounds claims in both
+the resume and the JD; the low answer-relevance reflects the lightweight MiniLM embeddings
+and the JD-as-question framing — a known baseline to improve, not a regression.
 
 ## Running it
 
 ```bash
 cd services/agent
 pip install -r requirements-dev.txt -r requirements-evals.txt
-python -m evals.run        # writes evals/report.json + evals/report.md
+python -m evals.run          # writes evals/report.json + evals/report.md
+python -m evals.run --gate   # also fails (exit 1) if a metric is below threshold
 ```
 
-(`requirements-evals.txt` carries Ragas; it is intentionally **not** in the
-runtime image, which installs only `requirements.txt` + `requirements-rag.txt`.)
+(`requirements-evals.txt` carries Ragas; it is intentionally **not** in the runtime
+image, which installs only `requirements.txt` + `requirements-rag.txt`.)
 
-With **no provider key** configured the run **skips** and exits 0 — so CI and
-key-less local runs stay green. The deterministic metric units are covered by
+With **no provider key** configured the run **skips** and exits 0 (even with `--gate`) — so
+key-less local and PR runs stay green. The deterministic metric units are covered by
 `pytest tests/test_evals.py`.
 
-## Gold set
+## Two-tier CI gate
 
-- `evals/data/parse_job.jsonl` — 17 real JDs with expected skills / title / seniority.
-- `evals/data/fit_score.jsonl` — 16 real JDs with an expected `fit_label`
-  (spread 10–85) and a short reference rationale.
-- `evals/data/sample_resume.txt` — one candidate, scored against every posting.
+Producing the candidate parse/score still calls the LLM, so quality **cannot** be gated on
+a pull request without exposing the judge key to PR-controlled code — the exfiltration risk
+closed in Phase 1. Gating is therefore split:
 
-## Baseline (illustrative)
+**Tier 1 — PR gate (key-free, in the `agent` pytest job, blocks PRs).** Three pure checks
+run on every PR with no secret: the eval-metric **unit tests**, a **gold-set integrity**
+test (every row well-formed, `sample_resume.txt` present), and a **mock-model smoke run**
+that drives the runner end-to-end with a fake model. These catch broken eval code,
+malformed data, and pipeline breakage.
 
-Measured locally with `gpt-4o-mini` as both generator and judge (2026-06). Numbers
-move with the model, the gold set, and judge variance — treat them as a starting
-point, not a contract. Phase 2 adds a tracked table and CI thresholds.
+**Tier 2 — main quality gate (keyed, in `.github/workflows/evals.yml`).** On push-to-main
+and manual dispatch the provider key is injected and the eval runs with `--gate`: it
+**fails the job** when a metric drops below `evals/thresholds.json`, and **flags Ragas
+regressions** (warnings) vs `evals/baseline.json`. The step is no longer
+`continue-on-error`, so a failure is real.
 
-| step | metric | score |
-| --- | --- | --- |
-| parse-job | skill F1 | 0.59 |
-| parse-job | title accuracy | 0.76 |
-| parse-job | seniority accuracy | 0.53 |
-| score-fit | fit-vs-label Spearman | 0.68 |
-| score-fit | faithfulness | 0.80 |
-| score-fit | context recall | 0.51 |
-| score-fit | answer relevance | 0.20 |
+### Security
 
-Faithfulness grounds claims in both the resume and the JD (a fit summary
-legitimately cites role requirements). The low answer-relevance reflects the
-lightweight MiniLM embeddings and the JD-as-question framing — a known baseline
-to improve, not a regression.
+The `OPENAI_API_KEY` secret is injected **only on trusted events** — push to `main`
+(post-merge) and manual `workflow_dispatch`. **Pull-request** runs deliberately get no key
+and skip, so PR-controlled code can never receive the provider secret. With no secret
+configured at all, every run skips and stays green.
 
-## CI
+### Wiring the main gate to deploys
 
-`.github/workflows/evals.yml` runs on `services/agent/**` / `prompts/**` changes,
-publishes the report to the run summary, and uploads `report.json` as an
-artifact. It **does not block merges**.
-
-The `OPENAI_API_KEY` secret is injected **only on trusted events** — push to
-`main` (post-merge) and manual `workflow_dispatch` — so a keyed eval runs there.
-**Pull-request** runs deliberately get no key and skip, so PR-controlled code
-can never receive the provider secret. With no secret configured at all, every
-run skips and stays green.
+A red gate on `main` is visible immediately. To make it block releases, either mark
+**Evals (report-only)** a required status check on `main` in branch protection, or add a
+`workflow_run` guard on the deploy workflow so a failed gate halts the deploy.

--- a/services/agent/evals/baseline.json
+++ b/services/agent/evals/baseline.json
@@ -1,0 +1,9 @@
+{
+  "skill_f1": 0.59,
+  "title_accuracy": 0.76,
+  "seniority_accuracy": 0.53,
+  "rank_correlation_spearman": 0.68,
+  "faithfulness": 0.80,
+  "context_recall": 0.51,
+  "answer_relevancy": 0.20
+}

--- a/services/agent/evals/gate.py
+++ b/services/agent/evals/gate.py
@@ -1,0 +1,77 @@
+"""Eval gate (Phase 2 · Workstream J): turn a report into pass/fail.
+
+`check_thresholds` hard-gates the deterministic + rank metrics against committed minimums
+(`thresholds.json`). `check_regression` flags drops vs a stored baseline (`baseline.json`)
+— surfaced as warnings rather than hard failures, since the Ragas LLM-judge metrics carry
+real variance. A skipped report (no provider key) gates nothing, so key-less PR runs and
+local runs stay green.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_DIR = Path(__file__).parent
+
+
+def _flatten(report: dict[str, Any]) -> dict[str, float]:
+    """Collect numeric metrics from the parse_job / fit_score sections (incl. nested ragas)."""
+    flat: dict[str, float] = {}
+    for section in ("parse_job", "fit_score"):
+        data = report.get(section)
+        if not isinstance(data, dict):
+            continue
+        for key, value in data.items():
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                flat[key] = float(value)
+        ragas = data.get("ragas")
+        if isinstance(ragas, dict):
+            for key, value in ragas.items():
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    flat[key] = float(value)
+    return flat
+
+
+def check_thresholds(report: dict[str, Any], thresholds: dict[str, float]) -> list[str]:
+    """Return human-readable failures for metrics below their committed minimum.
+
+    Returns ``[]`` when the report is not ``status == "ok"`` (a skipped run gates nothing)
+    or when a thresholded metric is absent (e.g. Ragas skipped)."""
+    if report.get("status") != "ok":
+        return []
+    flat = _flatten(report)
+    failures: list[str] = []
+    for metric, minimum in thresholds.items():
+        value = flat.get(metric)
+        if value is None:
+            continue
+        if value < minimum:
+            failures.append(f"{metric}={value} is below threshold {minimum}")
+    return failures
+
+
+def check_regression(
+    report: dict[str, Any], baseline: dict[str, float], tol: float = 0.1
+) -> list[str]:
+    """Return metrics that dropped more than ``tol`` below the stored baseline."""
+    if report.get("status") != "ok":
+        return []
+    flat = _flatten(report)
+    regressions: list[str] = []
+    for metric, base in baseline.items():
+        value = flat.get(metric)
+        if value is None or base is None:
+            continue
+        if value < base - tol:
+            regressions.append(f"{metric}={value} regressed vs baseline {base} (tol {tol})")
+    return regressions
+
+
+def load_thresholds() -> dict[str, float]:
+    return json.loads((_DIR / "thresholds.json").read_text(encoding="utf-8"))
+
+
+def load_baseline() -> dict[str, float]:
+    return json.loads((_DIR / "baseline.json").read_text(encoding="utf-8"))

--- a/services/agent/evals/gate.py
+++ b/services/agent/evals/gate.py
@@ -37,8 +37,10 @@ def _flatten(report: dict[str, Any]) -> dict[str, float]:
 def check_thresholds(report: dict[str, Any], thresholds: dict[str, float]) -> list[str]:
     """Return human-readable failures for metrics below their committed minimum.
 
-    Returns ``[]`` when the report is not ``status == "ok"`` (a skipped run gates nothing)
-    or when a thresholded metric is absent (e.g. Ragas skipped)."""
+    Returns ``[]`` when the report is not ``status == "ok"`` (a skipped run gates nothing).
+    On an ok run, a thresholded metric that is absent/``None`` is itself a failure — e.g. a
+    collapsed or all-failed score_fit makes Spearman ``None``, which must not pass the gate.
+    (Only metrics listed in ``thresholds`` are required; other absent metrics are ignored.)"""
     if report.get("status") != "ok":
         return []
     flat = _flatten(report)
@@ -46,6 +48,7 @@ def check_thresholds(report: dict[str, Any], thresholds: dict[str, float]) -> li
     for metric, minimum in thresholds.items():
         value = flat.get(metric)
         if value is None:
+            failures.append(f"{metric} is missing/None — cannot verify >= {minimum}")
             continue
         if value < minimum:
             failures.append(f"{metric}={value} is below threshold {minimum}")

--- a/services/agent/evals/run.py
+++ b/services/agent/evals/run.py
@@ -22,6 +22,7 @@ from app.config import settings
 from app.llm.provider import get_model, resolve_provider
 from app.rag.chunk import chunk_text
 from app.schemas import ScoreFitRequest
+from evals.gate import check_regression, check_thresholds, load_baseline, load_thresholds
 from evals.metrics.extraction import exact_match, skill_prf
 from evals.metrics.ragas_fit import fit_ragas_scores, mean, spearman
 
@@ -213,7 +214,7 @@ def render_markdown(report: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
-def main(output_dir: Path | None = None) -> int:
+def main(output_dir: Path | None = None, gate: bool = False) -> int:
     logging.basicConfig(level=logging.INFO)
     output_dir = output_dir or Path(__file__).parent
     generated_at = datetime.now(UTC).isoformat(timespec="seconds")
@@ -242,8 +243,23 @@ def main(output_dir: Path | None = None) -> int:
     (output_dir / "report.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
     (output_dir / "report.md").write_text(render_markdown(report), encoding="utf-8")
     print(render_markdown(report))
+
+    # Gate (Phase 2 · J): only meaningful on a keyed run. A skipped report gates nothing,
+    # so PR runs (no key) stay green. Thresholds hard-fail; regressions are flagged.
+    if gate and report["status"] == "ok":
+        regressions = check_regression(report, load_baseline())
+        for line in regressions:
+            print(f"::warning::eval regression: {line}")
+        failures = check_thresholds(report, load_thresholds())
+        if failures:
+            for line in failures:
+                print(f"::error::eval gate failed: {line}")
+            return 1
+
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+
+    raise SystemExit(main(gate="--gate" in sys.argv))

--- a/services/agent/evals/thresholds.json
+++ b/services/agent/evals/thresholds.json
@@ -1,0 +1,6 @@
+{
+  "skill_f1": 0.50,
+  "title_accuracy": 0.65,
+  "seniority_accuracy": 0.40,
+  "rank_correlation_spearman": 0.45
+}

--- a/services/agent/tests/test_evals.py
+++ b/services/agent/tests/test_evals.py
@@ -150,3 +150,121 @@ def test_run_skips_without_provider_key(tmp_path, monkeypatch):
     assert report["status"] == "skipped"
     assert report["provider"] is None
     assert (tmp_path / "report.md").exists()
+
+
+# --- J1: key-free PR gate (gold-set integrity + mock-model smoke) ------------
+
+
+def test_gold_sets_are_well_formed():
+    import json
+
+    from evals import run
+
+    for name in ("parse_job.jsonl", "fit_score.jsonl"):
+        rows = [
+            json.loads(line)
+            for line in (run._DATA_DIR / name).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert rows, f"{name} is empty"
+        for row in rows:
+            assert {"description_text", "expected"} <= set(row.keys())
+            assert row["description_text"].strip()
+    assert (run._DATA_DIR / "sample_resume.txt").read_text(encoding="utf-8").strip()
+
+
+def test_parse_job_eval_smoke_with_fake_model(monkeypatch):
+    """The runner pipeline executes end-to-end with a fake model — no key, no network."""
+    from app.schemas import ParsedJob
+    from evals import run
+
+    monkeypatch.setattr(
+        run, "parse_job", lambda text, config=None: ParsedJob(title="X", required_skills=["python"])
+    )
+    row = {
+        "description_text": "d",
+        "expected": {"required_skills": ["python"], "title": "X", "seniority": "mid"},
+    }
+    out = run.run_parse_job_eval([row])
+    assert out["n"] == 1 and out["errors"] == 0 and out["skill_f1"] == 1.0
+
+
+# --- J2: gate logic (pure) ---------------------------------------------------
+
+
+def test_check_thresholds_reports_failures():
+    from evals.gate import check_thresholds
+
+    report = {
+        "status": "ok",
+        "parse_job": {"skill_f1": 0.40, "title_accuracy": 0.9, "seniority_accuracy": 0.9},
+        "fit_score": {"rank_correlation_spearman": 0.7},
+    }
+    failures = check_thresholds(report, {"skill_f1": 0.50, "title_accuracy": 0.65})
+    assert any("skill_f1" in f for f in failures)
+    assert not any("title_accuracy" in f for f in failures)
+
+
+def test_check_thresholds_skips_when_report_skipped():
+    from evals.gate import check_thresholds
+
+    assert check_thresholds({"status": "skipped"}, {"skill_f1": 0.99}) == []
+
+
+def test_check_regression_flags_drops():
+    from evals.gate import check_regression
+
+    report = {"status": "ok", "fit_score": {"ragas": {"faithfulness": 0.50}}}
+    assert check_regression(report, {"faithfulness": 0.80}, tol=0.1)
+    assert check_regression(report, {"faithfulness": 0.55}, tol=0.1) == []  # within tolerance
+
+
+# --- J3: --gate exit behavior ------------------------------------------------
+
+
+def _stub_keyed_run(monkeypatch, parse_metrics, fit_metrics):
+    from evals import run
+
+    monkeypatch.setattr(run, "_provider_ready", lambda: True)
+    monkeypatch.setattr(run, "get_model", lambda: (object(), "fake:model"))
+    monkeypatch.setattr(run, "_load_jsonl", lambda path: [{}])
+    monkeypatch.setattr(run, "run_parse_job_eval", lambda rows: parse_metrics)
+    monkeypatch.setattr(run, "run_fit_score_eval", lambda rows, resume: fit_metrics)
+    return run
+
+
+def _pj(score: float) -> dict:
+    return {
+        "n": 1,
+        "errors": 0,
+        "skill_precision": score,
+        "skill_recall": score,
+        "skill_f1": score,
+        "title_accuracy": score,
+        "seniority_accuracy": score,
+    }
+
+
+def test_main_gate_fails_below_threshold(tmp_path, monkeypatch):
+    run = _stub_keyed_run(
+        monkeypatch,
+        _pj(0.10),
+        {"n": 1, "errors": 0, "rank_correlation_spearman": 0.10, "ragas": {}},
+    )
+    assert run.main(output_dir=tmp_path, gate=True) == 1
+
+
+def test_main_gate_passes_above_threshold(tmp_path, monkeypatch):
+    run = _stub_keyed_run(
+        monkeypatch,
+        _pj(0.90),
+        {"n": 1, "errors": 0, "rank_correlation_spearman": 0.90, "ragas": {}},
+    )
+    assert run.main(output_dir=tmp_path, gate=True) == 0
+
+
+def test_main_gate_passes_on_skip(tmp_path, monkeypatch):
+    from evals import run
+
+    monkeypatch.setattr(run, "resolve_provider", lambda: None)
+    assert run.main(output_dir=tmp_path, gate=True) == 0

--- a/services/agent/tests/test_evals.py
+++ b/services/agent/tests/test_evals.py
@@ -211,6 +211,16 @@ def test_check_thresholds_skips_when_report_skipped():
     assert check_thresholds({"status": "skipped"}, {"skill_f1": 0.99}) == []
 
 
+def test_check_thresholds_fails_when_thresholded_metric_missing():
+    """A thresholded metric absent on an ok run (e.g. Spearman None) is a failure."""
+    from evals.gate import check_thresholds
+
+    report = {"status": "ok", "parse_job": {"skill_f1": 0.9}, "fit_score": {"ragas": {}}}
+    failures = check_thresholds(report, {"skill_f1": 0.5, "rank_correlation_spearman": 0.45})
+    assert any("rank_correlation_spearman" in f for f in failures)
+    assert not any("skill_f1" in f for f in failures)
+
+
 def test_check_regression_flags_drops():
     from evals.gate import check_regression
 


### PR DESCRIPTION
Closes #50. Part of Phase 2 epic #51.

Promotes the report-only eval job to an honest two-tier gate.

## Why two tiers
Producing the candidate parse/score still calls the LLM, so eval **quality** can't be gated on a PR without exposing the judge key to PR-controlled code (the exfiltration risk Phase 1 closed). So:

- **Tier 1 — PR gate (key-free, in the `agent` pytest job):** gold-set integrity + a mock-model smoke run of the runner, plus the existing metric unit tests. Catches broken eval code / malformed data / pipeline breakage with no secret.
- **Tier 2 — main quality gate (keyed, `evals.yml`):** `python -m evals.run --gate` **fails the job** when a metric drops below `evals/thresholds.json`; Ragas regressions vs `evals/baseline.json` are **flagged** (warnings — judge variance). Dropped `continue-on-error`, so the keyed push-to-main run actually gates; PR runs skip (no key) → exit 0.

## What's in it
- `evals/gate.py` (`check_thresholds` hard-gate + `check_regression` flag), `thresholds.json` (baseline − margin), `baseline.json` (real gpt-4o-mini numbers).
- `evals/run.py` gains `--gate`; `evals.yml` gates on push-to-main; full **`EVALS.md`** (methodology, baseline/threshold table, two-tier rationale, security note, deploy-gate wiring).

## Checks
- New tests: gold-set integrity, mock-model smoke, threshold/regression logic, and `--gate` exit behavior (fails below threshold, passes above, exits 0 on skip). Full agent suite **76 passing**, `ruff` clean.
- Verified locally end-to-end: a keyed `python -m evals.run --gate` ran the real eval and exited 0 (passes current thresholds).
- The Evals workflow runs on this PR and **skips cleanly** (no key on PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)