### PR TITLE
docs(phase3): design spec + implementation plan — LangGraph, MCP & streaming

### DIFF
--- a/docs/superpowers/plans/2026-06-17-phase3-langgraph-mcp-streaming.md
+++ b/docs/superpowers/plans/2026-06-17-phase3-langgraph-mcp-streaming.md
@@ -1,0 +1,212 @@
+# Phase 3: LangGraph, MCP & streaming — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Confirm exact third-party APIs (LangGraph `StateGraph`/`interrupt`/checkpointer + `Command(resume=...)`, MCP Python SDK `FastMCP` streamable-HTTP + auth, `langchain-mcp-adapters` `MultiServerMCPClient`, FastAPI `StreamingResponse` + `.astream_events()`, Express SSE passthrough) via Context7 at the start of the relevant workstream.
+
+**Goal:** Add a stateful LangGraph application-assistant (with a human-in-the-loop interrupt), a remote authenticated MCP server exposing JobOps tools, end-to-end SSE streaming of the assistant run, and agent-as-MCP-client tool use — without breaking graceful degradation.
+
+**Architecture:** Four sub-issues, each its own branch/PR. **K** (Python/agent): a `StateGraph` composes the existing guarded chains/agents as nodes with conditional routing and an `interrupt` before outreach. **L** (new `services/mcp`): a FastMCP streamable-HTTP server that bridges to the existing REST API (auth-forwarded). **M** (agent + API + web): SSE streams the graph's `astream_events` through an Express passthrough to a live web panel. **N** (Python/agent): the research path loads external MCP tools via `langchain-mcp-adapters`, falling back to Tavily.
+
+**Tech Stack:** Python 3.12, FastAPI, LangChain, **LangGraph**, **MCP Python SDK (FastMCP)**, **langchain-mcp-adapters**; TypeScript/Express; Next.js 16/React 19; pytest; GitHub Actions.
+
+**Conventions to follow (existing patterns):**
+- Agent settings: add fields to `app/config.py` `Settings` (pydantic-settings; e.g. `assistant_fit_threshold` ← `ASSISTANT_FIT_THRESHOLD`).
+- Endpoints in `app/main.py` use `_require_llm()` then `_run(fn, *args)`; chains/agents accept `config: dict | None = None` and are already Phase-2-guarded.
+- Agent tests fake the model with the `_FakeModel`/`_FakeStructured` + `monkeypatch.setattr(mod, "get_model", ...)` pattern (`tests/test_tracing.py`); graph/agent tests must run **without** a provider key (CI-safe, per `conftest.py`).
+- API delegation lives in `apps/api/src/lib/agent-client.ts` (fetch + graceful fallback). Web calls the API via the `/api/proxy` pattern.
+- Graceful degradation is sacred: no provider/agent/MCP must **degrade**, never raise into the request path.
+- **Sequencing:** K → M → N share the agent/graph files — implement in order, each branched off `main` **after** the previous merges. **L is independent** (separate `services/mcp`) and can run in parallel. (Lesson from Phase 2.)
+
+---
+
+## File structure
+
+**Workstream K — LangGraph application-assistant (agent)**
+- Create `services/agent/app/graph/__init__.py`, `app/graph/state.py` (`AssistantState` TypedDict), `app/graph/assistant.py` (`build_assistant_graph()` + node functions + routing).
+- Modify `app/config.py` — `assistant_fit_threshold: int = 60`.
+- Modify `app/main.py` — `POST /assistant/run`, `POST /assistant/resume`.
+- Modify `app/schemas.py` — `AssistantRunRequest`, `AssistantResumeRequest`, `AssistantState`-response.
+- Modify `apps/api/src/lib/agent-client.ts` + a route + minimal web action (kick off a run, show result + approval).
+- Create `services/agent/tests/test_assistant_graph.py`.
+
+**Workstream L — MCP server (new `services/mcp`)**
+- Create `services/mcp/pyproject.toml` (or `requirements.txt`), `server.py` (FastMCP + tools), `api_client.py` (REST bridge), `README.md`, `tests/test_tools.py`.
+- Modify `.env.example` — `MCP_SERVER_API_BASE_URL`, `MCP_SERVER_API_KEY`.
+
+**Workstream M — Streaming (agent + API + web)**
+- Modify `app/main.py` — `POST /assistant/stream` (`StreamingResponse`, `text/event-stream`).
+- Create `apps/api/src/routes/assistant.ts` (SSE passthrough) + mount in `app.ts`.
+- Modify `apps/web` — a live assistant panel consuming the stream + approval control.
+- Create `services/agent/tests/test_assistant_stream.py`.
+
+**Workstream N — MCP client (agent)**
+- Create `app/agents/mcp_tools.py` (`load_mcp_tools()` + Tavily fallback).
+- Modify `app/agents/runner.py` (research) and/or `app/graph/assistant.py` (research node) to use the loaded tools.
+- Modify `app/config.py` — `mcp_client_servers: str | None = None`.
+- Create `services/agent/tests/test_mcp_tools.py`.
+
+---
+
+## Workstream K — LangGraph application-assistant
+
+### Task K1: deps + state + graph routing (TDD, no LLM)
+**Files:** Modify `services/agent/requirements*.txt`, `app/config.py`; Create `app/graph/__init__.py`, `app/graph/state.py`, `app/graph/assistant.py`; Test `tests/test_assistant_graph.py`
+
+- [ ] **Step 0: Confirm API** — via Context7, confirm LangGraph `StateGraph`, `START`/`END`, `add_conditional_edges`, `interrupt` (`langgraph.types`), `MemorySaver` (`langgraph.checkpoint.memory`), and `Command(resume=...)`. Confirm `langgraph` is a direct dep (add to `requirements.txt` if only transitive via `langchain`).
+- [ ] **Step 1: Failing test** — routing only, with node functions injected so no LLM runs:
+
+```python
+from app.graph.assistant import route_after_score
+
+def test_strong_fit_routes_to_research():
+    assert route_after_score({"fit": {"fit_score": 80}}, threshold=60) == "research"
+
+def test_weak_fit_ends():
+    assert route_after_score({"fit": {"fit_score": 30}}, threshold=60) == "end"
+```
+
+- [ ] **Step 2: Run — expect FAIL** — `pytest tests/test_assistant_graph.py -v`.
+- [ ] **Step 3: Implement** — `app/graph/state.py`:
+
+```python
+from __future__ import annotations
+from typing import TypedDict
+
+class AssistantState(TypedDict, total=False):
+    description_text: str
+    resume_text: str
+    profile_text: str
+    user_id: str | None
+    parsed: dict
+    fit: dict
+    research: dict
+    draft: dict
+    approved: bool
+    status: str
+```
+
+`app/graph/assistant.py` (routing + builder; nodes wrap existing functions in K2):
+
+```python
+from __future__ import annotations
+from app.config import settings
+
+def route_after_score(state: dict, threshold: int | None = None) -> str:
+    threshold = settings.assistant_fit_threshold if threshold is None else threshold
+    fit = state.get("fit") or {}
+    return "research" if int(fit.get("fit_score", 0)) >= threshold else "end"
+```
+
+Add `assistant_fit_threshold: int = 60` to `Settings`.
+
+- [ ] **Step 4: Run — expect PASS. Commit** — `feat(agent): assistant graph state + fit-based routing`.
+
+### Task K2: nodes wrapping the existing chains/agents (TDD, fake model)
+**Files:** Modify `app/graph/assistant.py`; Test `tests/test_assistant_graph.py`
+
+- [ ] **Step 1–2: Failing test** — build the graph with `get_model` monkeypatched (fake model returning canned `ParsedJob`/`FitScoreLLM`); invoke with a strong-fit fake and assert the state collects `parsed`, `fit`, and (strong path) `research`/`draft`. Use the `_FakeModel` pattern; the research node's agent is also monkeypatched.
+- [ ] **Step 3: Implement** node functions calling the existing guarded functions and writing into state:
+
+```python
+from app.chains.parse_job import parse_job
+from app.chains.score_fit import score_fit
+from app.chains.draft_outreach import draft_outreach
+from app.agents.runner import run_research
+from app.schemas import ScoreFitRequest, DraftOutreachRequest, ResearchRequest
+
+def parse_node(state: dict) -> dict:
+    parsed = parse_job(state["description_text"])
+    return {"parsed": parsed.model_dump(), "status": "scored"}
+
+def score_node(state: dict) -> dict:
+    req = ScoreFitRequest(description_text=state["description_text"],
+                          resume_text=state.get("resume_text", ""),
+                          profile_text=state.get("profile_text", ""),
+                          user_id=state.get("user_id"))
+    fit = score_fit(req)
+    return {"fit": fit.model_dump(), "status": "researched?"}
+# research_node -> run_research(ResearchRequest(...)); draft_node -> draft_outreach(DraftOutreachRequest(...))
+```
+
+`build_assistant_graph()` wires `START → parse → score → [route_after_score] → research → <interrupt> → draft → END` (interrupt added in K3); compile without a checkpointer here.
+
+- [ ] **Step 4–5: Run PASS; `ruff`. Commit** — `feat(agent): assistant graph nodes over parse/score/research/outreach`.
+
+### Task K3: human-in-the-loop interrupt + checkpointer + resume (TDD)
+**Files:** Modify `app/graph/assistant.py`; Test `tests/test_assistant_graph.py`
+
+- [ ] **Step 1–2: Failing test** — compile with `MemorySaver`; invoke a strong-fit run with `config={"configurable":{"thread_id":"t1"}}`; assert it **pauses** before outreach (no `draft` yet, `status == "awaiting_approval"`), then resume with `Command(resume={"approved": True})` and assert `draft` is produced; resume with `approved=False` ends without a draft.
+- [ ] **Step 3: Implement** — insert `interrupt(...)` in a `review_node` before `draft_node`; on resume, branch on the resumed `approved` value (draft vs end). Compile with `MemorySaver()`; expose `build_assistant_graph(checkpointer=...)`.
+- [ ] **Step 4–5: Run PASS; `ruff`. Commit** — `feat(agent): human-in-the-loop interrupt before outreach`.
+
+### Task K4: endpoints + API/web wiring
+**Files:** Modify `app/main.py`, `app/schemas.py`, `apps/api/src/lib/agent-client.ts`, an API route, `apps/web`; Test `tests/test_endpoints.py`
+
+- [ ] **Step 1–2: Failing test** — `POST /assistant/run` with no provider key → 503 (FastAPI TestClient); with a monkeypatched graph → returns the state incl. `status: "awaiting_approval"` and a `thread_id`.
+- [ ] **Step 3: Implement** — `AssistantRunRequest` (description/resume/profile/user_id) + `AssistantResumeRequest` (thread_id, approved). `/assistant/run` builds the graph (module-level singleton + `MemorySaver`), invokes with a generated `thread_id`, returns `{thread_id, state}`; `/assistant/resume` resumes with `Command`. Add `runAssistant`/`resumeAssistant` to `agent-client.ts` (throw `AgentDisabledError` when unset — net-new, no mock), an `/api/ai/assistant/*` route (Clerk + strict limiter + budget), and a minimal web action to start a run and render state + an Approve button.
+- [ ] **Step 4–5: Run PASS; `npm run check`; agent `pytest`/`ruff`. Commit** — `feat: application-assistant endpoints + API/web wiring`.
+
+---
+
+## Workstream L — MCP server (standalone)
+
+### Task L1: scaffold + REST bridge + first tool (TDD)
+**Files:** Create `services/mcp/requirements.txt`, `services/mcp/api_client.py`, `services/mcp/server.py`, `services/mcp/tests/test_tools.py`
+
+- [ ] **Step 0: Confirm API** — via Context7, confirm MCP Python SDK `FastMCP`, `@mcp.tool()`, and **streamable-HTTP** serving (`mcp.run(transport="streamable-http")` / `mcp.streamable_http_app()`), plus how to require auth.
+- [ ] **Step 1–2: Failing test** — `api_client.search_jobs(query, user_id)` calls `GET {BASE}/api/jobs` with `X-API-Key` + `X-User-Id` headers (mock `httpx`/`requests`); returns the parsed list. (Tools are thin wrappers over `api_client`, unit-tested without a live server.)
+- [ ] **Step 3: Implement** `api_client.py` — a small REST client reading `MCP_SERVER_API_BASE_URL` + `MCP_SERVER_API_KEY`, with `search_jobs`, `get_job`, `score_fit`, `draft_outreach`, `list_saved_searches` calling the matching API endpoints and forwarding `X-User-Id`. `server.py` — `mcp = FastMCP("jobops")` + `@mcp.tool()` wrappers delegating to `api_client`.
+- [ ] **Step 4–5: Run PASS. Commit** — `feat(mcp): JobOps MCP server scaffold + search_jobs over the REST bridge`.
+
+### Task L2: remaining tools + auth + run
+**Files:** Modify `services/mcp/server.py`, `api_client.py`; Create `services/mcp/README.md`; Modify `.env.example`
+- [ ] Add `get_job`, `score_fit`, `draft_outreach`, `list_saved_searches` tools (each TDD against the mocked REST client). Require auth on the HTTP transport (reject calls without the configured token); the user id is supplied per session/tool arg. Document running it (`python server.py` / uvicorn) and connecting an MCP client (MCP Inspector / Claude) in `README.md`. Add `MCP_SERVER_API_BASE_URL`/`MCP_SERVER_API_KEY` to `.env.example`.
+- [ ] **Verify:** `pytest services/mcp/tests`; manual MCP Inspector list/call against a locally-running API. **Commit** — `feat(mcp): full JobOps tool set + auth + run docs`.
+
+---
+
+## Workstream M — Streaming (agent → API → web)
+
+### Task M1: SSE assistant-stream endpoint (TDD)
+**Files:** Modify `app/main.py`; Test `tests/test_assistant_stream.py`
+- [ ] **Step 0: Confirm API** — via Context7, confirm FastAPI `StreamingResponse(media_type="text/event-stream")` and LangGraph `.astream_events(...)` event shape.
+- [ ] **Step 1–2: Failing test** — with a monkeypatched graph whose `astream_events` yields fake node events, `GET/POST /assistant/stream` yields ordered SSE lines (`event: status` … `event: result`). Use FastAPI TestClient streaming.
+- [ ] **Step 3: Implement** — an async generator that maps graph events → SSE frames (`f"event: {kind}\ndata: {json}\n\n"`), returned as `StreamingResponse(gen(), media_type="text/event-stream")`; `_require_llm()` guards it.
+- [ ] **Step 4–5: Run PASS; `ruff`. Commit** — `feat(agent): SSE streaming of the assistant run`.
+
+### Task M2: Express SSE passthrough
+**Files:** Create `apps/api/src/routes/assistant.ts`; Modify `apps/api/src/app.ts`; Test `apps/api/src/routes/assistant.test.ts`
+- [ ] **Step 1–2: Failing test** — a `createAssistantRouter({ streamUpstream })` whose route pipes upstream SSE chunks to the response with `Content-Type: text/event-stream` and no buffering; assert the client receives the streamed frames (fake upstream).
+- [ ] **Step 3: Implement** — the route sets `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `X-Accel-Buffering: no`, fetches the agent stream, and pipes `response.body` to `res`. Mount under `/api/ai/assistant/stream` (Clerk + strict limiter + budget). Confirm no global middleware buffers it.
+- [ ] **Step 4–5: Run PASS; `npm run check`. Commit** — `feat(api): SSE passthrough for the assistant stream`.
+
+### Task M3: web live panel + degradation
+**Files:** Modify `apps/web`
+- [ ] Add an assistant panel that POSTs to `/api/proxy/ai/assistant/stream`, reads the `ReadableStream`, renders per-node status + the streaming draft, and shows the Approve/Reject control at `awaiting_approval` (calling `/assistant/resume`). When the agent is unavailable (503), fall back to the non-streaming run. **Verify:** `npm run check`; manual browser check. **Commit** — `feat(web): live streaming assistant panel + approval`.
+
+---
+
+## Workstream N — MCP client (agent)
+
+### Task N1: MCP tool loader + Tavily fallback (TDD)
+**Files:** Create `app/agents/mcp_tools.py`; Modify `app/config.py`; Test `tests/test_mcp_tools.py`
+- [ ] **Step 0: Confirm API** — via Context7, confirm `langchain-mcp-adapters` `MultiServerMCPClient` config shape + `get_tools()`.
+- [ ] **Step 1–2: Failing test** — `load_research_tools()` returns the Tavily tool when `MCP_CLIENT_SERVERS` is unset (no network); with a monkeypatched MCP client returning fake tools, it returns those (plus/instead of Tavily). Never raises.
+- [ ] **Step 3: Implement** — parse `MCP_CLIENT_SERVERS` (JSON), build `MultiServerMCPClient`, `get_tools()`; on empty/error return `[web_search]` (the existing Tavily tool). Add `mcp_client_servers: str | None = None` to `Settings`.
+- [ ] **Step 4–5: Run PASS; `ruff`. Commit** — `feat(agent): load external MCP tools with Tavily fallback`.
+
+### Task N2: wire into research + docs
+**Files:** Modify `app/agents/runner.py` (and/or `app/graph/assistant.py` research node); Modify `.env.example`; Test `tests/test_mcp_tools.py`
+- [ ] Pass `load_research_tools()` into the research agent's `tools=[...]` (replacing the hardcoded `[web_search]`); assert with a fake model that the loaded tools are attached. Add `MCP_CLIENT_SERVERS` to `.env.example` with a comment.
+- [ ] **Verify:** `pytest && ruff check app tests`. **Commit** — `feat(agent): research consumes external MCP tools (Tavily fallback)`.
+
+---
+
+## Self-review (spec coverage)
+- **K — LangGraph:** K1 (state + routing) · K2 (nodes) · K3 (interrupt/resume) · K4 (endpoints + API/web). ✓ (criteria 1, 2)
+- **L — MCP server:** L1 (scaffold + bridge + first tool) · L2 (full tools + auth + docs). ✓ (criterion 3)
+- **M — Streaming:** M1 (SSE endpoint) · M2 (Express passthrough) · M3 (web panel + degradation). ✓ (criterion 4)
+- **N — MCP client:** N1 (loader + Tavily fallback) · N2 (wire into research). ✓ (criterion 5)
+- **Graceful degradation (criterion 6):** 503 path in K4/M1; Tavily fallback in N1; MCP-server auth in L2; web non-streaming fallback in M3. Existing tests preserved.
+- **Deferrals honored:** no hybrid-RAG/reranker (P4), no IaC/e2e/load (P5), no agent-graph refactor, no WebSockets.
+
+**Note:** exact third-party SDK APIs (LangGraph `interrupt`/checkpointer/`Command`, MCP `FastMCP` streamable-HTTP + auth, `langchain-mcp-adapters`, FastAPI/Express SSE) and `app/schemas.py` field names are confirmed against the repo + Context7 at the first task of each workstream, before writing code.

--- a/docs/superpowers/plans/2026-06-17-phase3-langgraph-mcp-streaming.md
+++ b/docs/superpowers/plans/2026-06-17-phase3-langgraph-mcp-streaming.md
@@ -28,13 +28,15 @@
 - Modify `apps/api/src/lib/agent-client.ts` + a route + minimal web action (kick off a run, show result + approval).
 - Create `services/agent/tests/test_assistant_graph.py`.
 
-**Workstream L — MCP server (new `services/mcp`)**
+**Workstream L — MCP server (new `services/mcp`) + API service-auth**
+- Modify `apps/api/src/lib/auth.ts` — **service-auth**: a valid shared key (`X-API-Key` = `API_SHARED_SECRET`) plus `X-User-Id` sets `request.userId` (so the bridge can act as a user). Without this, the bridge 401s in prod (see Task L0).
 - Create `services/mcp/pyproject.toml` (or `requirements.txt`), `server.py` (FastMCP + tools), `api_client.py` (REST bridge), `README.md`, `tests/test_tools.py`.
 - Modify `.env.example` — `MCP_SERVER_API_BASE_URL`, `MCP_SERVER_API_KEY`.
 
 **Workstream M — Streaming (agent + API + web)**
 - Modify `app/main.py` — `POST /assistant/stream` (`StreamingResponse`, `text/event-stream`).
 - Create `apps/api/src/routes/assistant.ts` (SSE passthrough) + mount in `app.ts`.
+- Create `apps/web/src/app/api/assistant-stream/route.ts` — a **streaming** Next proxy (the catch-all `/api/proxy` route buffers via `arrayBuffer()` and cannot stream SSE).
 - Modify `apps/web` — a live assistant panel consuming the stream + approval control.
 - Create `services/agent/tests/test_assistant_stream.py`.
 
@@ -149,12 +151,55 @@ def score_node(state: dict) -> dict:
 
 ## Workstream L — MCP server (standalone)
 
+### Task L0: API service-auth so the bridge can act as a user (TDD)
+**Files:** Modify `apps/api/src/lib/auth.ts`; Test `apps/api/src/lib/auth.test.ts`
+
+**Why (review fix):** with `CLERK_SECRET_KEY` set (prod), `attachUserId` only trusts Clerk and **ignores `X-User-Id`** (except `/api/n8n`), and `requireSharedApiKey` only gates *mutations* and never sets `request.userId`. So an MCP bridge sending `X-API-Key` + `X-User-Id` would pass header-mock tests but **401 at `requireUser`** on real `GET /api/jobs`, `/api/saved-searches`, etc. Add a service-principal path (mirrors the existing n8n M2M pattern).
+
+- [ ] **Step 1: Failing test** (`auth.test.ts`, mount `attachUserId` on a tiny app):
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import express from 'express';
+import { attachUserId } from './auth';
+
+test('a valid shared key + X-User-Id acts as that user', async () => {
+  process.env.API_SHARED_SECRET = 'svc-secret';
+  const app = express();
+  app.use(attachUserId);
+  app.get('/whoami', (req, res) => res.json({ userId: req.userId ?? null }));
+  // ... start server, then:
+  const res = await fetch(`${baseUrl}/whoami`, {
+    headers: { 'X-API-Key': 'svc-secret', 'X-User-Id': 'u_mcp' },
+  });
+  assert.equal((await res.json()).userId, 'u_mcp');
+});
+// And: with the WRONG/absent key, X-User-Id is ignored (falls through to Clerk/dev).
+```
+
+- [ ] **Step 2: Run — expect FAIL** — `npm test --workspace @jobops/api`.
+- [ ] **Step 3: Implement** — in `attachUserId`, before the Clerk branch (and after the `/api/n8n` branch):
+
+```ts
+const sharedSecret = process.env.API_SHARED_SECRET?.trim();
+const onBehalfOf = request.header('X-User-Id')?.trim();
+if (sharedSecret && request.header('X-API-Key')?.trim() === sharedSecret && onBehalfOf) {
+  request.userId = onBehalfOf; // service principal acts as the specified user
+  return next();
+}
+```
+
+Only a holder of the server-side `API_SHARED_SECRET` can act on behalf of a user, so no escalation for normal clients (absent/wrong key → `X-User-Id` ignored, exactly as today). Document this trust model in `services/mcp/README.md`.
+
+- [ ] **Step 4–5: Run PASS; `npm run check`. Commit** — `feat(api): service-auth — a valid shared key may act as a specified user`.
+
 ### Task L1: scaffold + REST bridge + first tool (TDD)
 **Files:** Create `services/mcp/requirements.txt`, `services/mcp/api_client.py`, `services/mcp/server.py`, `services/mcp/tests/test_tools.py`
 
 - [ ] **Step 0: Confirm API** — via Context7, confirm MCP Python SDK `FastMCP`, `@mcp.tool()`, and **streamable-HTTP** serving (`mcp.run(transport="streamable-http")` / `mcp.streamable_http_app()`), plus how to require auth.
 - [ ] **Step 1–2: Failing test** — `api_client.search_jobs(query, user_id)` calls `GET {BASE}/api/jobs` with `X-API-Key` + `X-User-Id` headers (mock `httpx`/`requests`); returns the parsed list. (Tools are thin wrappers over `api_client`, unit-tested without a live server.)
-- [ ] **Step 3: Implement** `api_client.py` — a small REST client reading `MCP_SERVER_API_BASE_URL` + `MCP_SERVER_API_KEY`, with `search_jobs`, `get_job`, `score_fit`, `draft_outreach`, `list_saved_searches` calling the matching API endpoints and forwarding `X-User-Id`. `server.py` — `mcp = FastMCP("jobops")` + `@mcp.tool()` wrappers delegating to `api_client`.
+- [ ] **Step 3: Implement** `api_client.py` — a small REST client reading `MCP_SERVER_API_BASE_URL` + `MCP_SERVER_API_KEY`, with `search_jobs`, `get_job`, `score_fit`, `draft_outreach`, `list_saved_searches` calling the matching API endpoints, sending `X-API-Key: MCP_SERVER_API_KEY` and `X-User-Id: <user>` on every call. **`MCP_SERVER_API_KEY` must equal the API's `API_SHARED_SECRET`** so the Task L0 service-auth path resolves the user (otherwise reads 401 in prod). `server.py` — `mcp = FastMCP("jobops")` + `@mcp.tool()` wrappers delegating to `api_client`.
 - [ ] **Step 4–5: Run PASS. Commit** — `feat(mcp): JobOps MCP server scaffold + search_jobs over the REST bridge`.
 
 ### Task L2: remaining tools + auth + run
@@ -179,9 +224,25 @@ def score_node(state: dict) -> dict:
 - [ ] **Step 3: Implement** — the route sets `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `X-Accel-Buffering: no`, fetches the agent stream, and pipes `response.body` to `res`. Mount under `/api/ai/assistant/stream` (Clerk + strict limiter + budget). Confirm no global middleware buffers it.
 - [ ] **Step 4–5: Run PASS; `npm run check`. Commit** — `feat(api): SSE passthrough for the assistant stream`.
 
-### Task M3: web live panel + degradation
-**Files:** Modify `apps/web`
-- [ ] Add an assistant panel that POSTs to `/api/proxy/ai/assistant/stream`, reads the `ReadableStream`, renders per-node status + the streaming draft, and shows the Approve/Reject control at `awaiting_approval` (calling `/assistant/resume`). When the agent is unavailable (503), fall back to the non-streaming run. **Verify:** `npm run check`; manual browser check. **Commit** — `feat(web): live streaming assistant panel + approval`.
+### Task M3: web streaming proxy + live panel + degradation
+**Files:** Create `apps/web/src/app/api/assistant-stream/route.ts`; Modify `apps/web` (panel)
+
+**Why a dedicated proxy (review fix):** the catch-all `apps/web/src/app/api/proxy/[...path]/route.ts` returns `new Response(await upstream.arrayBuffer())` — it **buffers** the whole body, so SSE can't stream through it. Also, that proxy forwards the path *after* `/api/proxy` straight to `API_BASE`, so the Express route at `/api/ai/assistant/stream` is reachable only at `/api/proxy/api/ai/assistant/stream` (the `api/` segment is required).
+
+- [ ] **Step 1: Streaming proxy route** — `apps/web/src/app/api/assistant-stream/route.ts`: a `POST` handler that attaches the Clerk token + `x-api-key` (same as the catch-all proxy) and **returns the stream unbuffered**:
+
+```ts
+const upstream = await fetch(`${API_BASE}/api/ai/assistant/stream`, {
+  method: 'POST', headers, body: await request.arrayBuffer(), cache: 'no-store',
+});
+return new Response(upstream.body, {            // <-- pass the ReadableStream through; do NOT arrayBuffer()
+  status: upstream.status,
+  headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
+});
+```
+
+- [ ] **Step 2: Panel** — POST to `/api/assistant-stream`, read the `ReadableStream`, render per-node status + the streaming draft, and show Approve/Reject at `awaiting_approval` (resume via the normal buffering proxy at **`/api/proxy/api/ai/assistant/resume`**). When the agent is unavailable (503), fall back to the non-streaming run (`/api/proxy/api/ai/assistant/run`).
+- [ ] **Step 3: Verify** — `npm run check`; manual browser check that tokens render incrementally (not all-at-once). **Commit** — `feat(web): streaming proxy + live assistant panel + approval`.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-17-phase3-langgraph-mcp-streaming-design.md
+++ b/docs/superpowers/specs/2026-06-17-phase3-langgraph-mcp-streaming-design.md
@@ -77,9 +77,17 @@ equally: each piece must read credibly in the portfolio **and** actually work in
   DB. The server holds the API base URL + shared API key; the MCP client supplies the
   **user id** so a session acts as that user.
 - **Auth:** unauthenticated tool calls are refused; the server forwards `X-API-Key`
-  (shared secret) + `X-User-Id` to the API. Configured via `MCP_SERVER_*` env.
-- **Rejected:** a DB-direct server (duplicates store logic, bypasses Phase 2 guards) and a
-  stdio-only server (not usable by the live app remotely; HTTP can still run locally).
+  (= the API's `API_SHARED_SECRET`) + `X-User-Id` to the API. **This requires an API-side
+  change:** today `attachUserId` only trusts Clerk when `CLERK_SECRET_KEY` is set and
+  ignores `X-User-Id` (except `/api/n8n`), so a bridge would 401 at `requireUser` on real
+  reads. Phase 3 adds a **service-auth** path to `apps/api/src/lib/auth.ts` — a valid
+  shared key plus `X-User-Id` sets `request.userId` (the same M2M trust model as n8n; only
+  a holder of the server-side secret can act on behalf of a user). Configured via
+  `MCP_SERVER_*` env.
+- **Rejected:** a DB-direct server (duplicates store logic, bypasses Phase 2 guards); a
+  stdio-only server (not usable by the live app remotely; HTTP can still run locally); and
+  minting per-user Clerk tokens in the bridge (needs Clerk M2M / a live session — heavier
+  than a shared service principal).
 
 ## 6. Workstream M — Streaming (agent → API → web)
 
@@ -90,8 +98,15 @@ equally: each piece must read credibly in the portfolio **and** actually work in
   agent's SSE through unbuffered, Clerk-auth'd, under the Phase 2 rate-limit/budget guards.
 - **Web:** a live assistant panel consuming the stream (fetch `ReadableStream` / SSE),
   rendering step progress + the streaming draft, with the approval control at the interrupt.
+  The existing catch-all `/api/proxy` route **buffers** (`await upstream.arrayBuffer()`) and
+  forwards the path after `/api/proxy` straight to `API_BASE`, so it can neither stream SSE
+  nor reach `/api/ai/...` without the `api/` segment. Phase 3 adds a **dedicated streaming
+  Next route** (`/api/assistant-stream`) that attaches the Clerk token + shared key and
+  returns `upstream.body` unbuffered; non-streaming run/resume calls use the normal proxy at
+  `/api/proxy/api/ai/assistant/*`.
 - **Degradation:** no agent/provider → 503; the UI keeps the existing non-streaming flow.
-- **Rejected:** WebSockets (heavier; SSE suffices and works on App Service).
+- **Rejected:** WebSockets (heavier; SSE suffices and works on App Service); routing SSE
+  through the buffering catch-all proxy (would defeat live streaming).
 
 ## 7. Workstream N — MCP client (`services/agent`)
 
@@ -109,9 +124,12 @@ equally: each piece must read credibly in the portfolio **and** actually work in
   `MCP_SERVER_API_BASE_URL` + `MCP_SERVER_API_KEY` (L); `MCP_CLIENT_SERVERS` (N). Live
   values via App Service config (existing pattern).
 - **Testing:** K — graph routing (strong/weak fit) + interrupt/resume with a fake model
-  (no LLM); L — each MCP tool handler against a mocked REST API + the auth-required path;
-  M — the SSE endpoint emits ordered events from a fake graph + the Express passthrough; N —
-  MCP-client tool loading with a mock adapter + the Tavily fallback. Preserve all existing
+  (no LLM); L — the **API service-auth** path (`attachUserId` resolves the user from a valid
+  shared key + `X-User-Id`, and ignores `X-User-Id` without the key) **and** each MCP tool
+  handler against a mocked REST API — so the bridge is verified against the real auth rule,
+  not just header mocks; M — the SSE endpoint emits ordered events from a fake graph + the
+  Express passthrough; N — MCP-client tool loading with a mock adapter + the Tavily
+  fallback. Preserve all existing
   graceful-degradation tests; `npm run check` + agent `pytest`/`ruff` green.
 - **Docs:** ARCHITECTURE (orchestration + MCP + streaming), README highlight, ROADMAP
   Phase 3, and a `services/mcp/README.md` (how to connect an MCP client).

--- a/docs/superpowers/specs/2026-06-17-phase3-langgraph-mcp-streaming-design.md
+++ b/docs/superpowers/specs/2026-06-17-phase3-langgraph-mcp-streaming-design.md
@@ -1,0 +1,139 @@
+# Design — Phase 3: LangGraph orchestration, MCP, and streaming
+
+**Date:** 2026-06-17
+**Status:** Approved (design accepted; scope: all four workstreams — LangGraph application-assistant, MCP server, streaming, MCP client; balanced portfolio-signal / prod-hardening driver)
+**Part of:** the "Production-grade AI" program (epic #43). Phase 1 (real data + LLMOps) and Phase 2 (safety, guardrails & eval gating) shipped. This spec covers **Phase 3 only**.
+
+## 1. Why
+
+Phase 1 made the AI observable and measured; Phase 2 made it safe. Phase 3 makes it
+**agentic and interoperable** — the advanced-orchestration + interop layer the 2026
+market associates with senior AI engineering: a real **stateful LangGraph workflow** with
+human-in-the-loop, a live **streaming** UX, and **MCP** in both directions (a hosted
+JobOps tool server, and the agent consuming external MCP tools). Both drivers weigh
+equally: each piece must read credibly in the portfolio **and** actually work in the live app.
+
+## 2. Goals / non-goals
+
+**Goals**
+- **K** — A LangGraph **application-assistant**: a stateful graph composing parse → score →
+  (conditional) research → draft-outreach, with conditional edges and a human-in-the-loop
+  interrupt before outreach.
+- **L** — A remote, authenticated **MCP server** exposing JobOps as tools (a bridge over
+  the existing REST API).
+- **M** — End-to-end **streaming** (SSE) of the assistant run to the web UI.
+- **N** — The agent as an **MCP client**: the research step consumes external MCP tools,
+  with graceful fallback to the current Tavily tool.
+
+**Non-goals (deferred to later phases)**
+- Hybrid retrieval / reranker / fine-tuning (Phase 4).
+- IaC / full Dockerization / e2e / caching / load test (Phase 5).
+- Refactoring the existing Phase 8 agents into explicit graphs (the new assistant graph is
+  the LangGraph showcase; `create_agent` is already LangGraph-backed).
+- WebSockets / bidirectional streaming (SSE is sufficient for server→client).
+
+## 3. Success criteria (acceptance)
+1. `POST /assistant/run` executes the graph **parse → score → (if fit ≥ threshold) research →
+   draft-outreach**, returns the accumulated state, and **pauses at a human-in-the-loop
+   interrupt** before outreach; `POST /assistant/resume` continues only on explicit approval.
+   Below-threshold fit short-circuits to a "pass" result without research/outreach.
+2. The graph **reuses the existing guarded chains/agents as nodes**, so Phase 2 guards
+   (PII redaction, injection defense, output moderation) still apply.
+3. A remote **MCP server** exposes `search_jobs`, `get_job`, `score_fit`, `draft_outreach`,
+   and `list_saved_searches`; it requires auth and acts as the supplied user; an MCP client
+   (e.g. MCP Inspector / Claude) can list and call the tools end to end.
+4. The web UI **streams** an assistant run live (per-node status + token deltas) via SSE
+   through an API passthrough, and surfaces the approval control at the interrupt.
+5. The research step **loads tools from a configured external MCP server** and uses them;
+   with none configured it falls back to the Tavily `web_search` tool — no regression.
+6. **Graceful degradation preserved:** no provider key → assistant/stream endpoints 503 and
+   the UI uses the existing non-streaming flow; no MCP client server → Tavily fallback; the
+   MCP server refuses unauthenticated calls. `npm run check` + agent `pytest`/`ruff` stay green.
+
+## 4. Workstream K — LangGraph application-assistant (`services/agent`)
+
+- **Graph (`app/graph/assistant.py`):** a `StateGraph` over an `AssistantState`
+  (`description_text`, `resume_text`, `profile_text`, `user_id`, `parsed`, `fit`,
+  `research`, `draft`, `approved`, `status`). Nodes wrap the **existing** functions:
+  `parse_job` → `score_fit` → `run_research` → `draft_outreach`.
+- **Conditional edges:** after scoring, route on `fit.fit_score ≥ ASSISTANT_FIT_THRESHOLD`
+  (default 60): strong → research → outreach; weak → END with an honest "pass" summary.
+- **Human-in-the-loop:** a LangGraph `interrupt` (with a checkpointer, in-memory for now)
+  **before** the outreach node — the run pauses and returns its proposed plan/draft inputs;
+  `/assistant/resume` (with `approved=true`) continues to draft-outreach, else ends.
+- **Endpoints (`app/main.py`):** `POST /assistant/run` and `POST /assistant/resume`
+  (thread id ties a run to its checkpoint). `_require_llm()` guards both. Nodes call the
+  Phase-2-guarded chains, so PII/injection/moderation are inherited.
+- **Rejected:** refactoring the existing agents into graphs (less new capability); a
+  monolithic chain instead of a graph (loses conditional routing + interrupt).
+
+## 5. Workstream L — MCP server (`services/mcp`, standalone)
+
+- **A remote, streamable-HTTP MCP server** (official MCP Python SDK / FastMCP) in a new
+  `services/mcp/`. Tools: `search_jobs`, `get_job`, `score_fit`, `draft_outreach`,
+  `list_saved_searches`.
+- **Bridge over the REST API:** each tool calls the existing `apps/api` HTTP endpoints
+  (language-agnostic; reuses every store, guard, and rate-limit) rather than touching the
+  DB. The server holds the API base URL + shared API key; the MCP client supplies the
+  **user id** so a session acts as that user.
+- **Auth:** unauthenticated tool calls are refused; the server forwards `X-API-Key`
+  (shared secret) + `X-User-Id` to the API. Configured via `MCP_SERVER_*` env.
+- **Rejected:** a DB-direct server (duplicates store logic, bypasses Phase 2 guards) and a
+  stdio-only server (not usable by the live app remotely; HTTP can still run locally).
+
+## 6. Workstream M — Streaming (agent → API → web)
+
+- **Agent:** `POST /assistant/stream` returns `text/event-stream` (FastAPI
+  `StreamingResponse`) driven by the graph's `.astream_events()` — emits per-node **status**
+  events and **token deltas** for generative steps, then a final `result` event.
+- **API:** an Express passthrough route (`/api/ai/assistant/stream`) that streams the
+  agent's SSE through unbuffered, Clerk-auth'd, under the Phase 2 rate-limit/budget guards.
+- **Web:** a live assistant panel consuming the stream (fetch `ReadableStream` / SSE),
+  rendering step progress + the streaming draft, with the approval control at the interrupt.
+- **Degradation:** no agent/provider → 503; the UI keeps the existing non-streaming flow.
+- **Rejected:** WebSockets (heavier; SSE suffices and works on App Service).
+
+## 7. Workstream N — MCP client (`services/agent`)
+
+- The **research** path loads tools from a configured external MCP server via
+  **`langchain-mcp-adapters`** and hands them to the agent/graph alongside (or instead of)
+  the Tavily tool. Server list is config-driven (`MCP_CLIENT_SERVERS`).
+- **Degradation:** no MCP server configured or reachable → fall back to the current Tavily
+  `web_search` tool; no regression to existing research behavior.
+- **Rejected:** hardcoding a single vendor MCP (brittle); making MCP mandatory (breaks the
+  no-key/offline guarantee).
+
+## 8. Cross-cutting
+
+- **Config/secrets (no real values in `.env.example`):** `ASSISTANT_FIT_THRESHOLD`;
+  `MCP_SERVER_API_BASE_URL` + `MCP_SERVER_API_KEY` (L); `MCP_CLIENT_SERVERS` (N). Live
+  values via App Service config (existing pattern).
+- **Testing:** K — graph routing (strong/weak fit) + interrupt/resume with a fake model
+  (no LLM); L — each MCP tool handler against a mocked REST API + the auth-required path;
+  M — the SSE endpoint emits ordered events from a fake graph + the Express passthrough; N —
+  MCP-client tool loading with a mock adapter + the Tavily fallback. Preserve all existing
+  graceful-degradation tests; `npm run check` + agent `pytest`/`ruff` green.
+- **Docs:** ARCHITECTURE (orchestration + MCP + streaming), README highlight, ROADMAP
+  Phase 3, and a `services/mcp/README.md` (how to connect an MCP client).
+
+## 9. Risks & mitigations
+- **LangGraph interrupt/checkpointer complexity** → in-memory checkpointer + a thread id;
+  confirm the v1 `interrupt`/`Command(resume=...)` API via Context7 before coding.
+- **Streaming on App Service** → SSE (not WebSockets); ensure the Express proxy disables
+  buffering/compression on the stream route.
+- **MCP auth** → the server never exposes the DB; it forwards the shared API key + user id
+  to the already-guarded REST API, and refuses unauthenticated calls.
+- **Shared-file conflicts across K/M/N** → they touch the agent/graph, so build sequentially
+  (K→M→N), each branched off `main` after the prior merges; **L is independent** and
+  parallel-safe. (Lesson from Phase 2's J-branched-off-H mistake.)
+- **Scope** → four sizeable workstreams; each is independently shippable (one PR each) and
+  degrades gracefully, keeping the phase manageable.
+
+## 10. SDLC / delivery
+This spec → an implementation plan (`writing-plans`) → **detailed GitHub issues**: an
+**epic** ("Phase 3 — LangGraph, MCP & streaming") plus four **sub-issues** (K LangGraph,
+L MCP server, M streaming, N MCP client), each with acceptance criteria and task
+checklists, under a **`Phase 3` milestone** with labels. Each sub-issue is delivered on its
+own branch → PR (`Closes #…`) → green CI → **user merges**; K→M→N sequential, L parallel.
+TDD where it fits; `npm run check` + agent `pytest`/`ruff` before every PR. Exact
+third-party SDK APIs confirmed via Context7 at the first task of each workstream.


### PR DESCRIPTION
Planning docs for **Phase 3** of the production-grade AI program (epic #61). No app code — spec + plan only.

## Contents
- **Spec:** `docs/superpowers/specs/2026-06-17-phase3-langgraph-mcp-streaming-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-17-phase3-langgraph-mcp-streaming.md`

## Scope (four workstreams → four sub-issues)
- **K #57** — LangGraph application-assistant: parse→score→conditional research→outreach, conditional edges + a human-in-the-loop interrupt before outreach.
- **L #58** — JobOps MCP server: remote, authenticated FastMCP streamable-HTTP server bridging the existing REST API.
- **M #59** — End-to-end SSE streaming of the assistant run (FastAPI → Express passthrough → live web panel).
- **N #60** — Agent as MCP client: research consumes external MCP tools via langchain-mcp-adapters, Tavily fallback.

## Sequencing
**K → M → N share the agent/graph files → sequential** (each branched off `main` after the prior merges). **L is independent → parallel-safe.** (Applying the Phase 2 branching lesson.)

Graceful degradation preserved throughout (no provider key / no MCP server / unauth'd MCP all degrade cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)