### PR TITLE
feat: Phase 3 · K — LangGraph application-assistant (HITL)

### DIFF
--- a/apps/api/src/lib/agent-client.ts
+++ b/apps/api/src/lib/agent-client.ts
@@ -64,6 +64,38 @@ export async function runAgentTask<T>(path: string, payload: unknown): Promise<T
   return callAgent<T>(path, payload, AGENT_TASK_TIMEOUT_MS);
 }
 
+export interface AssistantRunInput {
+  descriptionText: string;
+  resumeText?: string;
+  profileText?: string;
+  userId?: string;
+}
+
+/** Start an application-assistant run (LangGraph). Net-new — no mock fallback. */
+export async function runAssistant(input: AssistantRunInput): Promise<unknown> {
+  if (!isAgentEnabled()) {
+    throw new AgentDisabledError();
+  }
+  return callAgent(
+    '/assistant/run',
+    {
+      description_text: input.descriptionText,
+      resume_text: input.resumeText,
+      profile_text: input.profileText,
+      user_id: input.userId,
+    },
+    AGENT_TASK_TIMEOUT_MS,
+  );
+}
+
+/** Resume a paused assistant run with the human approval decision. */
+export async function resumeAssistant(threadId: string, approved: boolean): Promise<unknown> {
+  if (!isAgentEnabled()) {
+    throw new AgentDisabledError();
+  }
+  return callAgent('/assistant/resume', { thread_id: threadId, approved }, AGENT_TASK_TIMEOUT_MS);
+}
+
 /** Analyze the activity series via the agent (pandas + LLM narration). */
 export async function analyzeTelemetryViaAgent(series: ActivityPoint[]): Promise<TelemetryInsights> {
   return callAgent<TelemetryInsights>('/telemetry/insights', { series }, AGENT_TASK_TIMEOUT_MS);

--- a/apps/api/src/routes/ai.assistant.test.ts
+++ b/apps/api/src/routes/ai.assistant.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+import express from 'express';
+import { aiRouter } from './ai';
+
+// AGENT_SERVICE_URL is unset in tests, so the agent is "disabled" → assistant routes 503
+// once they pass validation. We assert auth + validation + the disabled-agent path.
+async function withServer(run: (baseUrl: string) => Promise<void>) {
+  const app = express();
+  app.use(express.json());
+  app.use((request, _response, next) => {
+    const header = request.header('X-User-Id');
+    if (header) request.userId = header.trim();
+    next();
+  });
+  app.use('/api/ai', aiRouter);
+
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('Test server did not provide a usable address');
+  }
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+test('POST /api/ai/assistant/run requires a signed-in user', async () => {
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/ai/assistant/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description_text: 'Build agents' }),
+    });
+    assert.equal(res.status, 401);
+  });
+});
+
+test('POST /api/ai/assistant/run requires description_text', async () => {
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/ai/assistant/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-User-Id': 'u1' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 400);
+  });
+});
+
+test('POST /api/ai/assistant/run returns 503 when the agent is not configured', async () => {
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/ai/assistant/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-User-Id': 'u1' },
+      body: JSON.stringify({ description_text: 'Build agents' }),
+    });
+    assert.equal(res.status, 503);
+  });
+});
+
+test('POST /api/ai/assistant/resume requires thread_id', async () => {
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/ai/assistant/resume`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-User-Id': 'u1' },
+      body: JSON.stringify({ approved: true }),
+    });
+    assert.equal(res.status, 400);
+  });
+});

--- a/apps/api/src/routes/ai.assistant.test.ts
+++ b/apps/api/src/routes/ai.assistant.test.ts
@@ -73,3 +73,15 @@ test('POST /api/ai/assistant/resume requires thread_id', async () => {
     assert.equal(res.status, 400);
   });
 });
+
+test('POST /api/ai/assistant/resume rejects a non-boolean approved', async () => {
+  await withServer(async (baseUrl) => {
+    // "false" must NOT be truthiness-coerced to an approval at the human gate.
+    const res = await fetch(`${baseUrl}/api/ai/assistant/resume`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-User-Id': 'u1' },
+      body: JSON.stringify({ thread_id: 't1', approved: 'false' }),
+    });
+    assert.equal(res.status, 400);
+  });
+});

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -353,13 +353,18 @@ aiRouter.post('/assistant/resume', async (request, response, next) => {
   const userId = requireUser(request, response);
   if (!userId) return;
 
-  const body = request.body as { thread_id?: string; approved?: boolean };
+  const body = request.body as { thread_id?: string; approved?: unknown };
   if (!body.thread_id?.trim()) {
     return response.status(400).json({ error: 'thread_id is required' });
   }
+  // This is the human-approval gate — require a real boolean, never truthiness-coerce
+  // (e.g. the string "false" must not approve outreach).
+  if (typeof body.approved !== 'boolean') {
+    return response.status(400).json({ error: 'approved must be a boolean' });
+  }
 
   try {
-    const result = await resumeAssistant(body.thread_id, Boolean(body.approved));
+    const result = await resumeAssistant(body.thread_id, body.approved);
     return response.json(result);
   } catch (error) {
     if (error instanceof AgentDisabledError) {

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -11,7 +11,9 @@ import {
   resolveFitScore,
   resolveOutreachDraft,
   resolveParsedJob,
+  resumeAssistant,
   runAgentTask,
+  runAssistant,
 } from '@/lib/agent-client';
 import { isSingleRecipientEmailAddress } from '@/lib/email';
 import { createGmailDraftIfEnabled } from '@/lib/gmail';
@@ -313,6 +315,51 @@ aiRouter.post('/agents/skill-gap', async (request, response, next) => {
       resume_text: body.resume_text ?? profile?.resumeText,
     });
 
+    return response.json(result);
+  } catch (error) {
+    if (error instanceof AgentDisabledError) {
+      return response.status(503).json({ error: AGENT_DISABLED_MESSAGE });
+    }
+    next(error);
+  }
+});
+
+aiRouter.post('/assistant/run', async (request, response, next) => {
+  const userId = requireUser(request, response);
+  if (!userId) return;
+
+  const body = request.body as { description_text?: string; resume_text?: string; profile_text?: string };
+  if (!body.description_text?.trim()) {
+    return response.status(400).json({ error: 'description_text is required' });
+  }
+
+  try {
+    const result = await runAssistant({
+      descriptionText: body.description_text,
+      resumeText: body.resume_text,
+      profileText: body.profile_text,
+      userId,
+    });
+    return response.json(result);
+  } catch (error) {
+    if (error instanceof AgentDisabledError) {
+      return response.status(503).json({ error: AGENT_DISABLED_MESSAGE });
+    }
+    next(error);
+  }
+});
+
+aiRouter.post('/assistant/resume', async (request, response, next) => {
+  const userId = requireUser(request, response);
+  if (!userId) return;
+
+  const body = request.body as { thread_id?: string; approved?: boolean };
+  if (!body.thread_id?.trim()) {
+    return response.status(400).json({ error: 'thread_id is required' });
+  }
+
+  try {
+    const result = await resumeAssistant(body.thread_id, Boolean(body.approved));
     return response.json(result);
   } catch (error) {
     if (error instanceof AgentDisabledError) {

--- a/services/agent/app/config.py
+++ b/services/agent/app/config.py
@@ -59,5 +59,9 @@ class Settings(BaseSettings):
     moderation_enabled: bool = True
     moderation_openai_api_key: str | None = None
 
+    # LangGraph application-assistant (Phase 3 · Workstream K). Strong-fit threshold:
+    # at/above it the assistant researches + drafts outreach; below it stops with a "pass".
+    assistant_fit_threshold: int = 60
+
 
 settings = Settings()

--- a/services/agent/app/graph/__init__.py
+++ b/services/agent/app/graph/__init__.py
@@ -1,0 +1,1 @@
+"""LangGraph orchestration for the agent (Phase 3 · Workstream K)."""

--- a/services/agent/app/graph/assistant.py
+++ b/services/agent/app/graph/assistant.py
@@ -1,0 +1,113 @@
+"""Application-assistant graph (Phase 3 · Workstream K).
+
+A stateful LangGraph workflow that composes the existing **guarded** chains/agents as
+nodes: parse-job → score-fit → (conditional, on fit) research → human-in-the-loop review →
+draft-outreach. Weak fit short-circuits to a "pass". Because the nodes call the existing
+chains, all Phase 2 guards (PII redaction, injection defense, output moderation) are
+inherited. The graph is checkpointed so a run can pause at the review interrupt and resume.
+"""
+
+from __future__ import annotations
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command, interrupt
+
+from app.agents.runner import run_research
+from app.chains.draft_outreach import draft_outreach
+from app.chains.parse_job import parse_job
+from app.chains.score_fit import score_fit
+from app.config import settings
+from app.graph.state import AssistantState
+from app.schemas import DraftOutreachRequest, ResearchRequest, ScoreFitRequest
+
+__all__ = ["build_assistant_graph", "route_after_score", "Command"]
+
+
+def route_after_score(state: dict, threshold: int | None = None) -> str:
+    """Strong fit → research; weak fit → end (a "pass")."""
+    threshold = settings.assistant_fit_threshold if threshold is None else threshold
+    fit = state.get("fit") or {}
+    return "research" if int(fit.get("fit_score", 0)) >= threshold else "end"
+
+
+def route_after_review(state: dict) -> str:
+    return "draft" if state.get("approved") else "end"
+
+
+def parse_node(state: AssistantState) -> dict:
+    parsed = parse_job(state["description_text"])
+    return {"parsed": parsed.model_dump(), "status": "parsed"}
+
+
+def score_node(state: AssistantState) -> dict:
+    req = ScoreFitRequest(
+        description_text=state["description_text"],
+        resume_text=state.get("resume_text", ""),
+        profile_text=state.get("profile_text", ""),
+        user_id=state.get("user_id"),
+    )
+    fit = score_fit(req)
+    return {"fit": fit.model_dump(), "status": "scored"}
+
+
+def research_node(state: AssistantState) -> dict:
+    parsed = state.get("parsed") or {}
+    brief = run_research(
+        ResearchRequest(
+            company=parsed.get("company") or "the company",
+            role=parsed.get("title"),
+            context=state["description_text"],
+        )
+    )
+    return {"research": brief.model_dump(), "status": "researched"}
+
+
+def review_node(state: AssistantState) -> dict:
+    """Human-in-the-loop: pause for explicit approval before drafting outreach."""
+    decision = interrupt(
+        {"reason": "approve_outreach", "fit": state.get("fit"), "research": state.get("research")}
+    )
+    approved = decision.get("approved") if isinstance(decision, dict) else bool(decision)
+    return {"approved": bool(approved), "status": "reviewed"}
+
+
+def draft_node(state: AssistantState) -> dict:
+    parsed = state.get("parsed") or {}
+    req = DraftOutreachRequest(
+        message_type="recruiter_email",
+        company=parsed.get("company"),
+        job_context=state["description_text"],
+        resume_summary=state.get("resume_text") or state.get("profile_text"),
+    )
+    draft = draft_outreach(req)
+    return {"draft": draft.model_dump(), "status": "drafted"}
+
+
+def pass_node(state: AssistantState) -> dict:
+    """Weak fit: stop honestly without research/outreach."""
+    return {"status": "passed"}
+
+
+def build_assistant_graph(checkpointer=None):
+    builder = StateGraph(AssistantState)
+    builder.add_node("parse", parse_node)
+    builder.add_node("score", score_node)
+    builder.add_node("research", research_node)
+    builder.add_node("review", review_node)
+    builder.add_node("draft", draft_node)
+    builder.add_node("pass", pass_node)
+
+    builder.add_edge(START, "parse")
+    builder.add_edge("parse", "score")
+    builder.add_conditional_edges(
+        "score", route_after_score, {"research": "research", "end": "pass"}
+    )
+    builder.add_edge("research", "review")
+    builder.add_conditional_edges(
+        "review", route_after_review, {"draft": "draft", "end": END}
+    )
+    builder.add_edge("draft", END)
+    builder.add_edge("pass", END)
+
+    return builder.compile(checkpointer=checkpointer or InMemorySaver())

--- a/services/agent/app/graph/state.py
+++ b/services/agent/app/graph/state.py
@@ -1,0 +1,20 @@
+"""Shared state for the application-assistant graph (Phase 3 · Workstream K)."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class AssistantState(TypedDict, total=False):
+    # Inputs
+    description_text: str
+    resume_text: str
+    profile_text: str
+    user_id: str | None
+    # Accumulated by the nodes
+    parsed: dict
+    fit: dict
+    research: dict
+    draft: dict
+    approved: bool
+    status: str

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import logging
 import os
+import uuid
 
 from fastapi import FastAPI, HTTPException
+from langgraph.types import Command
 from pydantic import BaseModel, Field
 
 from app.agents.runner import run_interview_prep, run_research, run_skill_gap
@@ -19,6 +21,7 @@ from app.chains.parse_job import parse_job
 from app.chains.score_fit import score_fit
 from app.chains.weekly import weekly_recommendations
 from app.config import settings
+from app.graph.assistant import build_assistant_graph
 from app.llm.provider import LLMNotConfigured, llm_available, resolve_provider
 from app.obs import traced_config, traced_span
 from app.rag.store import ingest_document, rag_available, retrieve, retrieve_resume_evidence
@@ -200,6 +203,73 @@ def research_endpoint(req: ResearchRequest) -> ResearchBrief:
 def skill_gap_endpoint(req: SkillGapRequest) -> SkillGapPlan:
     _require_llm()
     return _run(run_skill_gap, req, traced_config("agent-skill-gap"))
+
+
+# --- Phase 3 application-assistant (LangGraph) ------------------------------
+
+
+class AssistantRunRequest(BaseModel):
+    description_text: str
+    resume_text: str = ""
+    profile_text: str = ""
+    user_id: str | None = None
+
+
+class AssistantResumeRequest(BaseModel):
+    thread_id: str
+    approved: bool
+
+
+_assistant_graph = None
+
+
+def _get_assistant_graph():
+    """Lazily build the checkpointed assistant graph (module-level singleton)."""
+    global _assistant_graph
+    if _assistant_graph is None:
+        _assistant_graph = build_assistant_graph()
+    return _assistant_graph
+
+
+def _assistant_response(thread_id: str, state: dict) -> dict:
+    """Shape the graph state for the API. `__interrupt__` means it paused for approval."""
+    awaiting = "__interrupt__" in state
+    return {
+        "thread_id": thread_id,
+        "status": "awaiting_approval" if awaiting else state.get("status"),
+        "parsed": state.get("parsed"),
+        "fit": state.get("fit"),
+        "research": state.get("research"),
+        "draft": state.get("draft"),
+    }
+
+
+@app.post("/assistant/run")
+def assistant_run_endpoint(req: AssistantRunRequest) -> dict:
+    _require_llm()
+    graph = _get_assistant_graph()
+    thread_id = str(uuid.uuid4())
+    config = {"configurable": {"thread_id": thread_id}}
+    state = _run(
+        graph.invoke,
+        {
+            "description_text": req.description_text,
+            "resume_text": req.resume_text,
+            "profile_text": req.profile_text,
+            "user_id": req.user_id,
+        },
+        config,
+    )
+    return _assistant_response(thread_id, state)
+
+
+@app.post("/assistant/resume")
+def assistant_resume_endpoint(req: AssistantResumeRequest) -> dict:
+    _require_llm()
+    graph = _get_assistant_graph()
+    config = {"configurable": {"thread_id": req.thread_id}}
+    state = _run(graph.invoke, Command(resume={"approved": req.approved}), config)
+    return _assistant_response(req.thread_id, state)
 
 
 # --- Phase 11 telemetry -----------------------------------------------------

--- a/services/agent/requirements.txt
+++ b/services/agent/requirements.txt
@@ -13,6 +13,9 @@ langchain-anthropic>=1.0,<2
 langchain-openai>=1.0,<2
 langchain-google-genai>=3.0,<4
 
+# LangGraph application-assistant orchestration (Phase 3 · Workstream K).
+langgraph>=1.0,<2
+
 # HTTP client for agent tools (web search)
 httpx>=0.27,<1
 

--- a/services/agent/tests/test_assistant_graph.py
+++ b/services/agent/tests/test_assistant_graph.py
@@ -1,0 +1,73 @@
+"""Phase 3 · K — application-assistant graph (routing, nodes, HITL interrupt). No LLM."""
+
+from langgraph.types import Command
+
+from app.graph import assistant as A
+from app.schemas import FitScoreResponse, OutreachDraftResponse, ParsedJob, ResearchBrief
+
+# --- K1: routing ------------------------------------------------------------
+
+
+def test_strong_fit_routes_to_research():
+    assert A.route_after_score({"fit": {"fit_score": 80}}, threshold=60) == "research"
+
+
+def test_weak_fit_ends():
+    assert A.route_after_score({"fit": {"fit_score": 30}}, threshold=60) == "end"
+
+
+def test_route_after_review():
+    assert A.route_after_review({"approved": True}) == "draft"
+    assert A.route_after_review({"approved": False}) == "end"
+
+
+# --- K2/K3: nodes + interrupt/resume (fake model) ---------------------------
+
+
+def _patch_nodes(monkeypatch, fit_score: int):
+    parsed = ParsedJob(title="Eng", company="Acme")
+    fit = FitScoreResponse(fit_score=fit_score, model_used="fake")
+    brief = ResearchBrief(company_summary="ok")
+    draft = OutreachDraftResponse(draft_text="hi there", model_used="fake")
+    monkeypatch.setattr(A, "parse_job", lambda text, config=None: parsed)
+    monkeypatch.setattr(A, "score_fit", lambda req, config=None: fit)
+    monkeypatch.setattr(A, "run_research", lambda req, config=None: brief)
+    monkeypatch.setattr(A, "draft_outreach", lambda req, config=None: draft)
+
+
+def _inputs() -> dict:
+    return {"description_text": "Build agents", "resume_text": "me", "profile_text": ""}
+
+
+def test_strong_fit_pauses_then_drafts_on_approval(monkeypatch):
+    _patch_nodes(monkeypatch, fit_score=80)
+    graph = A.build_assistant_graph()
+    cfg = {"configurable": {"thread_id": "t-strong"}}
+
+    paused = graph.invoke(_inputs(), cfg)
+    assert "__interrupt__" in paused  # paused at the review interrupt
+    assert paused.get("draft") is None
+    assert paused["research"]["company_summary"] == "ok"
+
+    final = graph.invoke(Command(resume={"approved": True}), cfg)
+    assert final["draft"]["draft_text"] == "hi there"
+    assert final["status"] == "drafted"
+
+
+def test_strong_fit_rejected_produces_no_draft(monkeypatch):
+    _patch_nodes(monkeypatch, fit_score=80)
+    graph = A.build_assistant_graph()
+    cfg = {"configurable": {"thread_id": "t-reject"}}
+
+    graph.invoke(_inputs(), cfg)
+    final = graph.invoke(Command(resume={"approved": False}), cfg)
+    assert final.get("draft") is None
+
+
+def test_weak_fit_passes_without_research_or_draft(monkeypatch):
+    _patch_nodes(monkeypatch, fit_score=20)
+    graph = A.build_assistant_graph()
+    result = graph.invoke(_inputs(), {"configurable": {"thread_id": "t-weak"}})
+    assert result["status"] == "passed"
+    assert result.get("research") is None and result.get("draft") is None
+    assert "__interrupt__" not in result

--- a/services/agent/tests/test_endpoints.py
+++ b/services/agent/tests/test_endpoints.py
@@ -103,6 +103,42 @@ def test_rag_ingest_returns_503_when_disabled(monkeypatch):
     assert res.status_code == 503
 
 
+def test_assistant_run_returns_503_without_provider(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: False)
+    res = client.post("/assistant/run", json={"description_text": "Build AI agents."})
+    assert res.status_code == 503
+
+
+def test_assistant_run_pauses_for_approval(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+
+    class _FakeGraph:
+        def invoke(self, payload, config=None):
+            return {"__interrupt__": [object()], "fit": {"fit_score": 80},
+                    "research": {"company_summary": "ok"}}
+
+    monkeypatch.setattr(main, "_get_assistant_graph", lambda: _FakeGraph())
+    res = client.post("/assistant/run", json={"description_text": "d", "resume_text": "r"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "awaiting_approval"
+    assert data["thread_id"]
+    assert data["fit"]["fit_score"] == 80
+
+
+def test_assistant_resume_returns_draft(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+
+    class _FakeGraph:
+        def invoke(self, payload, config=None):
+            return {"status": "drafted", "draft": {"draft_text": "hi there"}}
+
+    monkeypatch.setattr(main, "_get_assistant_graph", lambda: _FakeGraph())
+    res = client.post("/assistant/resume", json={"thread_id": "t1", "approved": True})
+    assert res.status_code == 200
+    assert res.json()["draft"]["draft_text"] == "hi there"
+
+
 def test_score_fit_skips_rag_when_disabled(monkeypatch):
     monkeypatch.setattr(main, "llm_available", lambda: True)
     monkeypatch.setattr(main, "rag_available", lambda: False)


### PR DESCRIPTION
Closes #57. Part of Phase 3 epic #61 — the anchor workstream.

A stateful **LangGraph** application-assistant that composes the existing **guarded** chains/agents as nodes.

## What
- **Graph** (`services/agent/app/graph/`): `parse → score → (conditional on fit ≥ `ASSISTANT_FIT_THRESHOLD`) research → human-in-the-loop review interrupt → draft-outreach`. Weak fit short-circuits to a "pass". Checkpointed (`InMemorySaver`) so a run pauses at the interrupt and resumes via `Command(resume={"approved": ...})`.
- Nodes call the existing `parse_job`/`score_fit`/`run_research`/`draft_outreach`, so **all Phase 2 guards** (PII/injection/moderation) are inherited.
- **Agent endpoints**: `POST /assistant/run` (returns state; `status: "awaiting_approval"` when paused) + `POST /assistant/resume`. 503 without a provider.
- **API**: `agent-client` `runAssistant`/`resumeAssistant` + `/api/ai/assistant/run|resume` routes (Clerk-auth'd, under the Phase 2 strict limiter + daily budget; `AgentDisabledError` → 503).
- Pins `langgraph` as a direct runtime dep.

## Scope note
The **live web UI is intentionally deferred to M (#59)** — the streaming assistant panel is built there (one UI, streaming, rather than a throwaway non-streaming one here). K delivers the full backend assistant contract.

## Tests / checks
- `test_assistant_graph.py` — routing (strong/weak), nodes, and **interrupt/resume** with a fake model (no LLM). `test_endpoints.py` — run/resume (503 + fake graph). `ai.assistant.test.ts` — auth/validation/disabled-agent 503.
- Full agent suite **105 passing**, API suite **62 passing**, `ruff` + `npm run check` clean.
- The Evals workflow runs on this PR and **skips cleanly** (no key on PRs).

## Sequencing
Per the plan, **M (#59) and N (#60) build on this and share the agent/graph files → sequential**; **L (#58) is independent and can go in parallel**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)