### PR TITLE
feat: Phase 3 · M — end-to-end SSE streaming of the assistant run

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,6 +5,7 @@ import { attachUserId, clerkAuth } from '@/lib/auth';
 import { globalLimiter, strictLimiter } from '@/lib/rate-limit';
 import { enforceDailyBudget } from '@/lib/budget';
 import { aiRouter } from '@/routes/ai';
+import { assistantStreamRouter } from '@/routes/assistant';
 import { demoRouter } from '@/routes/demo';
 import { healthRouter } from '@/routes/health';
 import { jobsRouter } from '@/routes/jobs';
@@ -69,6 +70,9 @@ export function createApp() {
 
   app.use('/api', healthRouter);
   app.use('/api/jobs', jobsRouter);
+  // SSE assistant stream: mounted at the exact path (before the AI router) so it pipes
+  // unbuffered and doesn't double-apply the AI guards to /assistant/run|resume.
+  app.use('/api/ai/assistant/stream', strictLimiter, enforceDailyBudget, assistantStreamRouter);
   // Stricter per-user limit on the expensive AI + discovery routes; the AI routes
   // additionally enforce the per-user daily spend ceiling (discovery has no LLM cost).
   app.use('/api/ai', strictLimiter, enforceDailyBudget, aiRouter);

--- a/apps/api/src/lib/agent-client.ts
+++ b/apps/api/src/lib/agent-client.ts
@@ -96,6 +96,19 @@ export async function resumeAssistant(threadId: string, approved: boolean): Prom
   return callAgent('/assistant/resume', { thread_id: threadId, approved }, AGENT_TASK_TIMEOUT_MS);
 }
 
+/** Open the agent's SSE assistant stream; returns the raw upstream Response to pipe. */
+export async function streamAssistantUpstream(payload: unknown): Promise<Response> {
+  if (!isAgentEnabled()) {
+    throw new AgentDisabledError();
+  }
+  return fetch(`${AGENT_URL}/assistant/stream`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(AGENT_TASK_TIMEOUT_MS),
+  });
+}
+
 /** Analyze the activity series via the agent (pandas + LLM narration). */
 export async function analyzeTelemetryViaAgent(series: ActivityPoint[]): Promise<TelemetryInsights> {
   return callAgent<TelemetryInsights>('/telemetry/insights', { series }, AGENT_TASK_TIMEOUT_MS);

--- a/apps/api/src/routes/assistant.test.ts
+++ b/apps/api/src/routes/assistant.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+import express from 'express';
+import { createAssistantStreamRouter } from './assistant';
+
+function sseStream(frames: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const frame of frames) controller.enqueue(encoder.encode(frame));
+      controller.close();
+    },
+  });
+}
+
+async function withServer(
+  router: ReturnType<typeof createAssistantStreamRouter>,
+  run: (baseUrl: string) => Promise<void>,
+) {
+  const app = express();
+  app.use(express.json());
+  app.use((request, _response, next) => {
+    const header = request.header('X-User-Id');
+    if (header) request.userId = header.trim();
+    next();
+  });
+  app.use('/stream', router);
+
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('Test server did not provide a usable address');
+  }
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+test('pipes upstream SSE frames through unbuffered', async () => {
+  const router = createAssistantStreamRouter({
+    openUpstream: async () => ({
+      ok: true,
+      status: 200,
+      body: sseStream([
+        'event: status\ndata: {"node": "parse"}\n\n',
+        'event: awaiting_approval\ndata: {"thread_id": "t1"}\n\n',
+      ]),
+    }),
+  });
+  await withServer(router, async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-User-Id': 'u1' },
+      body: JSON.stringify({ description_text: 'Build agents' }),
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('content-type'), 'text/event-stream');
+    const text = await res.text();
+    assert.ok(text.includes('event: status') && text.includes('"node": "parse"'));
+    assert.ok(text.includes('event: awaiting_approval'));
+  });
+});
+
+test('requires a signed-in user', async () => {
+  const router = createAssistantStreamRouter({
+    openUpstream: async () => ({ ok: true, status: 200, body: sseStream([]) }),
+  });
+  await withServer(router, async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description_text: 'd' }),
+    });
+    assert.equal(res.status, 401);
+  });
+});
+
+test('requires description_text', async () => {
+  const router = createAssistantStreamRouter({
+    openUpstream: async () => ({ ok: true, status: 200, body: sseStream([]) }),
+  });
+  await withServer(router, async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-User-Id': 'u1' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 400);
+  });
+});

--- a/apps/api/src/routes/assistant.ts
+++ b/apps/api/src/routes/assistant.ts
@@ -1,0 +1,79 @@
+import { Router } from 'express';
+import { requireUser } from '@/lib/auth';
+import { streamAssistantUpstream } from '@/lib/agent-client';
+
+/** The upstream shape we need to pipe — satisfied by a fetch `Response`. */
+export interface UpstreamStream {
+  ok: boolean;
+  status: number;
+  body: ReadableStream<Uint8Array> | null;
+}
+
+export interface AssistantStreamDeps {
+  openUpstream: (payload: unknown) => Promise<UpstreamStream>;
+}
+
+/**
+ * SSE passthrough for the application-assistant run (Phase 3 · Workstream M).
+ *
+ * Pipes the agent's `text/event-stream` straight through, unbuffered, so the browser
+ * receives node-status events live. Mounted at the exact `/api/ai/assistant/stream` path
+ * (before the AI router) so it doesn't double-apply the AI guards to run/resume.
+ */
+export function createAssistantStreamRouter(
+  deps: AssistantStreamDeps = { openUpstream: streamAssistantUpstream },
+) {
+  const router = Router();
+
+  router.post('/', async (request, response, next) => {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
+    const body = request.body as { description_text?: string; resume_text?: string; profile_text?: string };
+    if (!body.description_text?.trim()) {
+      response.status(400).json({ error: 'description_text is required' });
+      return;
+    }
+
+    let upstream: UpstreamStream;
+    try {
+      upstream = await deps.openUpstream({
+        description_text: body.description_text,
+        resume_text: body.resume_text,
+        profile_text: body.profile_text,
+        user_id: userId,
+      });
+    } catch (error) {
+      next(error);
+      return;
+    }
+
+    if (!upstream.ok || !upstream.body) {
+      response.status(upstream.status || 502).json({ error: 'Assistant stream unavailable' });
+      return;
+    }
+
+    response.status(200);
+    response.setHeader('Content-Type', 'text/event-stream');
+    response.setHeader('Cache-Control', 'no-cache, no-transform');
+    response.setHeader('Connection', 'keep-alive');
+    response.setHeader('X-Accel-Buffering', 'no'); // disable proxy buffering
+
+    const reader = upstream.body.getReader();
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        response.write(Buffer.from(value));
+      }
+    } catch {
+      // client disconnected or upstream errored mid-stream; just end the response
+    } finally {
+      response.end();
+    }
+  });
+
+  return router;
+}
+
+export const assistantStreamRouter = createAssistantStreamRouter();

--- a/apps/web/src/app/(app)/assistant/page.tsx
+++ b/apps/web/src/app/(app)/assistant/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import { AssistantPanel } from '@/components/assistant-panel';
+import { SectionCard } from '@/components/section-card';
+
+export const metadata: Metadata = { title: 'Assistant' };
+
+export default function AssistantPage() {
+  return (
+    <div className="mx-auto w-full max-w-4xl space-y-6">
+      <div className="space-y-1">
+        <h1 className="font-heading text-2xl font-semibold">Application assistant</h1>
+        <p className="text-muted-foreground text-sm">
+          A guided run — parse the role, score your fit, research the company, then draft outreach
+          only after you approve. Each step streams live; nothing is sent automatically.
+        </p>
+      </div>
+      <SectionCard
+        title="Run the assistant"
+        description="Paste a job description (and optionally your resume) to start a streamed, human-in-the-loop run."
+      >
+        <AssistantPanel />
+      </SectionCard>
+    </div>
+  );
+}

--- a/apps/web/src/app/api/assistant-stream/route.ts
+++ b/apps/web/src/app/api/assistant-stream/route.ts
@@ -1,0 +1,42 @@
+import { auth } from '@clerk/nextjs/server';
+import type { NextRequest } from 'next/server';
+
+/**
+ * Streaming proxy to the Express assistant SSE route (Phase 3 · Workstream M).
+ *
+ * The catch-all `/api/proxy` route buffers (`await upstream.arrayBuffer()`) and cannot
+ * stream SSE, so the assistant stream gets its own route that attaches the Clerk token +
+ * shared secret server-side and returns the upstream `ReadableStream` **unbuffered**.
+ */
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const API_BASE = (process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://127.0.0.1:4000').replace(/\/$/, '');
+const SHARED_SECRET = process.env.API_SHARED_SECRET?.trim();
+
+export async function POST(request: NextRequest) {
+  const headers = new Headers();
+  headers.set('content-type', 'application/json');
+
+  const { getToken } = await auth();
+  const token = await getToken();
+  if (token) headers.set('authorization', `Bearer ${token}`);
+  if (SHARED_SECRET) headers.set('x-api-key', SHARED_SECRET);
+
+  const upstream = await fetch(`${API_BASE}/api/ai/assistant/stream`, {
+    method: 'POST',
+    headers,
+    body: await request.arrayBuffer(),
+    cache: 'no-store',
+  });
+
+  // Pass the stream through untouched (do NOT buffer with arrayBuffer()).
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      'content-type': upstream.headers.get('content-type') ?? 'text/event-stream',
+      'cache-control': 'no-cache, no-transform',
+    },
+  });
+}

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -24,6 +24,7 @@ import {
 
 const items = [
   { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
+  { href: '/assistant', label: 'Assistant', icon: Sparkles },
   { href: '/jobs', label: 'Jobs', icon: Briefcase },
   { href: '/outreach', label: 'Outreach', icon: Send },
   { href: '/reports', label: 'Reports', icon: FileBarChart },

--- a/apps/web/src/components/assistant-panel.tsx
+++ b/apps/web/src/components/assistant-panel.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Loader2, Sparkles, X } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+
+interface Step {
+  node: string;
+  status?: string | null;
+}
+
+interface AssistantResult {
+  thread_id?: string;
+  draft?: { draft_text?: string } | null;
+}
+
+const NODE_LABELS: Record<string, string> = {
+  parse: 'Parsing the job description',
+  score: 'Scoring fit against your resume',
+  research: 'Researching the company',
+  review: 'Awaiting your approval',
+  draft: 'Drafting outreach',
+  pass: 'Below the fit bar — stopping',
+};
+
+export function AssistantPanel() {
+  const [description, setDescription] = useState('');
+  const [resume, setResume] = useState('');
+  const [steps, setSteps] = useState<Step[]>([]);
+  const [threadId, setThreadId] = useState<string | null>(null);
+  const [awaiting, setAwaiting] = useState(false);
+  const [draft, setDraft] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+
+  function handleFrame(frame: string) {
+    const lines = frame.split('\n');
+    const event = lines.find((l) => l.startsWith('event:'))?.slice(6).trim();
+    const dataLine = lines.find((l) => l.startsWith('data:'))?.slice(5).trim();
+    if (!event || !dataLine) return;
+    let data: Record<string, unknown> = {};
+    try {
+      data = JSON.parse(dataLine);
+    } catch {
+      return;
+    }
+    if (event === 'status') {
+      setSteps((prev) => [...prev, { node: String(data.node), status: data.status as string }]);
+    } else if (event === 'awaiting_approval') {
+      setThreadId((data.thread_id as string) ?? null);
+      setAwaiting(true);
+    } else if (event === 'result') {
+      const result = data as AssistantResult;
+      if (result.draft?.draft_text) setDraft(result.draft.draft_text);
+    } else if (event === 'error') {
+      toast.error((data.message as string) ?? 'Assistant stream error');
+    }
+  }
+
+  async function run() {
+    if (!description.trim()) {
+      toast.error('Paste a job description first.');
+      return;
+    }
+    setSteps([]);
+    setDraft(null);
+    setThreadId(null);
+    setAwaiting(false);
+    setRunning(true);
+    try {
+      const res = await fetch('/api/assistant-stream', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description_text: description, resume_text: resume }),
+      });
+      if (res.status === 503) {
+        toast.error('The AI agent service is not available right now.');
+        return;
+      }
+      if (!res.ok || !res.body) {
+        toast.error('Assistant run failed.');
+        return;
+      }
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const frames = buffer.split('\n\n');
+        buffer = frames.pop() ?? '';
+        for (const frame of frames) handleFrame(frame);
+      }
+    } catch {
+      toast.error('Assistant run failed.');
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  async function decide(approved: boolean) {
+    if (!threadId) return;
+    setAwaiting(false);
+    try {
+      const res = await fetch('/api/proxy/api/ai/assistant/resume', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ thread_id: threadId, approved }),
+      });
+      const data = (await res.json()) as AssistantResult;
+      if (data?.draft?.draft_text) setDraft(data.draft.draft_text);
+      else if (!approved) toast.info('Outreach skipped — nothing drafted.');
+    } catch {
+      toast.error('Could not submit your decision.');
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <textarea
+          className="border-input bg-background min-h-32 rounded-lg border p-3 text-sm"
+          placeholder="Paste a job description…"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <textarea
+          className="border-input bg-background min-h-32 rounded-lg border p-3 text-sm"
+          placeholder="Paste your resume (optional)…"
+          value={resume}
+          onChange={(e) => setResume(e.target.value)}
+        />
+      </div>
+
+      <Button onClick={run} disabled={running}>
+        {running ? <Loader2 className="size-4 animate-spin" /> : <Sparkles className="size-4" />}
+        Run assistant
+      </Button>
+
+      {steps.length > 0 && (
+        <ol className="space-y-1 text-sm">
+          {steps.map((step, i) => (
+            <li key={i} className="text-muted-foreground flex items-center gap-2">
+              <Check className="size-3.5 text-emerald-500" />
+              {NODE_LABELS[step.node] ?? step.node}
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {awaiting && (
+        <div className="bg-muted/40 flex items-center gap-3 rounded-lg border p-3">
+          <p className="mr-auto text-sm font-medium">Approve drafting outreach for this role?</p>
+          <Button size="sm" onClick={() => decide(true)}>
+            <Check className="size-4" /> Approve
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => decide(false)}>
+            <X className="size-4" /> Skip
+          </Button>
+        </div>
+      )}
+
+      {draft && (
+        <div className="rounded-lg border p-3">
+          <p className="mb-1 text-xs font-medium tracking-wide uppercase">Drafted outreach (review before sending)</p>
+          <p className="text-sm whitespace-pre-wrap">{draft}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -7,11 +7,13 @@ Node API can transparently fall back to its deterministic mock.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import uuid
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
 from langgraph.types import Command
 from pydantic import BaseModel, Field
 
@@ -270,6 +272,50 @@ def assistant_resume_endpoint(req: AssistantResumeRequest) -> dict:
     config = {"configurable": {"thread_id": req.thread_id}}
     state = _run(graph.invoke, Command(resume={"approved": req.approved}), config)
     return _assistant_response(req.thread_id, state)
+
+
+def _sse(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+async def _assistant_event_stream(payload: dict, config: dict):
+    """Stream the assistant run as SSE: one `status` event per node, an
+    `awaiting_approval` event at the HITL interrupt, else a final `result`."""
+    graph = _get_assistant_graph()
+    thread_id = config["configurable"]["thread_id"]
+    awaiting = False
+    try:
+        async for update in graph.astream(payload, config, stream_mode="updates"):
+            for node, delta in update.items():
+                if node == "__interrupt__":
+                    awaiting = True
+                    snapshot = _assistant_response(thread_id, graph.get_state(config).values)
+                    snapshot["status"] = "awaiting_approval"
+                    yield _sse("awaiting_approval", snapshot)
+                else:
+                    status = delta.get("status") if isinstance(delta, dict) else None
+                    yield _sse("status", {"node": node, "status": status})
+        if not awaiting:
+            yield _sse("result", _assistant_response(thread_id, graph.get_state(config).values))
+    except Exception as exc:  # noqa: BLE001 - surface streaming failures as an SSE error
+        logger.exception("assistant stream failed")
+        yield _sse("error", {"message": str(exc)})
+
+
+@app.post("/assistant/stream")
+async def assistant_stream_endpoint(req: AssistantRunRequest) -> StreamingResponse:
+    _require_llm()
+    thread_id = str(uuid.uuid4())
+    config = {"configurable": {"thread_id": thread_id}}
+    payload = {
+        "description_text": req.description_text,
+        "resume_text": req.resume_text,
+        "profile_text": req.profile_text,
+        "user_id": req.user_id,
+    }
+    return StreamingResponse(
+        _assistant_event_stream(payload, config), media_type="text/event-stream"
+    )
 
 
 # --- Phase 11 telemetry -----------------------------------------------------

--- a/services/agent/tests/test_assistant_stream.py
+++ b/services/agent/tests/test_assistant_stream.py
@@ -1,0 +1,58 @@
+"""Phase 3 · M — SSE streaming of the assistant run (no LLM; fake graph)."""
+
+from fastapi.testclient import TestClient
+
+import app.main as main
+
+client = TestClient(main.app)
+
+
+class _FakeState:
+    def __init__(self, values):
+        self.values = values
+
+
+class _FakeGraph:
+    def __init__(self, with_interrupt: bool):
+        self._with_interrupt = with_interrupt
+
+    async def astream(self, payload, config, stream_mode=None):
+        yield {"parse": {"status": "parsed"}}
+        yield {"score": {"status": "scored"}}
+        if self._with_interrupt:
+            yield {"research": {"status": "researched"}}
+            yield {"__interrupt__": ("approve_outreach",)}
+        else:
+            yield {"pass": {"status": "passed"}}
+
+    def get_state(self, config):
+        return _FakeState({"fit": {"fit_score": 80}, "research": {"company_summary": "ok"}})
+
+
+def test_stream_503_without_provider(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: False)
+    res = client.post("/assistant/stream", json={"description_text": "d"})
+    assert res.status_code == 503
+
+
+def test_stream_emits_status_then_awaiting_approval(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+    monkeypatch.setattr(main, "_get_assistant_graph", lambda: _FakeGraph(with_interrupt=True))
+
+    res = client.post("/assistant/stream", json={"description_text": "d", "resume_text": "r"})
+    assert res.status_code == 200
+    assert res.headers["content-type"].startswith("text/event-stream")
+    body = res.text
+    assert "event: status" in body and '"node": "parse"' in body
+    assert "event: awaiting_approval" in body
+    assert "event: result" not in body  # paused at the interrupt
+
+
+def test_stream_weak_fit_emits_result(monkeypatch):
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+    monkeypatch.setattr(main, "_get_assistant_graph", lambda: _FakeGraph(with_interrupt=False))
+
+    res = client.post("/assistant/stream", json={"description_text": "d"})
+    assert res.status_code == 200
+    assert "event: result" in res.text
+    assert "event: awaiting_approval" not in res.text


### PR DESCRIPTION
Closes #59. Part of Phase 3 epic #61. Builds on K (#63).

Streams the LangGraph assistant run end to end — agent → API → web — and ships the live UI that K deferred.

## What
- **Agent** (M1): `POST /assistant/stream` returns `text/event-stream` from `graph.astream(stream_mode="updates")` — a `status` event per node, an `awaiting_approval` event at the HITL interrupt, else a final `result`; failures surface as an `error` event. 503 without a provider.
- **API** (M2): `agent-client.streamAssistantUpstream` + a dedicated assistant-stream router that **pipes the SSE through unbuffered** (`X-Accel-Buffering: no`), mounted at the exact `/api/ai/assistant/stream` path (before the AI router) so it streams and doesn't double-apply the AI guards to run/resume.
- **Web** (M3): a dedicated **unbuffered** Next route (`/api/assistant-stream`) — the catch-all `/api/proxy` buffers (`arrayBuffer()`) and drops the `/api` segment, so SSE needs its own route — plus the `/assistant` page + `AssistantPanel` that renders per-node status live, an Approve/Skip control at the interrupt (resume via `/api/proxy/api/ai/assistant/resume`), and the drafted outreach. Sidebar link added.

## Degradation
No agent/provider → 503 + a clear toast (the panel doesn't break). Resume goes through the normal buffering proxy (non-streaming) — fine for a single JSON response.

## Tests / checks
- `test_assistant_stream.py` — SSE emits ordered status → awaiting_approval (or → result) from a fake graph; 503 without a provider. `assistant.test.ts` — passthrough pipes fake upstream frames + auth/validation. Agent suite **108**, API suite **66**, `ruff` + `npm run check` green (`/assistant` + `/api/assistant-stream` build).
- Evals workflow runs on this PR and **skips cleanly**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)