### PR TITLE
feat: Phase 3 · L — JobOps MCP server (FastMCP REST bridge)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,11 @@ NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:4000
 API_SHARED_SECRET=
 NEXT_PUBLIC_API_SHARED_SECRET=
 
+# JobOps MCP server (services/mcp, Phase 3 · Workstream L). Bridges the REST API.
+# MCP_SERVER_API_KEY must equal API_SHARED_SECRET so the API's service-auth resolves the user.
+MCP_SERVER_API_BASE_URL=http://127.0.0.1:4000
+MCP_SERVER_API_KEY=
+
 # API edge guards (Phase 2 · Workstream G). All optional — sensible defaults apply.
 # Rate limiting: window + per-window request caps (global vs. the AI/discovery routes).
 RATE_LIMIT_WINDOW_MS=60000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,29 @@ jobs:
 
       - name: Test (pytest)
         run: pytest
+
+  mcp:
+    name: MCP server (Python)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/mcp
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: services/mcp/requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Test (pytest)
+        run: pytest

--- a/apps/api/src/lib/auth.test.ts
+++ b/apps/api/src/lib/auth.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+import express from 'express';
+import { attachUserId } from './auth';
+
+function snapshotEnv(keys: string[]) {
+  const snapshot = new Map<string, string | undefined>();
+  for (const key of keys) snapshot.set(key, process.env[key]);
+  return () => {
+    for (const [key, value] of snapshot) {
+      if (typeof value === 'undefined') delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}
+
+async function whoami(headers: Record<string, string>): Promise<string | null> {
+  const app = express();
+  app.use(attachUserId);
+  app.get('/whoami', (request, response) => response.json({ userId: request.userId ?? null }));
+
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('Test server did not provide a usable address');
+  }
+  try {
+    const res = await fetch(`http://127.0.0.1:${address.port}/whoami`, { headers });
+    return ((await res.json()) as { userId: string | null }).userId;
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+test('a valid shared key + X-User-Id acts as that user (service principal)', async () => {
+  const restore = snapshotEnv(['API_SHARED_SECRET']);
+  process.env.API_SHARED_SECRET = 'svc-secret';
+  try {
+    const userId = await whoami({ 'X-API-Key': 'svc-secret', 'X-User-Id': 'u_mcp' });
+    assert.equal(userId, 'u_mcp');
+  } finally {
+    restore();
+  }
+});
+
+test('the service path requires both the key and X-User-Id', async () => {
+  const restore = snapshotEnv(['API_SHARED_SECRET']);
+  process.env.API_SHARED_SECRET = 'svc-secret';
+  try {
+    // Valid key but no X-User-Id → the service-auth branch is skipped and we fall through
+    // to the normal resolution (the dev default, since Clerk is off in tests) rather than
+    // erroring or acting as an empty user.
+    const userId = await whoami({ 'X-API-Key': 'svc-secret' });
+    assert.equal(userId, 'user_local_dev');
+  } finally {
+    restore();
+  }
+});

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -32,6 +32,17 @@ export function attachUserId(request: Request, _response: Response, next: NextFu
     return next();
   }
 
+  // Service principal (e.g. the MCP server bridge): a holder of the shared API key may act
+  // on behalf of a specific user via X-User-Id. Mirrors the n8n machine-to-machine trust —
+  // only a caller with the server-side secret can set the user, so unauthenticated clients
+  // can't (the X-User-Id below it is honored only in dev where Clerk is off).
+  const sharedSecret = process.env.API_SHARED_SECRET?.trim();
+  const onBehalfOf = request.header('X-User-Id')?.trim();
+  if (sharedSecret && request.header('X-API-Key')?.trim() === sharedSecret && onBehalfOf) {
+    request.userId = onBehalfOf;
+    return next();
+  }
+
   if (clerkEnabled) {
     const { userId } = getAuth(request);
     if (userId) {

--- a/services/mcp/README.md
+++ b/services/mcp/README.md
@@ -1,0 +1,48 @@
+# JobOps Copilot — MCP server
+
+A **Model Context Protocol** server (FastMCP, streamable-HTTP) that exposes JobOps as tools
+for MCP clients (e.g. MCP Inspector, Claude). Phase 3 · Workstream L.
+
+It is a thin **bridge over the existing REST API** (`apps/api`) — it never touches the
+database, so it reuses every store, guard, and rate-limit the API already enforces. It is a
+standalone package with its own venv, intentionally isolated from the agent's FastAPI pins.
+
+## Tools
+
+| Tool | What it does |
+| --- | --- |
+| `search_jobs(user_id, query?)` | The user's tracked jobs, optionally filtered by title/company. |
+| `get_job(user_id, job_id)` | One job with its analysis + outreach drafts. |
+| `list_saved_searches(user_id)` | The user's saved job searches. |
+| `score_fit(user_id, job_id)` | Score the resume against a stored job. |
+| `draft_outreach(user_id, job_id, message_type?)` | Draft outreach (human-review only — never sends). |
+
+## Auth model
+
+Each call sends the shared API key (`MCP_SERVER_API_KEY`, which **must equal the API's
+`API_SHARED_SECRET`**) plus the acting `X-User-Id`, so the API's service-auth path resolves
+the user (see `apps/api/src/lib/auth.ts`). The shared key lives only server-side and is
+never exposed to MCP clients. **Deploy the MCP server behind network access control** (it
+can act as any user via the shared key); per-MCP-client OAuth is a future hardening step.
+
+## Run it
+
+```bash
+cd services/mcp
+python -m venv .venv && .venv/Scripts/activate   # (or source .venv/bin/activate)
+pip install -r requirements-dev.txt
+
+export MCP_SERVER_API_BASE_URL=http://127.0.0.1:4000   # the JobOps API
+export MCP_SERVER_API_KEY=<same value as the API's API_SHARED_SECRET>
+python server.py                                       # streamable-HTTP on the default port
+```
+
+Then point an MCP client at it (e.g. `npx @modelcontextprotocol/inspector`) to list and call
+the tools end to end against a running JobOps API.
+
+## Tests & lint
+
+```bash
+pytest          # mocks the REST API via httpx.MockTransport — no live server needed
+ruff check .
+```

--- a/services/mcp/api_client.py
+++ b/services/mcp/api_client.py
@@ -1,0 +1,65 @@
+"""Thin REST bridge to the JobOps API (Phase 3 · Workstream L).
+
+Each MCP tool delegates here rather than touching the database, so the MCP server reuses
+every store, guard, and rate-limit the API already enforces. Calls send the shared API key
+(`MCP_SERVER_API_KEY`, which must equal the API's `API_SHARED_SECRET`) plus the acting
+`X-User-Id`, so the API's service-auth path (Task L0) resolves the user.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+# Injectable for tests (e.g. httpx.MockTransport); None → real network transport.
+_transport: httpx.BaseTransport | None = None
+
+
+def _base_url() -> str:
+    return os.environ.get("MCP_SERVER_API_BASE_URL", "http://127.0.0.1:4000").rstrip("/")
+
+
+def _headers(user_id: str) -> dict[str, str]:
+    return {
+        "X-API-Key": os.environ.get("MCP_SERVER_API_KEY", ""),
+        "X-User-Id": user_id,
+        "Content-Type": "application/json",
+    }
+
+
+def _request(method: str, path: str, user_id: str, json: dict | None = None) -> Any:
+    with httpx.Client(base_url=_base_url(), timeout=30, transport=_transport) as client:
+        response = client.request(method, path, headers=_headers(user_id), json=json)
+        response.raise_for_status()
+        return response.json()
+
+
+def search_jobs(user_id: str, query: str = "") -> list[dict]:
+    """The user's tracked jobs, optionally filtered by a title/company substring."""
+    jobs = _request("GET", "/api/jobs", user_id).get("jobs", [])
+    if query:
+        needle = query.lower()
+        jobs = [j for j in jobs if needle in f"{j.get('title', '')} {j.get('company', '')}".lower()]
+    return jobs
+
+
+def get_job(user_id: str, job_id: str) -> dict | None:
+    """A single job with its analysis and outreach."""
+    return _request("GET", f"/api/jobs/{job_id}", user_id).get("job")
+
+
+def list_saved_searches(user_id: str) -> list[dict]:
+    return _request("GET", "/api/saved-searches", user_id).get("savedSearches", [])
+
+
+def score_fit(user_id: str, job_id: str) -> dict:
+    """Score the user's resume against a stored job (uses the saved profile)."""
+    return _request("POST", "/api/ai/score-fit", user_id, json={"job_id": job_id})
+
+
+def draft_outreach(user_id: str, job_id: str, message_type: str = "recruiter_email") -> dict:
+    """Draft (human-review) outreach for a stored job. Never sends."""
+    body = {"job_id": job_id, "message_type": message_type}
+    return _request("POST", "/api/ai/draft-outreach", user_id, json=body)

--- a/services/mcp/pyproject.toml
+++ b/services/mcp/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "jobops-mcp"
+version = "0.1.0"
+description = "JobOps Copilot MCP server (FastMCP) bridging the REST API."
+requires-python = ">=3.11"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/services/mcp/requirements-dev.txt
+++ b/services/mcp/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8,<9
+ruff>=0.6,<1

--- a/services/mcp/requirements.txt
+++ b/services/mcp/requirements.txt
@@ -1,0 +1,4 @@
+# JobOps MCP server (Phase 3 · Workstream L). Standalone — isolated from the agent's
+# FastAPI/Starlette pins, so the MCP SDK's Starlette requirement doesn't conflict.
+mcp>=1.12,<2
+httpx>=0.27,<1

--- a/services/mcp/server.py
+++ b/services/mcp/server.py
@@ -1,0 +1,56 @@
+"""JobOps Copilot MCP server (Phase 3 · Workstream L).
+
+A FastMCP server (streamable-HTTP) that exposes JobOps as tools, implemented as a thin
+bridge over the existing REST API (see api_client). Run it and connect an MCP client
+(e.g. MCP Inspector or Claude) — see README.md.
+
+Auth model: the server holds the shared API key server-side (MCP_SERVER_API_KEY) and acts
+on behalf of the `user_id` passed to each tool. Deploy it behind network access control;
+the shared key is never exposed to MCP clients.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+import api_client
+
+mcp = FastMCP("jobops", stateless_http=True, json_response=True)
+
+
+@mcp.tool()
+def search_jobs(user_id: str, query: str = "") -> list[dict]:
+    """List the user's tracked jobs, optionally filtered by a title/company substring."""
+    return api_client.search_jobs(user_id, query)
+
+
+@mcp.tool()
+def get_job(user_id: str, job_id: str) -> dict | None:
+    """Get one job (with its analysis and outreach drafts) by id."""
+    return api_client.get_job(user_id, job_id)
+
+
+@mcp.tool()
+def list_saved_searches(user_id: str) -> list[dict]:
+    """List the user's saved job searches."""
+    return api_client.list_saved_searches(user_id)
+
+
+@mcp.tool()
+def score_fit(user_id: str, job_id: str) -> dict:
+    """Score the user's resume against a stored job and return the structured assessment."""
+    return api_client.score_fit(user_id, job_id)
+
+
+@mcp.tool()
+def draft_outreach(user_id: str, job_id: str, message_type: str = "recruiter_email") -> dict:
+    """Draft outreach for a stored job (human-review only — never sends)."""
+    return api_client.draft_outreach(user_id, job_id, message_type)
+
+
+def main() -> None:
+    mcp.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mcp/tests/test_tools.py
+++ b/services/mcp/tests/test_tools.py
@@ -1,0 +1,78 @@
+"""Phase 3 · L — MCP REST-bridge tools (mocked API; no live server)."""
+
+import json
+
+import httpx
+
+import api_client
+
+
+def _mock(handler):
+    return httpx.MockTransport(handler)
+
+
+def test_search_jobs_forwards_auth_and_filters(monkeypatch):
+    monkeypatch.setenv("MCP_SERVER_API_KEY", "svc-secret")
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = request.headers
+        return httpx.Response(
+            200,
+            json={
+                "jobs": [
+                    {"id": "1", "title": "AI Engineer", "company": "Acme"},
+                    {"id": "2", "title": "Data Scientist", "company": "Globex"},
+                ]
+            },
+        )
+
+    monkeypatch.setattr(api_client, "_transport", _mock(handler))
+    jobs = api_client.search_jobs("u_mcp", query="engineer")
+    assert captured["headers"]["x-api-key"] == "svc-secret"
+    assert captured["headers"]["x-user-id"] == "u_mcp"
+    assert [j["id"] for j in jobs] == ["1"]  # filtered to the AI Engineer role
+
+
+def test_get_job(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/jobs/abc"
+        return httpx.Response(200, json={"job": {"id": "abc"}})
+
+    monkeypatch.setattr(api_client, "_transport", _mock(handler))
+    assert api_client.get_job("u", "abc")["id"] == "abc"
+
+
+def test_list_saved_searches(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/saved-searches"
+        return httpx.Response(200, json={"savedSearches": [{"id": "s1"}]})
+
+    monkeypatch.setattr(api_client, "_transport", _mock(handler))
+    assert api_client.list_saved_searches("u")[0]["id"] == "s1"
+
+
+def test_score_fit_posts_job_id(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST" and request.url.path == "/api/ai/score-fit"
+        assert json.loads(request.content)["job_id"] == "j1"
+        return httpx.Response(200, json={"fit_score": 80})
+
+    monkeypatch.setattr(api_client, "_transport", _mock(handler))
+    assert api_client.score_fit("u", "j1")["fit_score"] == 80
+
+
+def test_draft_outreach_posts_payload(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert json.loads(request.content) == {"job_id": "j1", "message_type": "recruiter_email"}
+        return httpx.Response(200, json={"draft_text": "hi"})
+
+    monkeypatch.setattr(api_client, "_transport", _mock(handler))
+    assert api_client.draft_outreach("u", "j1")["draft_text"] == "hi"
+
+
+def test_server_registers_tools():
+    # Importing the server constructs the FastMCP app and runs the @mcp.tool decorators.
+    import server
+
+    assert server.mcp is not None


### PR DESCRIPTION
Closes #58. Part of Phase 3 epic #61. Independent of K/M/N.

A remote, authenticated **MCP server** exposing JobOps as tools — a thin bridge over the existing REST API.

## What
- **`services/mcp`** (standalone, own venv): a FastMCP **streamable-HTTP** server with tools `search_jobs`, `get_job`, `list_saved_searches`, `score_fit`, `draft_outreach`. Each delegates to `apps/api` over HTTP (`api_client`), forwarding `X-API-Key` + `X-User-Id` — it never touches the DB, so it reuses every store/guard/rate-limit.
- **API service-auth (Task L0):** `attachUserId` now lets a holder of the shared key act as a specific user via `X-User-Id` (n8n-style M2M). Without it the bridge would 401 in prod (Clerk ignores `X-User-Id`). `MCP_SERVER_API_KEY` must equal `API_SHARED_SECRET`.
- README (run + connect + auth model), `.env.example` (`MCP_SERVER_*`), and a new **`mcp` CI job** (ruff + pytest).

## Why a separate package
The MCP SDK (`mcp`) pulls **Starlette 1.x**, which conflicts with the agent's `fastapi 0.119` (`starlette <0.49`). Keeping the MCP server in its own package/venv isolates that — no conflict with the agent.

## Auth model (honest scope)
The shared key lives server-side and is never exposed to MCP clients; the server can act as any user via that key, so it's meant to run **behind network access control**. Per-MCP-client OAuth is a documented future hardening step.

## Tests / checks
- `services/mcp` tests mock the REST API via `httpx.MockTransport` (auth headers, filtering, POST payloads) — **6 passing**, ruff clean. `auth.test.ts` covers the service-auth path; full API suite **68 passing**, `npm run check` green.
- `evals.yml` is not triggered (no agent/prompts changes); the new `mcp` CI job runs the package tests.

## Note
This is **independent** of the K→M→N chain. **N (#60)** remains deferred pending a fastapi/starlette bump (the same Starlette conflict, but in the agent env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)