### PR TITLE
feat(agent): Phase 3 · N — research consumes external MCP tools (Tavily fallback)

### DIFF
--- a/services/agent/app/agents/mcp_tools.py
+++ b/services/agent/app/agents/mcp_tools.py
@@ -1,0 +1,63 @@
+"""Agent-as-MCP-client tool loading (Phase 3 · Workstream N).
+
+Loads tools from external MCP servers (via langchain-mcp-adapters) for the research agent,
+with graceful fallback to the built-in Tavily ``web_search`` tool. Never raises into the
+request path: any misconfiguration / unreachable server / async-context limitation degrades
+to Tavily, so research behavior is unchanged when MCP isn't available.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from app.agents.tools import web_search
+from app.config import settings
+
+logger = logging.getLogger("jobops.agent.mcp")
+
+_cache: list | None = None  # external MCP tools, cached only after a successful load
+
+
+def _load_external_mcp_tools() -> list | None:
+    """Load tools from the configured MCP servers, or ``None`` when unavailable.
+
+    Returns ``None`` (→ caller falls back to Tavily) when no servers are configured, when
+    called from within a running event loop (``get_tools`` is async and we can't
+    ``asyncio.run`` there), or on any error.
+    """
+    if not settings.mcp_client_servers:
+        return None
+    try:
+        asyncio.get_running_loop()
+        return None  # inside an async loop (e.g. the streaming graph) — skip this call
+    except RuntimeError:
+        pass  # no running loop → safe to drive the async client
+    try:
+        from langchain_mcp_adapters.client import MultiServerMCPClient
+
+        connections = json.loads(settings.mcp_client_servers)
+        tools = asyncio.run(MultiServerMCPClient(connections).get_tools())
+        return tools or None
+    except Exception:  # noqa: BLE001 - MCP is best-effort; fall back to Tavily with a log
+        logger.warning("External MCP tools unavailable; using Tavily web_search", exc_info=True)
+        return None
+
+
+def load_research_tools() -> list:
+    """Tools for the research agent: external MCP tools when available, else Tavily."""
+    global _cache
+    if _cache is not None:
+        return _cache
+    tools = _load_external_mcp_tools()
+    if tools:
+        _cache = tools  # cache only a successful MCP load
+        return tools
+    return [web_search]  # don't cache the fallback — retry from a sync context next time
+
+
+def reset_mcp_tools_cache() -> None:
+    """Clear the cached MCP tools (tests)."""
+    global _cache
+    _cache = None

--- a/services/agent/app/agents/runner.py
+++ b/services/agent/app/agents/runner.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from langchain.agents import create_agent
 from langchain.agents.structured_output import ToolStrategy
 
-from app.agents.tools import web_search
+from app.agents.mcp_tools import load_research_tools
 from app.llm.provider import get_model
 from app.prompts import INTERVIEW_PREP_SYSTEM, RESEARCH_SYSTEM, SKILL_GAP_SYSTEM
 from app.safety.pii import maybe_redact
@@ -79,7 +79,7 @@ def run_research(req: ResearchRequest, config: dict | None = None) -> ResearchBr
     model, _ = get_model()
     agent = create_agent(
         model,
-        tools=[web_search],
+        tools=load_research_tools(),
         system_prompt=RESEARCH_SYSTEM,
         response_format=ToolStrategy(ResearchBrief),
     )

--- a/services/agent/app/config.py
+++ b/services/agent/app/config.py
@@ -63,5 +63,10 @@ class Settings(BaseSettings):
     # at/above it the assistant researches + drafts outreach; below it stops with a "pass".
     assistant_fit_threshold: int = 60
 
+    # Agent-as-MCP-client (Phase 3 · Workstream N). JSON map of external MCP servers to load
+    # research tools from, e.g. {"fetch": {"transport": "http", "url": "http://host/mcp"}}.
+    # Unset → the research agent uses the built-in Tavily web_search tool.
+    mcp_client_servers: str | None = None
+
 
 settings = Settings()

--- a/services/agent/requirements.txt
+++ b/services/agent/requirements.txt
@@ -1,7 +1,8 @@
 # Core service + LLM providers (Phase 9).
 # RAG deps (psycopg, pgvector, sentence-transformers) are added in Phase 10,
 # telemetry deps (pandas) in Phase 11.
-fastapi>=0.115,<0.120
+# fastapi >=0.137 allows Starlette 1.x, which the MCP SDK (Phase 3 · N) requires.
+fastapi>=0.137,<0.140
 uvicorn[standard]>=0.30,<0.40
 pydantic>=2.7,<3
 pydantic-settings>=2.3,<3
@@ -15,6 +16,9 @@ langchain-google-genai>=3.0,<4
 
 # LangGraph application-assistant orchestration (Phase 3 · Workstream K).
 langgraph>=1.0,<2
+
+# Agent-as-MCP-client: load external MCP tools into the research agent (Phase 3 · N).
+langchain-mcp-adapters>=0.3,<1
 
 # HTTP client for agent tools (web search)
 httpx>=0.27,<1

--- a/services/agent/tests/test_mcp_tools.py
+++ b/services/agent/tests/test_mcp_tools.py
@@ -1,0 +1,63 @@
+"""Phase 3 · N — agent-as-MCP-client tool loading + Tavily fallback (no network)."""
+
+from app.agents import mcp_tools
+from app.agents.tools import web_search
+
+
+def test_falls_back_to_tavily_without_config(monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "mcp_client_servers", None)
+    mcp_tools.reset_mcp_tools_cache()
+    assert mcp_tools.load_research_tools() == [web_search]
+
+
+def test_uses_external_mcp_tools_when_available(monkeypatch):
+    mcp_tools.reset_mcp_tools_cache()
+    monkeypatch.setattr(mcp_tools, "_load_external_mcp_tools", lambda: ["mcp_a", "mcp_b"])
+    assert mcp_tools.load_research_tools() == ["mcp_a", "mcp_b"]
+
+
+def test_caches_successful_load(monkeypatch):
+    mcp_tools.reset_mcp_tools_cache()
+    calls = {"n": 0}
+
+    def fake():
+        calls["n"] += 1
+        return ["t"]
+
+    monkeypatch.setattr(mcp_tools, "_load_external_mcp_tools", fake)
+    mcp_tools.load_research_tools()
+    mcp_tools.load_research_tools()
+    assert calls["n"] == 1  # cached after the first successful load
+
+
+def test_does_not_cache_fallback(monkeypatch):
+    mcp_tools.reset_mcp_tools_cache()
+    monkeypatch.setattr(mcp_tools, "_load_external_mcp_tools", lambda: None)
+    assert mcp_tools.load_research_tools() == [web_search]
+    # later a sync context succeeds → MCP tools are used (fallback was not cached)
+    monkeypatch.setattr(mcp_tools, "_load_external_mcp_tools", lambda: ["mcp_a"])
+    assert mcp_tools.load_research_tools() == ["mcp_a"]
+
+
+def test_research_agent_uses_loaded_tools(monkeypatch):
+    from app.agents import runner
+    from app.schemas import ResearchBrief, ResearchRequest
+
+    captured: dict = {}
+
+    class _FakeAgent:
+        def invoke(self, payload, config=None):
+            return {"messages": [], "structured_response": ResearchBrief()}
+
+    def fake_create_agent(model, tools, system_prompt, response_format):
+        captured["tools"] = tools
+        return _FakeAgent()
+
+    monkeypatch.setattr(runner, "create_agent", fake_create_agent)
+    monkeypatch.setattr(runner, "get_model", lambda: (object(), "fake"))
+    monkeypatch.setattr(runner, "load_research_tools", lambda: ["sentinel_tool"])
+
+    runner.run_research(ResearchRequest(company="Acme"))
+    assert captured["tools"] == ["sentinel_tool"]


### PR DESCRIPTION
Closes #60. Part of Phase 3 epic #61 — the final sub-issue.

Makes the agent an **MCP client**: the research agent loads tools from external MCP servers, with graceful fallback to the built-in Tavily web_search.

## What
- **`app/agents/mcp_tools.py`** — `load_research_tools()` loads tools from `MCP_CLIENT_SERVERS` (JSON) via `langchain-mcp-adapters` (`MultiServerMCPClient.get_tools()`), caching a successful load. Falls back to Tavily when unset, unreachable, errored, or called from a running event loop (where the async client can't be driven synchronously). Never raises.
- **`runner.py`** — the research agent's `tools=` now come from `load_research_tools()`.

## The dependency unblock
N was blocked: `langchain-mcp-adapters → mcp → Starlette 1.x`, but the agent's `fastapi 0.119` capped `starlette <0.49`. Resolved by **bumping `fastapi` to `>=0.137`** (allows Starlette 1.x). Verified the resolution (`fastapi 0.137.1 + starlette 1.3.1 + mcp 1.28 + langchain-mcp-adapters 0.3`) and the **full agent suite passes** on the new set.

## Tests / checks
- `test_mcp_tools.py` — Tavily fallback (no config), external-MCP path, success-caching, fallback-not-cached, and the research agent wiring (mock adapter / fake model; no network). Agent suite **113 passing**, `ruff` green.
- `evals.yml` runs on this PR and **skips cleanly** (no key on PRs).

## Note
A benign `StarletteDeprecationWarning` (TestClient httpx) appears under the new Starlette; non-blocking. App Insights' Starlette instrumentation under Starlette 1.x is a possible follow-up (it fails open today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)