### PR TITLE
docs(phase4): design spec + implementation plan — hybrid RAG, reranker & eval

### DIFF
--- a/docs/superpowers/plans/2026-06-17-phase4-hybrid-rag-reranker.md
+++ b/docs/superpowers/plans/2026-06-17-phase4-hybrid-rag-reranker.md
@@ -56,7 +56,7 @@ alter table embeddings
 create index if not exists embeddings_tsv_idx on embeddings using gin (chunk_tsv);
 ```
 
-- [ ] **Step 2: Apply locally** — `npm run db:init --workspace @jobops/api` (or apply manually) against a dev `DATABASE_URL`. Expected: `\d embeddings` shows `chunk_tsv` + the GIN index.
+- [ ] **Step 2: Apply locally** — `npm run db:init --workspace @jobops/api` (or apply manually) against a dev `DATABASE_URL`. Expected: `\d embeddings` shows `chunk_tsv` + the GIN index. (`db:init` re-runs every migration each invocation and 007 sorts after 006; the `if not exists` guards keep re-runs safe. The GIN build briefly locks the table for writes — fine at portfolio scale, same as 003's HNSW index. Step 0 already confirms PG ≥12 for `GENERATED ... STORED`.)
 - [ ] **Step 3: Config** — add to `Settings`:
 
 ```python
@@ -76,14 +76,20 @@ create index if not exists embeddings_tsv_idx on embeddings using gin (chunk_tsv
 from app.rag.fusion import reciprocal_rank_fusion
 
 def test_rrf_rewards_agreement_across_rankings():
-    dense = ["a", "b", "c"]
+    # "b" is rank-0 in BOTH lists, so it wins unambiguously (no exact tie to depend on
+    # insertion order). "a" appears in both but lower; "c"/"d" appear once.
+    dense = ["b", "a", "c"]
     lexical = ["b", "a", "d"]
-    # b is high in both -> should rank first; top_k caps the result
-    assert reciprocal_rank_fusion([dense, lexical], top_k=3) == ["b", "a", "c"]
+    result = reciprocal_rank_fusion([dense, lexical], top_k=3)
+    assert result[0] == "b"
+    assert set(result) == {"b", "a", "c"} or set(result) == {"b", "a", "d"}
+    assert result.index("a") < result.index(result[-1])  # "a" beats the single-list tail
 
 def test_rrf_handles_empty_and_dedup():
     assert reciprocal_rank_fusion([[], ["x", "x"]], top_k=2) == ["x"]
 ```
+
+(The two single-occurrence tails `c`/`d` score identically, so don't assert which of them appears — only that `b` then `a` lead.)
 
 - [ ] **Step 2: Run — expect FAIL** — `pytest tests/test_fusion.py -v`.
 - [ ] **Step 3: Implement** `app/rag/fusion.py`:
@@ -114,10 +120,12 @@ def reciprocal_rank_fusion(rankings: Sequence[Sequence[str]], k0: int = 60, top_
 **Files:** Modify `app/rag/store.py`; Test `tests/test_rag.py`
 
 - [ ] **Step 1–2: Failing test** — with a fake `_connect` cursor returning canned `(id, chunk_text)` rows for the dense and lexical SQL, `retrieve(query, k=2, mode="hybrid")` returns the RRF-fused top-2 texts; and when the lexical query raises (simulating a missing `chunk_tsv`), it falls back to the dense top-2. (Patch `store._connect` with a fake context manager; assert SQL routing via the cursor's recorded queries.)
-- [ ] **Step 3: Implement** — split the current query into `_dense_candidates(cur, query_literal, pool, where, params)` (order by `embedding <=> %s::vector`) and `_lexical_candidates(cur, query, pool, where, params)` (`where chunk_tsv @@ websearch_to_tsquery('english', %s) order by ts_rank_cd(chunk_tsv, websearch_to_tsquery('english', %s)) desc`), each selecting `id, chunk_text`. `retrieve()` reads `mode = (mode or settings.rag_retrieval_mode)`:
-  - `vector`: dense top-k (today's behavior).
-  - `hybrid`: pull `rag_candidate_pool` from each side; `texts = {id: chunk_text}`; `fused = reciprocal_rank_fusion([dense_ids, lexical_ids], top_k=k)`; return `[texts[i] for i in fused]`. Wrap the lexical query in try/except → on error, log and return dense top-k.
-  - Keep the `traced_span` + user/source filters on both sides.
+- [ ] **Step 3: Implement** — split the current query into `_dense_candidates(cur, query_literal, n, where, params)` (order by `embedding <=> %s::vector` limit `n`) and `_lexical_candidates(cur, query, n, where, params)` (`where chunk_tsv @@ websearch_to_tsquery('english', %s) order by ts_rank_cd(chunk_tsv, websearch_to_tsquery('english', %s)) desc` limit `n`), each selecting `id, chunk_text`. `retrieve()` reads `mode = (mode or settings.rag_retrieval_mode)` and a **`fetch_k` = how many to return** (defaults to `k` in O3; **P2 sets it to `rag_candidate_pool` when rerank is on** so the reranker sees a real pool):
+  - `vector`: dense top-`fetch_k` (today's behavior when `fetch_k==k`).
+  - `hybrid`: pull `rag_candidate_pool` from each side; `texts = {id: chunk_text}`;
+    `fused = reciprocal_rank_fusion([dense_ids, lexical_ids], top_k=fetch_k)`;
+    return `[texts[i] for i in fused]`. Wrap the lexical query in try/except → on error, log and return dense top-`fetch_k`.
+  - Keep the `traced_span` + user/source filters on both sides. (O3 always passes `fetch_k=k` — rerank doesn't exist yet; P2 generalizes it.)
 - [ ] **Step 4–5: Run PASS; `pytest tests/test_rag.py && ruff`. Commit** — `feat(rag): hybrid retrieval (dense + FTS via RRF) with vector fallback`.
 
 ---
@@ -158,15 +166,15 @@ def rerank(query: str, chunks: list[str], k: int) -> list[str]:
         return chunks[:k]
 ```
 
-Add to `Settings`: `rag_rerank_enabled: bool = True` and `rag_rerank_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"`.
+Add to `Settings`: `rag_rerank_enabled: bool = False` (opt-in — off by default to avoid a cold-start cross-encoder download + CPU inference on the first score-fit request; see spec §5) and `rag_rerank_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"`.
 
 - [ ] **Step 4–5: Run PASS; `ruff`. Commit** — `feat(rag): CPU cross-encoder reranker (graceful)`.
 
 ### Task P2: wire rerank into retrieve
 **Files:** Modify `app/rag/store.py`; Test `tests/test_rag.py`
 
-- [ ] **Step 1–2: Failing test** — with hybrid stubbed to return a known pool and `rag_rerank_enabled=True`, `retrieve(query, k=2)` calls `rerank` (monkeypatched to reverse the pool) and returns its top-2; with `rag_rerank_enabled=False`, the pool's first 2 are returned unchanged.
-- [ ] **Step 3: Implement** — in `retrieve()`, when `settings.rag_rerank_enabled`, retrieve `max(k, rag_candidate_pool)` candidates (hybrid or vector), then `from app.rag.rerank import rerank; return rerank(query, pool, k)`. When disabled, return the pool's top-k as before. Import `rerank` lazily inside the function so CI without torch is unaffected.
+- [ ] **Step 1–2: Failing test** — with `rag_rerank_enabled=True`, assert `retrieve(query, k=2)` fetches a **pool** (`fetch_k == max(k, rag_candidate_pool)`, not `k`) from the dense/hybrid path (assert via the recorded SQL `limit` or a stubbed fetch capturing `fetch_k`) and then calls `rerank` (monkeypatched to reverse the pool) returning its top-2; with `rag_rerank_enabled=False`, `fetch_k == k` and the top-2 are returned unchanged. This pins the **pool-not-`k`** behavior so hybrid's benefit isn't collapsed before reranking.
+- [ ] **Step 3: Implement** — in `retrieve()`, set `fetch_k = max(k, settings.rag_candidate_pool) if settings.rag_rerank_enabled else k`, fetch that many via the vector/hybrid path (O3 already returns `fetch_k`), then: when rerank enabled, `from app.rag.rerank import rerank; return rerank(query, pool, k)`; when disabled, return the top-`k` directly. Import `rerank` lazily inside the function so CI without torch is unaffected.
 - [ ] **Step 4–5: Run PASS; `pytest && ruff check app tests`. Commit** — `feat(rag): rerank the candidate pool in retrieve()`.
 
 ---
@@ -177,8 +185,35 @@ Add to `Settings`: `rag_rerank_enabled: bool = True` and `rag_rerank_model: str 
 **Files:** Create `evals/retrieval.py`; Modify `evals/run.py`, `EVALS.md`, `.env.example`, `docs/ARCHITECTURE.md`; Test `tests/test_retrieval_eval.py`
 
 - [ ] **Step 1–2: Failing test** — `run_retrieval_modes(rows, resume_text, modes, deps)` with injected fake `retrieve`/`score_fit`/`ragas` returns a dict keyed by mode, each with `rank_correlation_spearman` + `ragas` metrics; assert it runs every requested mode and aggregates per mode. (No DB/LLM — inject the retriever + scorer.)
-- [ ] **Step 3: Implement** `evals/retrieval.py` — for each mode (`off`/`vector`/`hybrid`/`hybrid+rerank`): build each row's `retrieved_context` via the retriever under that mode (`off` → `[]`; others → `retrieve_resume_evidence` with the matching `RAG_RETRIEVAL_MODE`/`RAG_RERANK_ENABLED` toggled), run the existing `run_fit_score_eval` machinery, and collect the metrics. `evals/run.py` gains a `--retrieval-modes` flag that, when a DB + provider are present, runs the sweep and prints/writes a per-mode comparison table (else prints a skip line). Document the modes + a real results table in `EVALS.md`; add `RAG_*` vars to `.env.example` and a RAG paragraph to `ARCHITECTURE.md`.
-- [ ] **Step 4–5: Run PASS; `pytest && ruff`; (optionally) a real `python -m evals.run --retrieval-modes` against a keyed dev DB to fill the EVALS.md numbers. Commit** — `feat(evals): retrieval-mode comparison (off/vector/hybrid/+rerank)`.
+- [ ] **Step 3a: Refactor the scoring seam** — `run_fit_score_eval` currently hard-codes
+  `contexts = chunk_text(resume_text)` and grounds Ragas in `[*contexts, JD]` (`run.py:122,157`).
+  Add a parameter so the caller injects per-row `retrieved_context` (e.g.
+  `run_fit_score_eval(rows, resume_text, contexts_for=lambda row: [...])`, defaulting to the
+  current whole-resume behavior for the existing `python -m evals.run`). List `run.py` as
+  **Modified** for this signature change. This is the seam the sweep needs — it is **not** a
+  no-op reuse.
+- [ ] **Step 3b: Implement `evals/retrieval.py`** — for each mode build each row's
+  `retrieved_context` and pass it through the refactored scorer:
+  - `off` → `[]` (JD only, **no** resume evidence) — the true no-retrieval baseline.
+  - `vector` / `hybrid` / `hybrid+rerank` → the **top-k retrieved chunks** via
+    `retrieve_resume_evidence` with `RAG_RETRIEVAL_MODE` / `RAG_RERANK_ENABLED` toggled per mode.
+  Ragas `retrieved_contexts` per mode = that mode's `retrieved_context` (+ the JD, as today).
+  Collect context-recall / faithfulness / answer-relevancy / fit-vs-label Spearman per mode.
+  **Note in the report** that `off`/today's baseline dumps the whole resume while retrieval
+  modes pass only top-k, so context-recall may fall even as faithfulness/precision rise — show
+  all four metrics, not one headline.
+- [ ] **Step 3c: DB precondition** — before reporting `hybrid`/`hybrid+rerank`, assert the
+  `chunk_tsv` column + `embeddings_tsv_idx` exist (query `information_schema`/`pg_indexes`);
+  if absent, **mark those modes N/A and warn** rather than silently reporting `hybrid ≈ vector`
+  (which the O3 fallback would otherwise produce).
+- [ ] **Step 3d: Entrypoint + docs** — `evals/run.py` gains `--retrieval-modes`: with a DB +
+  provider it runs the sweep and writes a per-mode table (JSON + markdown); else prints a skip
+  line. Add `RAG_*` to `.env.example` (incl. `RAG_RERANK_ENABLED=false`) + a RAG paragraph to
+  `ARCHITECTURE.md`.
+- [ ] **Step 4–5: Run PASS; `pytest && ruff`.** For the EVALS.md numbers, run
+  `python -m evals.run --retrieval-modes` against a keyed dev DB **and commit the exact command
+  + the captured `evals/retrieval_report.json`** alongside `EVALS.md` so the comparison is
+  reproducible/auditable, not just pasted. **Commit** — `feat(evals): retrieval-mode comparison (off/vector/hybrid/+rerank)`.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-17-phase4-hybrid-rag-reranker.md
+++ b/docs/superpowers/plans/2026-06-17-phase4-hybrid-rag-reranker.md
@@ -1,0 +1,192 @@
+# Phase 4: hybrid retrieval, reranker & retrieval eval — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Confirm exact APIs (`websearch_to_tsquery`/`ts_rank_cd` on the installed Postgres; `sentence_transformers.CrossEncoder.predict`) via Context7 at the start of the relevant workstream.
+
+**Goal:** Improve RAG retrieval quality with hybrid (dense + lexical) search fused via RRF and a CPU cross-encoder reranker, then measure the gain end-to-end with the existing eval harness — without breaking the no-DB / no-model / no-key degradation guarantees.
+
+**Architecture:** Three sequential sub-issues in `services/agent`. **O**: add a Postgres FTS column + lexical query beside the pgvector dense query and fuse with Reciprocal Rank Fusion. **P**: rerank a larger candidate pool with a `sentence-transformers` CrossEncoder (lazy, CPU). **Q**: a mode sweep over the fit-score gold set comparing off/vector/hybrid/hybrid+rerank. All wired through the existing `app/rag/store.py:retrieve()` so callers are unchanged.
+
+**Tech Stack:** Python 3.12, psycopg + pgvector + Postgres full-text search, sentence-transformers (CrossEncoder), pytest.
+
+**Conventions to follow (existing patterns):**
+- `app/rag/store.py` keeps DB imports lazy (`import psycopg` inside `_connect`) and uses `%s::vector` literals; retrieval is user/source-scoped.
+- Lazy CPU models via `@lru_cache` (mirror `app/rag/embeddings.py:_get_model`); heavy deps live in `requirements-rag.txt`, imported lazily so CI stays light.
+- Config: add fields to `app/config.py` `Settings` (e.g. `rag_retrieval_mode` ← `RAG_RETRIEVAL_MODE`).
+- Graceful degradation is sacred: missing DB column / model / key must **fall back**, never raise into retrieval or the request path.
+- **Sequencing:** O → P → Q share `app/rag/` + `evals/` — implement in order, each branched off `main` after the previous merges.
+
+---
+
+## File structure
+
+**Workstream O — Hybrid retrieval**
+- Create `db/migrations/007_fts.sql` — `tsvector` generated column on `embeddings` + GIN index.
+- Create `services/agent/app/rag/fusion.py` — `reciprocal_rank_fusion(rankings, ...)` (pure).
+- Modify `services/agent/app/rag/store.py` — `_dense_candidates`, `_lexical_candidates`, hybrid path in `retrieve()` with vector fallback.
+- Modify `services/agent/app/config.py` — `rag_retrieval_mode`, `rag_candidate_pool`.
+- Create `services/agent/tests/test_fusion.py`; extend `tests/test_rag.py`.
+
+**Workstream P — Reranker**
+- Create `services/agent/app/rag/rerank.py` — lazy CrossEncoder + `rerank(query, chunks, k)`.
+- Modify `services/agent/app/rag/store.py` — rerank the pool in `retrieve()` when enabled.
+- Modify `services/agent/app/config.py` — `rag_rerank_enabled`, `rag_rerank_model`.
+- Create `services/agent/tests/test_rerank.py`.
+
+**Workstream Q — Retrieval eval**
+- Create `services/agent/evals/retrieval.py` — mode sweep over the fit-score gold set.
+- Modify `services/agent/evals/run.py` — `--retrieval-modes` entrypoint.
+- Modify `EVALS.md`, `.env.example`, `docs/ARCHITECTURE.md`.
+- Create `services/agent/tests/test_retrieval_eval.py`.
+
+---
+
+## Workstream O — Hybrid retrieval
+
+### Task O1: FTS migration + config
+**Files:** Create `db/migrations/007_fts.sql`; Modify `services/agent/app/config.py`
+
+- [ ] **Step 0: Confirm API** — via Context7, confirm `to_tsvector`/`websearch_to_tsquery`/`ts_rank_cd` usage and the generated-column syntax on the installed Postgres (pgvector image, PG 16+).
+- [ ] **Step 1: Migration** `db/migrations/007_fts.sql`:
+
+```sql
+-- Lexical (full-text) side of hybrid retrieval (Phase 4 · O).
+alter table embeddings
+  add column if not exists chunk_tsv tsvector
+  generated always as (to_tsvector('english', chunk_text)) stored;
+create index if not exists embeddings_tsv_idx on embeddings using gin (chunk_tsv);
+```
+
+- [ ] **Step 2: Apply locally** — `npm run db:init --workspace @jobops/api` (or apply manually) against a dev `DATABASE_URL`. Expected: `\d embeddings` shows `chunk_tsv` + the GIN index.
+- [ ] **Step 3: Config** — add to `Settings`:
+
+```python
+    # RAG retrieval (Phase 4). mode: "vector" (dense only) or "hybrid" (dense + FTS via RRF).
+    rag_retrieval_mode: str = "hybrid"
+    rag_candidate_pool: int = 16  # candidates pulled per side before fusion / rerank
+```
+
+- [ ] **Step 4: Commit** — `feat(rag): FTS column + index migration + retrieval config`.
+
+### Task O2: Reciprocal Rank Fusion (TDD, pure)
+**Files:** Create `app/rag/fusion.py`; Test `tests/test_fusion.py`
+
+- [ ] **Step 1: Failing test**
+
+```python
+from app.rag.fusion import reciprocal_rank_fusion
+
+def test_rrf_rewards_agreement_across_rankings():
+    dense = ["a", "b", "c"]
+    lexical = ["b", "a", "d"]
+    # b is high in both -> should rank first; top_k caps the result
+    assert reciprocal_rank_fusion([dense, lexical], top_k=3) == ["b", "a", "c"]
+
+def test_rrf_handles_empty_and_dedup():
+    assert reciprocal_rank_fusion([[], ["x", "x"]], top_k=2) == ["x"]
+```
+
+- [ ] **Step 2: Run — expect FAIL** — `pytest tests/test_fusion.py -v`.
+- [ ] **Step 3: Implement** `app/rag/fusion.py`:
+
+```python
+from __future__ import annotations
+from collections.abc import Sequence
+
+def reciprocal_rank_fusion(rankings: Sequence[Sequence[str]], k0: int = 60, top_k: int = 4) -> list[str]:
+    """Fuse ranked id lists by Reciprocal Rank Fusion: score(id)=Σ 1/(k0+rank)."""
+    scores: dict[str, float] = {}
+    for ranking in rankings:
+        seen: set[str] = set()
+        for rank, doc_id in enumerate(ranking):
+            if doc_id in seen:
+                continue
+            seen.add(doc_id)
+            scores[doc_id] = scores.get(doc_id, 0.0) + 1.0 / (k0 + rank)
+    ordered = sorted(scores, key=lambda d: scores[d], reverse=True)
+    return ordered[:top_k]
+```
+
+(Verify the expected order in the test against this formula; adjust the test, not the formula, if ties differ.)
+
+- [ ] **Step 4–5: Run PASS; `ruff`. Commit** — `feat(rag): reciprocal rank fusion`.
+
+### Task O3: hybrid retrieve with vector fallback (TDD)
+**Files:** Modify `app/rag/store.py`; Test `tests/test_rag.py`
+
+- [ ] **Step 1–2: Failing test** — with a fake `_connect` cursor returning canned `(id, chunk_text)` rows for the dense and lexical SQL, `retrieve(query, k=2, mode="hybrid")` returns the RRF-fused top-2 texts; and when the lexical query raises (simulating a missing `chunk_tsv`), it falls back to the dense top-2. (Patch `store._connect` with a fake context manager; assert SQL routing via the cursor's recorded queries.)
+- [ ] **Step 3: Implement** — split the current query into `_dense_candidates(cur, query_literal, pool, where, params)` (order by `embedding <=> %s::vector`) and `_lexical_candidates(cur, query, pool, where, params)` (`where chunk_tsv @@ websearch_to_tsquery('english', %s) order by ts_rank_cd(chunk_tsv, websearch_to_tsquery('english', %s)) desc`), each selecting `id, chunk_text`. `retrieve()` reads `mode = (mode or settings.rag_retrieval_mode)`:
+  - `vector`: dense top-k (today's behavior).
+  - `hybrid`: pull `rag_candidate_pool` from each side; `texts = {id: chunk_text}`; `fused = reciprocal_rank_fusion([dense_ids, lexical_ids], top_k=k)`; return `[texts[i] for i in fused]`. Wrap the lexical query in try/except → on error, log and return dense top-k.
+  - Keep the `traced_span` + user/source filters on both sides.
+- [ ] **Step 4–5: Run PASS; `pytest tests/test_rag.py && ruff`. Commit** — `feat(rag): hybrid retrieval (dense + FTS via RRF) with vector fallback`.
+
+---
+
+## Workstream P — Reranker
+
+### Task P1: cross-encoder rerank (TDD, fake model)
+**Files:** Create `app/rag/rerank.py`; Modify `app/config.py`; Test `tests/test_rerank.py`
+
+- [ ] **Step 0: Confirm API** — via Context7, confirm `sentence_transformers.CrossEncoder(model).predict([(query, doc), ...])` returns a score per pair (higher = more relevant).
+- [ ] **Step 1–2: Failing test** — monkeypatch the lazy model getter with a fake whose `predict` returns fixed scores; `rerank("q", ["a","b","c"], k=2)` returns the 2 highest-scored chunks in score order; and when the model getter raises, `rerank` returns the first `k` unchanged (graceful).
+- [ ] **Step 3: Implement** `app/rag/rerank.py`:
+
+```python
+from __future__ import annotations
+import logging
+from functools import lru_cache
+from app.config import settings
+
+logger = logging.getLogger("jobops.agent.rag")
+
+@lru_cache(maxsize=1)
+def _get_model():
+    from sentence_transformers import CrossEncoder  # lazy: pulls torch
+    return CrossEncoder(settings.rag_rerank_model)
+
+def rerank(query: str, chunks: list[str], k: int) -> list[str]:
+    """Re-score (query, chunk) pairs with a CPU cross-encoder; return the top k.
+    Any failure returns the first k chunks unchanged (graceful)."""
+    if not chunks:
+        return chunks
+    try:
+        scores = _get_model().predict([(query, chunk) for chunk in chunks])
+        ranked = [c for _, c in sorted(zip(scores, chunks, strict=False), key=lambda p: p[0], reverse=True)]
+        return ranked[:k]
+    except Exception:  # noqa: BLE001 - reranking is best-effort
+        logger.warning("Rerank unavailable; returning pre-rerank order", exc_info=True)
+        return chunks[:k]
+```
+
+Add to `Settings`: `rag_rerank_enabled: bool = True` and `rag_rerank_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"`.
+
+- [ ] **Step 4–5: Run PASS; `ruff`. Commit** — `feat(rag): CPU cross-encoder reranker (graceful)`.
+
+### Task P2: wire rerank into retrieve
+**Files:** Modify `app/rag/store.py`; Test `tests/test_rag.py`
+
+- [ ] **Step 1–2: Failing test** — with hybrid stubbed to return a known pool and `rag_rerank_enabled=True`, `retrieve(query, k=2)` calls `rerank` (monkeypatched to reverse the pool) and returns its top-2; with `rag_rerank_enabled=False`, the pool's first 2 are returned unchanged.
+- [ ] **Step 3: Implement** — in `retrieve()`, when `settings.rag_rerank_enabled`, retrieve `max(k, rag_candidate_pool)` candidates (hybrid or vector), then `from app.rag.rerank import rerank; return rerank(query, pool, k)`. When disabled, return the pool's top-k as before. Import `rerank` lazily inside the function so CI without torch is unaffected.
+- [ ] **Step 4–5: Run PASS; `pytest && ruff check app tests`. Commit** — `feat(rag): rerank the candidate pool in retrieve()`.
+
+---
+
+## Workstream Q — Retrieval eval (downstream delta)
+
+### Task Q1: mode sweep + entrypoint + docs
+**Files:** Create `evals/retrieval.py`; Modify `evals/run.py`, `EVALS.md`, `.env.example`, `docs/ARCHITECTURE.md`; Test `tests/test_retrieval_eval.py`
+
+- [ ] **Step 1–2: Failing test** — `run_retrieval_modes(rows, resume_text, modes, deps)` with injected fake `retrieve`/`score_fit`/`ragas` returns a dict keyed by mode, each with `rank_correlation_spearman` + `ragas` metrics; assert it runs every requested mode and aggregates per mode. (No DB/LLM — inject the retriever + scorer.)
+- [ ] **Step 3: Implement** `evals/retrieval.py` — for each mode (`off`/`vector`/`hybrid`/`hybrid+rerank`): build each row's `retrieved_context` via the retriever under that mode (`off` → `[]`; others → `retrieve_resume_evidence` with the matching `RAG_RETRIEVAL_MODE`/`RAG_RERANK_ENABLED` toggled), run the existing `run_fit_score_eval` machinery, and collect the metrics. `evals/run.py` gains a `--retrieval-modes` flag that, when a DB + provider are present, runs the sweep and prints/writes a per-mode comparison table (else prints a skip line). Document the modes + a real results table in `EVALS.md`; add `RAG_*` vars to `.env.example` and a RAG paragraph to `ARCHITECTURE.md`.
+- [ ] **Step 4–5: Run PASS; `pytest && ruff`; (optionally) a real `python -m evals.run --retrieval-modes` against a keyed dev DB to fill the EVALS.md numbers. Commit** — `feat(evals): retrieval-mode comparison (off/vector/hybrid/+rerank)`.
+
+---
+
+## Self-review (spec coverage)
+- **O — hybrid:** O1 (migration + config) · O2 (RRF) · O3 (hybrid retrieve + vector fallback). ✓ (criteria 1)
+- **P — reranker:** P1 (cross-encoder, graceful) · P2 (wire into retrieve). ✓ (criteria 2, 4 — no new dep)
+- **Q — retrieval eval:** Q1 (mode sweep + entrypoint + EVALS.md). ✓ (criterion 3)
+- **Graceful degradation (criterion 5):** vector fallback (O3), pre-rerank fallback (P1), eval skip without DB/key (Q1); RAG already no-ops without a DB.
+- **Deferrals honored:** no fine-tuning, no new gold set, no embedding/store swap.
+
+**Note:** exact Postgres FTS function usage and the `CrossEncoder.predict` contract are confirmed against the repo + Context7 at the first task of each workstream; the RRF tie-ordering in the O2 test is verified against the implemented formula before locking the assertion.

--- a/docs/superpowers/specs/2026-06-17-phase4-hybrid-rag-reranker-design.md
+++ b/docs/superpowers/specs/2026-06-17-phase4-hybrid-rag-reranker-design.md
@@ -36,9 +36,11 @@ revisit later.
 1. With `RAG_RETRIEVAL_MODE=hybrid`, `retrieve()` fuses dense (cosine) + lexical (FTS)
    rankings via RRF and returns the top `k`; with `vector` it behaves as today. An
    un-migrated DB or an FTS error **falls back to vector-only** — retrieval never breaks.
-2. With `RAG_RERANK_ENABLED=true`, retrieval pulls a larger pool (`RAG_CANDIDATE_POOL`) and a
-   cross-encoder reranks it to the top `k`; any reranker load/inference error returns the
-   pre-rerank top-k. User-scoping and source filters hold throughout.
+2. With `RAG_RERANK_ENABLED=true` (opt-in; **default off** — see §5), retrieval pulls a
+   larger pool (`RAG_CANDIDATE_POOL`) and a cross-encoder reranks it to the top `k`. When
+   rerank is on, the **fusion/dense step returns the pool, not `k`** (so the reranker sees a
+   real pool); when off, retrieval returns the top `k` directly. Any reranker load/inference
+   error returns the pre-rerank top-k. User-scoping and source filters hold throughout.
 3. `python -m evals.run` (or a dedicated entrypoint) can run the fit-score eval across
    retrieval modes and emit a **per-mode comparison** (context-recall / faithfulness /
    answer-relevancy / fit-vs-label Spearman); it **skips** without a DB or provider.
@@ -58,8 +60,10 @@ revisit later.
   over the dense and lexical rank lists (`k0=60`), returning the top `k` by fused score. A
   pure function, unit-tested.
 - **`retrieve()` mode:** `RAG_RETRIEVAL_MODE` ∈ {`vector`, `hybrid`} (default `hybrid`).
-  Hybrid runs both queries (pull `candidate_pool` each), fuses, returns top `k`. On a missing
-  `tsvector` column or any FTS error, log + fall back to the vector path.
+  Hybrid runs both queries (pull `candidate_pool` each), fuses, and returns the top
+  **`fetch_k`** — which is `RAG_CANDIDATE_POOL` when rerank is enabled (the reranker then
+  narrows to `k`), else `k`. On a missing `tsvector` column or any FTS error, log + fall back
+  to the vector path (also honoring `fetch_k`).
 - **Rejected:** a BM25 extension / external search engine — Postgres FTS is built-in and
   reuses the existing table + connection.
 
@@ -69,9 +73,13 @@ revisit later.
   pairs with a **CPU cross-encoder** (`sentence-transformers` `CrossEncoder`, default
   `cross-encoder/ms-marco-MiniLM-L-6-v2`), returning the top `k`. The model is **lazy-loaded**
   and cached (mirrors `embeddings._get_model`).
-- **Wiring:** when `RAG_RERANK_ENABLED` (default true), `retrieve()` returns a pool of
-  `RAG_CANDIDATE_POOL` (default 16) candidates and reranks to `k`. Any error (no model, no
-  torch, inference failure) → return the pre-rerank top-`k`.
+- **Wiring:** when `RAG_RERANK_ENABLED` (**default false** — opt-in), `retrieve()` fetches a
+  pool of `RAG_CANDIDATE_POOL` (default 16) candidates (hybrid or vector) and reranks to `k`.
+  Default-off is deliberate: the scale-to-zero CPU container would otherwise download the
+  ~80 MB cross-encoder and run inference on the **first** score-fit after every cold start,
+  on the user's request path. Off by default keeps prod on vector/hybrid; rerank is the
+  opt-in quality lever (and the eval in §6 measures it regardless of the default). Any error
+  (no model, no torch, inference failure) → return the pre-rerank top-`k`.
 - **No new dep:** `CrossEncoder` is part of `sentence-transformers` (already in
   `requirements-rag.txt`); only a model download at runtime.
 - **Rejected:** LLM-as-reranker (slower, token cost, trips the budget guard).
@@ -81,8 +89,23 @@ revisit later.
 - **`evals/retrieval.py`** (+ a `--retrieval-modes` path in `run.py`): for each mode in
   `off` / `vector` / `hybrid` / `hybrid+rerank`, build each fit-score row's
   `retrieved_context` via the **real retriever** under that mode (ingest the sample resume →
-  retrieve per JD), run the existing fit-score scoring + Ragas, and collect
-  context-recall / faithfulness / answer-relevancy / fit-vs-label Spearman.
+  retrieve per JD), run the fit-score scoring + Ragas, and collect context-recall /
+  faithfulness / answer-relevancy / fit-vs-label Spearman.
+- **Seam (note):** today's `run_fit_score_eval` hard-codes `contexts = chunk_text(resume_text)`
+  (the *whole* chunked resume) and grounds Ragas faithfulness in `[*contexts, JD]`. Q must
+  refactor it to accept an injected `retrieved_context` (a `contexts` arg / context-builder)
+  so each mode supplies its own; the sweep is **not** a no-op reuse. List `run.py` as modified.
+- **Exact per-mode payload (avoid a context-volume artifact):** `off` = JD only, no resume
+  evidence (`retrieved_context=[]`); `vector`/`hybrid`/`hybrid+rerank` = the **top-k retrieved
+  chunks** (not the whole resume). Ragas `retrieved_contexts` per mode = the mode's
+  `retrieved_context` (+ the JD, as today). Because `off`/today's baseline dumps the whole
+  resume while the retrieval modes pass only top-k, context-recall may *drop* even as
+  precision/faithfulness rise — the report must show all four metrics per mode, not a single
+  headline, so the trade-off is visible.
+- **DB precondition:** `hybrid`/`hybrid+rerank` silently fall back to vector-only when the
+  `chunk_tsv` column is absent (§4). The sweep must **assert `chunk_tsv` / `embeddings_tsv_idx`
+  exist** before reporting hybrid numbers (else warn + mark the mode N/A), so a 003-but-not-007
+  DB can't produce a silently-bogus `hybrid ≈ vector` comparison in `EVALS.md`.
 - **Report:** a per-mode comparison table (markdown + JSON) showing the deltas; the numbers
   from a real keyed + DB run are recorded in `EVALS.md`.
 - **Skip:** needs a DB (pgvector + FTS) **and** a provider; absent either, it skips cleanly
@@ -92,9 +115,10 @@ revisit later.
 ## 7. Cross-cutting
 
 - **Config (`config.py` + `.env.example`, defaults shown):** `RAG_RETRIEVAL_MODE=hybrid`,
-  `RAG_RERANK_ENABLED=true`, `RAG_RERANK_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2`,
-  `RAG_CANDIDATE_POOL=16`. All optional; defaults give the improved pipeline, and each can be
-  turned off to fall back.
+  `RAG_RERANK_ENABLED=false`, `RAG_RERANK_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2`,
+  `RAG_CANDIDATE_POOL=16`. All optional; the default pipeline is **hybrid retrieval** (cheap,
+  pure-Postgres), with the reranker an opt-in lever (off by default to avoid cold-start CPU
+  latency on the request path — see §5).
 - **Testing:** O — RRF fusion (pure) + the hybrid `retrieve` path with a fake DB cursor;
   P — `rerank` with a fake CrossEncoder (ordering) + the graceful-skip path; Q — the
   mode-sweep aggregation with a fake retriever + fake scorer. All key-free / DB-free via

--- a/docs/superpowers/specs/2026-06-17-phase4-hybrid-rag-reranker-design.md
+++ b/docs/superpowers/specs/2026-06-17-phase4-hybrid-rag-reranker-design.md
@@ -1,0 +1,121 @@
+# Design — Phase 4: hybrid retrieval, reranker & retrieval eval
+
+**Date:** 2026-06-17
+**Status:** Approved (design accepted; scope: hybrid retrieval + cross-encoder reranker + downstream retrieval eval. **Fine-tuning deferred** — infra-constrained. Balanced portfolio-signal / prod-hardening driver.)
+**Part of:** the "Production-grade AI" program (epic #43). Phases 1–3 shipped. This spec covers **Phase 4 only**.
+
+## 1. Why
+
+Retrieval quality is the foundation of grounded fit scoring (Phase 10 RAG). Phase 4 raises
+it with two standard, well-understood upgrades — **hybrid search** (dense + lexical) and a
+**cross-encoder reranker** — and **measures** the gain with the existing eval harness so the
+improvement is evidence-based, not assumed. Both drivers weigh equally: credible in the
+portfolio (real retrieval engineering) and a real quality lift in the live app.
+
+Fine-tuning (the third deferred item) is intentionally **out of scope**: it needs labeled
+training data and GPU training infra the CPU-only Azure-for-Students deployment can't host;
+revisit later.
+
+## 2. Goals / non-goals
+
+**Goals**
+- **O** — Hybrid retrieval: add Postgres full-text (lexical) search beside the current
+  pgvector (dense) search and fuse the rankings (Reciprocal Rank Fusion).
+- **P** — Reranker: re-score a larger candidate pool with a CPU cross-encoder and keep the
+  best `k`.
+- **Q** — Retrieval eval: compare `off` / `vector` / `hybrid` / `hybrid+rerank` on the
+  existing fit-score gold set and report the deltas.
+
+**Non-goals (deferred / out)**
+- **Fine-tuning** embeddings or the LLM (Phase 4 originally, now deferred — infra).
+- A new retrieval gold set / recall@k labeling (we use the **downstream delta** instead).
+- IaC / e2e / caching / load test (Phase 5).
+- Swapping the embedding model or vector store (keep MiniLM + pgvector).
+
+## 3. Success criteria (acceptance)
+1. With `RAG_RETRIEVAL_MODE=hybrid`, `retrieve()` fuses dense (cosine) + lexical (FTS)
+   rankings via RRF and returns the top `k`; with `vector` it behaves as today. An
+   un-migrated DB or an FTS error **falls back to vector-only** — retrieval never breaks.
+2. With `RAG_RERANK_ENABLED=true`, retrieval pulls a larger pool (`RAG_CANDIDATE_POOL`) and a
+   cross-encoder reranks it to the top `k`; any reranker load/inference error returns the
+   pre-rerank top-k. User-scoping and source filters hold throughout.
+3. `python -m evals.run` (or a dedicated entrypoint) can run the fit-score eval across
+   retrieval modes and emit a **per-mode comparison** (context-recall / faithfulness /
+   answer-relevancy / fit-vs-label Spearman); it **skips** without a DB or provider.
+4. **No new dependency** (CrossEncoder ships with `sentence-transformers`); the reranker
+   stays in `requirements-rag.txt`, not the lean base.
+5. **Graceful degradation preserved:** no DB → RAG off (as today); no reranker model →
+   pre-rerank results; no provider → evals skip. `npm run check` + agent `pytest`/`ruff` green.
+
+## 4. Workstream O — Hybrid retrieval (`services/agent`)
+
+- **Schema (`db/migrations/007_fts.sql`):** add a generated `tsvector` column on
+  `embeddings` over `chunk_text` (`to_tsvector('english', chunk_text)`) + a **GIN** index.
+  Idempotent (`add column if not exists` / `create index if not exists`).
+- **Lexical query:** `websearch_to_tsquery('english', :query)` ranked by `ts_rank_cd`,
+  with the same `source_type`/`source_id`/`user_id` filters as the dense path.
+- **Fusion (`app/rag/fusion.py`):** **Reciprocal Rank Fusion** — `score(doc) = Σ 1/(k0+rank_i)`
+  over the dense and lexical rank lists (`k0=60`), returning the top `k` by fused score. A
+  pure function, unit-tested.
+- **`retrieve()` mode:** `RAG_RETRIEVAL_MODE` ∈ {`vector`, `hybrid`} (default `hybrid`).
+  Hybrid runs both queries (pull `candidate_pool` each), fuses, returns top `k`. On a missing
+  `tsvector` column or any FTS error, log + fall back to the vector path.
+- **Rejected:** a BM25 extension / external search engine — Postgres FTS is built-in and
+  reuses the existing table + connection.
+
+## 5. Workstream P — Reranker (`services/agent`)
+
+- **`app/rag/rerank.py`:** `rerank(query, chunks, k) -> list[str]` scoring `(query, chunk)`
+  pairs with a **CPU cross-encoder** (`sentence-transformers` `CrossEncoder`, default
+  `cross-encoder/ms-marco-MiniLM-L-6-v2`), returning the top `k`. The model is **lazy-loaded**
+  and cached (mirrors `embeddings._get_model`).
+- **Wiring:** when `RAG_RERANK_ENABLED` (default true), `retrieve()` returns a pool of
+  `RAG_CANDIDATE_POOL` (default 16) candidates and reranks to `k`. Any error (no model, no
+  torch, inference failure) → return the pre-rerank top-`k`.
+- **No new dep:** `CrossEncoder` is part of `sentence-transformers` (already in
+  `requirements-rag.txt`); only a model download at runtime.
+- **Rejected:** LLM-as-reranker (slower, token cost, trips the budget guard).
+
+## 6. Workstream Q — Retrieval eval (downstream delta) (`services/agent/evals`)
+
+- **`evals/retrieval.py`** (+ a `--retrieval-modes` path in `run.py`): for each mode in
+  `off` / `vector` / `hybrid` / `hybrid+rerank`, build each fit-score row's
+  `retrieved_context` via the **real retriever** under that mode (ingest the sample resume →
+  retrieve per JD), run the existing fit-score scoring + Ragas, and collect
+  context-recall / faithfulness / answer-relevancy / fit-vs-label Spearman.
+- **Report:** a per-mode comparison table (markdown + JSON) showing the deltas; the numbers
+  from a real keyed + DB run are recorded in `EVALS.md`.
+- **Skip:** needs a DB (pgvector + FTS) **and** a provider; absent either, it skips cleanly
+  (consistent with the existing eval). The sweep logic is unit-tested with a fake
+  retriever/model (no DB/key).
+
+## 7. Cross-cutting
+
+- **Config (`config.py` + `.env.example`, defaults shown):** `RAG_RETRIEVAL_MODE=hybrid`,
+  `RAG_RERANK_ENABLED=true`, `RAG_RERANK_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2`,
+  `RAG_CANDIDATE_POOL=16`. All optional; defaults give the improved pipeline, and each can be
+  turned off to fall back.
+- **Testing:** O — RRF fusion (pure) + the hybrid `retrieve` path with a fake DB cursor;
+  P — `rerank` with a fake CrossEncoder (ordering) + the graceful-skip path; Q — the
+  mode-sweep aggregation with a fake retriever + fake scorer. All key-free / DB-free via
+  mocks; preserve existing RAG/eval tests.
+- **Docs:** `EVALS.md` retrieval-modes section (with real deltas), ARCHITECTURE RAG update.
+
+## 8. Risks & mitigations
+- **Reranker CPU latency** on the scale-to-zero container → small candidate pool (16), lazy
+  load, toggle off; only affects score-fit, which already calls the LLM.
+- **FTS on un-migrated DBs** → vector-only fallback; migration is idempotent.
+- **Eval needs a DB** → the mode sweep skips without one; numbers captured from a deliberate
+  local/keyed run and documented.
+- **Model download cost** (cross-encoder ~80 MB) → in `requirements-rag.txt`/runtime image
+  only; lazy.
+- **Scope** → three focused, sequential workstreams; each degrades gracefully.
+
+## 9. SDLC / delivery
+This spec → an implementation plan (`writing-plans`) → **GitHub issues**: an **epic**
+("Phase 4 — hybrid retrieval, reranker & retrieval eval") + three **sub-issues**
+(O hybrid, P reranker, Q eval) under a **`Phase 4` milestone** with labels. Each sub-issue is
+its own branch → PR (`Closes #…`) → green CI → **user merges**; **O→P→Q sequential** (shared
+`rag/`+`evals/`). TDD where it fits; `npm run check` + agent `pytest`/`ruff` before each PR.
+Exact APIs (`websearch_to_tsquery`/`ts_rank_cd`, `CrossEncoder`) confirmed via Context7 at
+each workstream's first task.


### PR DESCRIPTION
Planning docs for **Phase 4** of the production-grade AI program (epic #70). No app code — spec + plan only.

## Contents
- **Spec:** `docs/superpowers/specs/2026-06-17-phase4-hybrid-rag-reranker-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-17-phase4-hybrid-rag-reranker.md`

## Scope (three workstreams → three sub-issues)
- **O #67** — Hybrid retrieval: add Postgres FTS beside pgvector and fuse via Reciprocal Rank Fusion (vector-only fallback).
- **P #68** — CPU cross-encoder reranker over a larger candidate pool (ships with sentence-transformers — no new dep; graceful).
- **Q #69** — Retrieval-mode eval: compare off/vector/hybrid/+rerank on the existing fit-score gold set (downstream delta — no new labeling).

**Fine-tuning is deferred** (infra-constrained — CPU-only Azure for Students; needs labeled data + GPU).

## Sequencing
**O → P → Q are sequential** (shared `app/rag/` + `evals/`), each branched off `main` after the prior merges.

Graceful degradation preserved throughout (no DB / no FTS column / no reranker model / no key all degrade cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)