### PR TITLE
feat(rag): Phase 4 · O — hybrid retrieval (pgvector + FTS via RRF)

### DIFF
--- a/db/migrations/007_fts.sql
+++ b/db/migrations/007_fts.sql
@@ -1,0 +1,20 @@
+-- Lexical (full-text) side of hybrid retrieval (Phase 4 · O).
+--
+-- Adds a stored, auto-maintained tsvector of each chunk so we can run a
+-- Postgres full-text query beside the pgvector dense query and fuse the two
+-- with Reciprocal Rank Fusion (see app/rag/store.py + app/rag/fusion.py).
+--
+-- The two-argument to_tsvector('english', ...) pins the text-search config so
+-- the GIN index stays consistent regardless of default_text_search_config, and
+-- queries must use the same config (websearch_to_tsquery('english', ...)).
+--
+-- Idempotent: db:init replays every migration on each run, and the GENERATED
+-- column requires Postgres >= 12 (the pgvector image is PG 16+). The GIN build
+-- briefly locks the table for writes -- fine at portfolio scale, same as 003's
+-- HNSW index.
+
+alter table embeddings
+  add column if not exists chunk_tsv tsvector
+  generated always as (to_tsvector('english', chunk_text)) stored;
+
+create index if not exists embeddings_tsv_idx on embeddings using gin (chunk_tsv);

--- a/services/agent/app/config.py
+++ b/services/agent/app/config.py
@@ -68,5 +68,9 @@ class Settings(BaseSettings):
     # Unset → the research agent uses the built-in Tavily web_search tool.
     mcp_client_servers: str | None = None
 
+    # RAG retrieval (Phase 4 · O). mode: "vector" (dense only) or "hybrid" (dense + FTS via RRF).
+    rag_retrieval_mode: str = "hybrid"
+    rag_candidate_pool: int = 16  # candidates pulled per side before fusion / rerank
+
 
 settings = Settings()

--- a/services/agent/app/config.py
+++ b/services/agent/app/config.py
@@ -7,6 +7,8 @@ reads ``LLM_PROVIDER``. Mirrors the names already used in the repo root
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -69,7 +71,9 @@ class Settings(BaseSettings):
     mcp_client_servers: str | None = None
 
     # RAG retrieval (Phase 4 · O). mode: "vector" (dense only) or "hybrid" (dense + FTS via RRF).
-    rag_retrieval_mode: str = "hybrid"
+    # Literal so a typo (e.g. RAG_RETRIEVAL_MODE=hibrid) fails loud at startup rather than
+    # silently falling through to vector-only.
+    rag_retrieval_mode: Literal["vector", "hybrid"] = "hybrid"
     rag_candidate_pool: int = 16  # candidates pulled per side before fusion / rerank
 
 

--- a/services/agent/app/rag/fusion.py
+++ b/services/agent/app/rag/fusion.py
@@ -1,0 +1,30 @@
+"""Reciprocal Rank Fusion for hybrid retrieval (Phase 4 · O).
+
+Pure, dependency-free: fuses several ranked id lists (e.g. a dense pgvector
+ranking and a lexical full-text ranking) into one combined ordering.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def reciprocal_rank_fusion(
+    rankings: Sequence[Sequence[str]], top_k: int, k0: int = 60
+) -> list[str]:
+    """Fuse ranked id lists by Reciprocal Rank Fusion: score(id) = Σ 1/(k0+rank).
+
+    ``top_k`` is required so a caller can never silently truncate to a hidden
+    default; production passes the desired fetch size explicitly. ``k0`` damps
+    the contribution of low ranks (the standard RRF constant).
+    """
+    scores: dict[str, float] = {}
+    for ranking in rankings:
+        seen: set[str] = set()
+        for rank, doc_id in enumerate(ranking):
+            if doc_id in seen:
+                continue
+            seen.add(doc_id)
+            scores[doc_id] = scores.get(doc_id, 0.0) + 1.0 / (k0 + rank)
+    ordered = sorted(scores, key=lambda d: scores[d], reverse=True)
+    return ordered[:top_k]

--- a/services/agent/app/rag/store.py
+++ b/services/agent/app/rag/store.py
@@ -15,6 +15,7 @@ from app.config import settings
 from app.obs import traced_span
 from app.rag.chunk import chunk_text
 from app.rag.embeddings import embed_query, embed_texts
+from app.rag.fusion import reciprocal_rank_fusion
 
 logger = logging.getLogger("jobops.agent.rag")
 
@@ -79,15 +80,58 @@ def ingest_document(
     return len(chunks)
 
 
+def _dense_candidates(
+    cur, query_literal: str, n: int, where_sql: str, where_params: list[object]
+) -> list[tuple[str, str]]:
+    """Top-``n`` (id, chunk_text) by cosine distance (the pgvector dense side)."""
+    sql = (
+        f"select id, chunk_text from embeddings {where_sql} "
+        "order by embedding <=> %s::vector limit %s"
+    )
+    cur.execute(sql, [*where_params, query_literal, n])
+    return cur.fetchall()
+
+
+def _lexical_candidates(
+    cur, query: str, n: int, where_sql: str, where_params: list[object]
+) -> list[tuple[str, str]]:
+    """Top-``n`` (id, chunk_text) by full-text rank (the Postgres FTS lexical side).
+
+    Raises if the ``chunk_tsv`` column is absent (caller falls back to dense). An
+    all-stopword / unparseable query yields an *empty* tsquery that matches zero
+    rows **without** raising -- that is expected, and RRF simply degrades to the
+    dense ranking; only real errors trigger the vector fallback.
+    """
+    fts_match = "chunk_tsv @@ websearch_to_tsquery('english', %s)"
+    where = (where_sql + " and " + fts_match) if where_sql else ("where " + fts_match)
+    sql = (
+        f"select id, chunk_text from embeddings {where} "
+        "order by ts_rank_cd(chunk_tsv, websearch_to_tsquery('english', %s)) desc limit %s"
+    )
+    cur.execute(sql, [*where_params, query, query, n])
+    return cur.fetchall()
+
+
 def retrieve(
     query: str,
     k: int = 4,
     source_type: str | None = None,
     source_id: str | None = None,
     user_id: str | None = None,
+    mode: str | None = None,
 ) -> list[str]:
-    """Return the ``k`` most similar chunk texts (cosine distance)."""
-    with traced_span("rag.retrieve", query=query[:200], k=k, source_type=source_type) as span:
+    """Return the ``k`` chunk texts most relevant to ``query``.
+
+    ``mode`` (default ``settings.rag_retrieval_mode``): ``"vector"`` uses dense
+    cosine similarity only; ``"hybrid"`` pulls a candidate pool from the dense and
+    lexical (FTS) sides and fuses them with Reciprocal Rank Fusion, falling back to
+    vector-only if the lexical query fails (e.g. the ``chunk_tsv`` column is absent).
+    """
+    mode = mode or settings.rag_retrieval_mode
+    fetch_k = k  # how many to return; P2 raises this to a pool when reranking is on
+    with traced_span(
+        "rag.retrieve", query=query[:200], k=k, mode=mode, source_type=source_type
+    ) as span:
         query_literal = _vector_literal(embed_query(query))
 
         conditions: list[str] = []
@@ -103,15 +147,29 @@ def retrieve(
             params.append(user_id)
         where_sql = ("where " + " and ".join(conditions)) if conditions else ""
 
-        sql = (
-            f"select chunk_text from embeddings {where_sql} "
-            "order by embedding <=> %s::vector limit %s"
-        )
-        params.extend([query_literal, k])
-
         with _connect() as conn, conn.cursor() as cur:
-            cur.execute(sql, params)
-            chunks = [row[0] for row in cur.fetchall()]
+            if mode == "hybrid":
+                pool = settings.rag_candidate_pool
+                dense = _dense_candidates(cur, query_literal, pool, where_sql, params)
+                texts = {row[0]: row[1] for row in dense}
+                try:
+                    lexical = _lexical_candidates(cur, query, pool, where_sql, params)
+                    for row in lexical:
+                        texts.setdefault(row[0], row[1])
+                    fused = reciprocal_rank_fusion(
+                        [[row[0] for row in dense], [row[0] for row in lexical]],
+                        top_k=fetch_k,
+                    )
+                    chunks = [texts[doc_id] for doc_id in fused]
+                except Exception:  # noqa: BLE001 - lexical side is best-effort
+                    logger.warning(
+                        "Lexical retrieval unavailable; falling back to vector-only",
+                        exc_info=True,
+                    )
+                    chunks = [row[1] for row in dense[:fetch_k]]
+            else:
+                dense = _dense_candidates(cur, query_literal, fetch_k, where_sql, params)
+                chunks = [row[1] for row in dense]
 
         if span is not None:
             span.update(output={"chunk_count": len(chunks)})

--- a/services/agent/tests/test_fusion.py
+++ b/services/agent/tests/test_fusion.py
@@ -1,0 +1,25 @@
+from app.rag.fusion import reciprocal_rank_fusion
+
+
+def test_rrf_rewards_agreement_across_rankings():
+    # "b" is rank-0 in BOTH lists, so it wins unambiguously (no exact tie to depend on
+    # insertion order). "a" appears in both but lower; "c"/"d" appear once.
+    dense = ["b", "a", "c"]
+    lexical = ["b", "a", "d"]
+    result = reciprocal_rank_fusion([dense, lexical], top_k=3)
+    assert result[0] == "b"
+    assert set(result) == {"b", "a", "c"} or set(result) == {"b", "a", "d"}
+    assert result.index("a") < result.index(result[-1])  # "a" beats the single-list tail
+
+
+def test_rrf_handles_empty_and_dedup():
+    assert reciprocal_rank_fusion([[], ["x", "x"]], top_k=2) == ["x"]
+
+
+def test_rrf_top_k_is_required():
+    # Refinement: top_k is a required arg so a caller can never silently truncate
+    # to a hidden default (production always passes fetch_k explicitly).
+    import pytest
+
+    with pytest.raises(TypeError):
+        reciprocal_rank_fusion([["a", "b"]])

--- a/services/agent/tests/test_rag.py
+++ b/services/agent/tests/test_rag.py
@@ -39,3 +39,90 @@ def test_vector_literal_formats_pgvector():
 def test_rag_unavailable_without_database(monkeypatch):
     monkeypatch.setattr(store.settings, "database_url", None)
     assert store.rag_available() is False
+
+
+# --- hybrid retrieval (Phase 4 · O3) -------------------------------------------------
+
+DENSE_ROWS = [("1", "dense-a"), ("2", "shared-b"), ("3", "shared-c")]
+LEXICAL_ROWS = [("2", "shared-b"), ("3", "shared-c"), ("4", "lex-d")]
+
+
+class _FakeCursor:
+    """Records executed SQL and returns canned rows for the dense vs lexical query."""
+
+    def __init__(self, dense_rows, lexical_rows, lexical_error=False):
+        self._dense = dense_rows
+        self._lexical = lexical_rows
+        self._lexical_error = lexical_error
+        self.queries: list[str] = []
+        self._last: list[tuple[str, str]] = []
+        self._limit: int | None = None
+
+    def execute(self, sql, params=None):
+        self.queries.append(sql)
+        self._limit = params[-1] if params else None  # the trailing `limit %s`
+        if "websearch_to_tsquery" in sql:
+            if self._lexical_error:
+                raise RuntimeError("column chunk_tsv does not exist")
+            self._last = self._lexical
+        else:
+            self._last = self._dense
+
+    def fetchall(self):
+        return self._last[: self._limit] if self._limit is not None else self._last
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _patch_store(monkeypatch, cursor):
+    monkeypatch.setattr(store, "embed_query", lambda _q: [0.0, 0.0, 0.0])
+    monkeypatch.setattr(store, "_connect", lambda: _FakeConn(cursor))
+
+
+def test_hybrid_retrieve_fuses_dense_and_lexical(monkeypatch):
+    cursor = _FakeCursor(DENSE_ROWS, LEXICAL_ROWS)
+    _patch_store(monkeypatch, cursor)
+    # "2"/"3" rank highly in both lists, so RRF surfaces them above the singletons.
+    assert store.retrieve("python backend", k=2, mode="hybrid") == ["shared-b", "shared-c"]
+    assert any("websearch_to_tsquery" in q for q in cursor.queries)  # lexical side ran
+
+
+def test_hybrid_falls_back_to_vector_when_lexical_errors(monkeypatch):
+    cursor = _FakeCursor(DENSE_ROWS, LEXICAL_ROWS, lexical_error=True)
+    _patch_store(monkeypatch, cursor)
+    # Missing chunk_tsv column -> lexical raises -> dense top-k returned, no crash.
+    assert store.retrieve("python backend", k=2, mode="hybrid") == ["dense-a", "shared-b"]
+
+
+def test_hybrid_empty_lexical_degrades_to_dense(monkeypatch):
+    # Refinement #2: an all-stopword query yields an empty tsquery matching zero rows
+    # WITHOUT raising; RRF then degrades to the dense ranking (not the error path).
+    cursor = _FakeCursor(DENSE_ROWS, [])
+    _patch_store(monkeypatch, cursor)
+    assert store.retrieve("the a of", k=2, mode="hybrid") == ["dense-a", "shared-b"]
+    assert any("websearch_to_tsquery" in q for q in cursor.queries)  # it ran, didn't error
+
+
+def test_vector_mode_skips_lexical(monkeypatch):
+    cursor = _FakeCursor(DENSE_ROWS, LEXICAL_ROWS)
+    _patch_store(monkeypatch, cursor)
+    assert store.retrieve("python backend", k=2, mode="vector") == ["dense-a", "shared-b"]
+    assert not any("websearch_to_tsquery" in q for q in cursor.queries)  # lexical skipped

--- a/services/agent/tests/test_rag.py
+++ b/services/agent/tests/test_rag.py
@@ -55,11 +55,13 @@ class _FakeCursor:
         self._lexical = lexical_rows
         self._lexical_error = lexical_error
         self.queries: list[str] = []
+        self.calls: list[tuple[str, list]] = []  # (sql, params) for binding assertions
         self._last: list[tuple[str, str]] = []
         self._limit: int | None = None
 
     def execute(self, sql, params=None):
         self.queries.append(sql)
+        self.calls.append((sql, list(params) if params else []))
         self._limit = params[-1] if params else None  # the trailing `limit %s`
         if "websearch_to_tsquery" in sql:
             if self._lexical_error:
@@ -126,3 +128,26 @@ def test_vector_mode_skips_lexical(monkeypatch):
     _patch_store(monkeypatch, cursor)
     assert store.retrieve("python backend", k=2, mode="vector") == ["dense-a", "shared-b"]
     assert not any("websearch_to_tsquery" in q for q in cursor.queries)  # lexical skipped
+
+
+def test_hybrid_scoping_flows_into_lexical_query(monkeypatch):
+    # Highest-stakes guarantee: tenant/source filters must reach the LEXICAL side too,
+    # or one user could retrieve another's chunks via full-text search.
+    cursor = _FakeCursor(DENSE_ROWS, LEXICAL_ROWS)
+    _patch_store(monkeypatch, cursor)
+    store.retrieve(
+        "python backend",
+        k=2,
+        mode="hybrid",
+        source_type="resume",
+        source_id="resume-x",
+        user_id="u1",
+    )
+    lexical_sql, lexical_params = next(
+        (sql, params) for sql, params in cursor.calls if "websearch_to_tsquery" in sql
+    )
+    assert "user_id = %s" in lexical_sql
+    # Scoping binds precede the two tsquery binds, which precede the limit.
+    assert lexical_params[:3] == ["resume", "resume-x", "u1"]
+    assert lexical_params[3] == "python backend" and lexical_params[4] == "python backend"
+    assert lexical_params[-1] == store.settings.rag_candidate_pool  # pool, then RRF to k


### PR DESCRIPTION
## Summary
Workstream **O** of Phase 4 (epic #70): adds a **lexical (full-text) side** to RAG retrieval beside the existing pgvector dense search and fuses the two with **Reciprocal Rank Fusion**, behind `RAG_RETRIEVAL_MODE` (defaults to `hybrid`).

- **`db/migrations/007_fts.sql`** — stored, auto-maintained `chunk_tsv` (`to_tsvector('english', chunk_text)`) on `embeddings` + GIN index. Idempotent; verified applied (`chunk_tsv` GENERATED ALWAYS + `embeddings_tsv_idx` present).
- **`app/rag/fusion.py`** — pure `reciprocal_rank_fusion(rankings, top_k, k0=60)`. `top_k` is **required** (no hidden default that could silently truncate).
- **`app/rag/store.py`** — `retrieve()` split into `_dense_candidates` + `_lexical_candidates`; hybrid pulls `rag_candidate_pool` per side and fuses to `k`. **Graceful:** lexical error (e.g. missing `chunk_tsv`) → vector-only fallback; an empty tsquery just degrades RRF to the dense ranking without raising.
- **`app/config.py`** — `rag_retrieval_mode` (`hybrid`), `rag_candidate_pool` (`16`).

Includes two review refinements from the planning PR (#71): RRF `top_k` made required, and explicit empty-tsquery handling + test.

## Test Plan
- [x] `pytest` (agent suite green, incl. new `test_fusion.py` + hybrid/fallback/empty-lexical/vector-mode cases in `test_rag.py`)
- [x] `ruff check app tests` clean
- [x] `npm run check` (web + api build, types, lint) green
- [x] Migration 007 applied + verified against the dev DB
- [ ] Reviewer confirms degradation paths (no FTS column → vector-only)

Closes #67. Sequenced before P (#68) and Q (#69), which branch off `main` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)