### PR TITLE
feat(rag): Phase 4 · P — CPU cross-encoder reranker

### DIFF
--- a/services/agent/.env.example
+++ b/services/agent/.env.example
@@ -23,6 +23,15 @@ GEMINI_MODEL=gemini-2.0-flash
 # RAG (Phase 10) — reuse the same Postgres as the Node API
 DATABASE_URL=
 
+# RAG retrieval tuning (Phase 4). Defaults shown; all optional.
+# RAG_RETRIEVAL_MODE: "hybrid" (dense pgvector + Postgres FTS via RRF) or "vector" (dense only).
+RAG_RETRIEVAL_MODE=hybrid
+RAG_CANDIDATE_POOL=16
+# RAG_RERANK_ENABLED: opt-in CPU cross-encoder rerank of the candidate pool (downloads the
+# model on first use). Off by default to keep the first score-fit request fast.
+RAG_RERANK_ENABLED=false
+RAG_RERANK_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+
 # Research agent web search (Phase 8, optional)
 TAVILY_API_KEY=
 

--- a/services/agent/app/config.py
+++ b/services/agent/app/config.py
@@ -76,5 +76,11 @@ class Settings(BaseSettings):
     rag_retrieval_mode: Literal["vector", "hybrid"] = "hybrid"
     rag_candidate_pool: int = 16  # candidates pulled per side before fusion / rerank
 
+    # CPU cross-encoder reranker (Phase 4 · P). Opt-in: off by default to avoid a cold-start
+    # model download + CPU inference on the first score-fit request. When on, retrieve() reranks
+    # the candidate pool down to k. CrossEncoder ships with sentence-transformers (no new dep).
+    rag_rerank_enabled: bool = False
+    rag_rerank_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
 
 settings = Settings()

--- a/services/agent/app/rag/rerank.py
+++ b/services/agent/app/rag/rerank.py
@@ -1,0 +1,45 @@
+"""CPU cross-encoder reranker for hybrid retrieval (Phase 4 · P).
+
+Re-scores (query, chunk) pairs with a small cross-encoder so the most relevant
+candidates from the fused dense+lexical pool float to the top. The model is
+loaded lazily and cached (mirrors ``app/rag/embeddings.py``) and ``torch`` is
+only imported on first use, so CI stays light. Reranking is best-effort: any
+failure returns the pre-rerank order so the request path never breaks.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+
+from app.config import settings
+
+logger = logging.getLogger("jobops.agent.rag")
+
+
+@lru_cache(maxsize=1)
+def _get_model():
+    from sentence_transformers import CrossEncoder  # lazy: pulls torch
+
+    return CrossEncoder(settings.rag_rerank_model)
+
+
+def rerank(query: str, chunks: list[str], k: int) -> list[str]:
+    """Re-score (query, chunk) pairs with a CPU cross-encoder; return the top k.
+
+    Any failure (model unavailable, no network, inference error) returns the
+    first k chunks unchanged (graceful)."""
+    if not chunks:
+        return chunks
+    try:
+        scores = _get_model().predict([(query, chunk) for chunk in chunks])
+        ranked = [
+            chunk
+            for _score, chunk in sorted(
+                zip(scores, chunks, strict=False), key=lambda pair: pair[0], reverse=True
+            )
+        ]
+        return ranked[:k]
+    except Exception:  # noqa: BLE001 - reranking is best-effort
+        logger.warning("Rerank unavailable; returning pre-rerank order", exc_info=True)
+        return chunks[:k]

--- a/services/agent/app/rag/store.py
+++ b/services/agent/app/rag/store.py
@@ -126,9 +126,14 @@ def retrieve(
     cosine similarity only; ``"hybrid"`` pulls a candidate pool from the dense and
     lexical (FTS) sides and fuses them with Reciprocal Rank Fusion, falling back to
     vector-only if the lexical query fails (e.g. the ``chunk_tsv`` column is absent).
+
+    When ``settings.rag_rerank_enabled`` is set, a larger pool is fetched and a CPU
+    cross-encoder reranks it down to ``k`` (best-effort; pre-rerank order on failure).
     """
     mode = mode or settings.rag_retrieval_mode
-    fetch_k = k  # how many to return; P2 raises this to a pool when reranking is on
+    # When reranking, fetch a real pool so the reranker has candidates to reorder;
+    # otherwise return exactly k. (max() guards a pool smaller than k.)
+    fetch_k = max(k, settings.rag_candidate_pool) if settings.rag_rerank_enabled else k
     with traced_span(
         "rag.retrieve", query=query[:200], k=k, mode=mode, source_type=source_type
     ) as span:
@@ -170,6 +175,11 @@ def retrieve(
             else:
                 dense = _dense_candidates(cur, query_literal, fetch_k, where_sql, params)
                 chunks = [row[1] for row in dense]
+
+        if settings.rag_rerank_enabled:
+            from app.rag.rerank import rerank  # lazy: keeps torch out of the import path
+
+            chunks = rerank(query, chunks, k)
 
         if span is not None:
             span.update(output={"chunk_count": len(chunks)})

--- a/services/agent/tests/test_rag.py
+++ b/services/agent/tests/test_rag.py
@@ -195,3 +195,41 @@ def test_rerank_disabled_fetches_k_and_skips_rerank(monkeypatch):
     result = store.retrieve("python backend", k=2, mode="vector")
     assert cursor.calls[0][1][-1] == 2  # fetch_k == k
     assert result == ["dense-a", "shared-b"]
+
+
+def test_rerank_in_hybrid_mode_reranks_the_fused_pool(monkeypatch):
+    import app.rag.rerank as rerank_mod
+
+    cursor = _FakeCursor(DENSE_ROWS, LEXICAL_ROWS)
+    _patch_store(monkeypatch, cursor)
+    monkeypatch.setattr(store.settings, "rag_rerank_enabled", True)
+    monkeypatch.setattr(store.settings, "rag_candidate_pool", 16)
+
+    captured = {}
+
+    def fake_rerank(query, chunks, k):
+        captured["pool"] = list(chunks)
+        return list(reversed(chunks))[:k]
+
+    monkeypatch.setattr(rerank_mod, "rerank", fake_rerank)
+
+    result = store.retrieve("python backend", k=2, mode="hybrid")
+    # Both sides pulled with limit == pool (16), then RRF fuses to fetch_k (also 16),
+    # so the reranker sees the *fused* candidates, not a dense-only or k-collapsed set.
+    assert all(call[1][-1] == 16 for call in cursor.calls)
+    assert set(captured["pool"]) == {"dense-a", "shared-b", "shared-c", "lex-d"}
+    assert result == list(reversed(captured["pool"]))[:2]
+
+
+def test_rerank_with_k_larger_than_pool(monkeypatch):
+    import app.rag.rerank as rerank_mod
+
+    cursor = _FakeCursor(DENSE_ROWS, LEXICAL_ROWS)
+    _patch_store(monkeypatch, cursor)
+    monkeypatch.setattr(store.settings, "rag_rerank_enabled", True)
+    monkeypatch.setattr(store.settings, "rag_candidate_pool", 4)
+    monkeypatch.setattr(rerank_mod, "rerank", lambda _q, chunks, k: chunks[:k])
+
+    # max(k, pool) guard: k=10 > pool=4 -> fetch_k == 10, never below k.
+    store.retrieve("python backend", k=10, mode="vector")
+    assert cursor.calls[0][1][-1] == 10

--- a/services/agent/tests/test_rag.py
+++ b/services/agent/tests/test_rag.py
@@ -151,3 +151,47 @@ def test_hybrid_scoping_flows_into_lexical_query(monkeypatch):
     assert lexical_params[:3] == ["resume", "resume-x", "u1"]
     assert lexical_params[3] == "python backend" and lexical_params[4] == "python backend"
     assert lexical_params[-1] == store.settings.rag_candidate_pool  # pool, then RRF to k
+
+
+# --- reranker wiring (Phase 4 · P2) --------------------------------------------------
+
+
+def test_rerank_enabled_fetches_pool_then_reranks_to_k(monkeypatch):
+    import app.rag.rerank as rerank_mod
+
+    cursor = _FakeCursor(DENSE_ROWS, LEXICAL_ROWS)
+    _patch_store(monkeypatch, cursor)
+    monkeypatch.setattr(store.settings, "rag_rerank_enabled", True)
+    monkeypatch.setattr(store.settings, "rag_candidate_pool", 16)
+
+    captured = {}
+
+    def fake_rerank(query, chunks, k):
+        captured["pool"] = list(chunks)  # what the reranker actually saw
+        return list(reversed(chunks))[:k]
+
+    monkeypatch.setattr(rerank_mod, "rerank", fake_rerank)
+
+    result = store.retrieve("python backend", k=2, mode="vector")
+    # Pool, not k: dense was fetched with limit == max(k, pool) == 16 so the reranker
+    # gets real candidates (otherwise hybrid/rerank benefit collapses before reranking).
+    assert cursor.calls[0][1][-1] == 16
+    assert captured["pool"] == ["dense-a", "shared-b", "shared-c"]
+    assert result == ["shared-c", "shared-b"]  # reversed top-2
+
+
+def test_rerank_disabled_fetches_k_and_skips_rerank(monkeypatch):
+    import app.rag.rerank as rerank_mod
+
+    cursor = _FakeCursor(DENSE_ROWS, LEXICAL_ROWS)
+    _patch_store(monkeypatch, cursor)
+    monkeypatch.setattr(store.settings, "rag_rerank_enabled", False)
+
+    def boom(*_a, **_k):
+        raise AssertionError("rerank must not be called when disabled")
+
+    monkeypatch.setattr(rerank_mod, "rerank", boom)
+
+    result = store.retrieve("python backend", k=2, mode="vector")
+    assert cursor.calls[0][1][-1] == 2  # fetch_k == k
+    assert result == ["dense-a", "shared-b"]

--- a/services/agent/tests/test_rerank.py
+++ b/services/agent/tests/test_rerank.py
@@ -1,0 +1,33 @@
+"""Reranker tests — run without the model or torch (CI-safe via a fake model)."""
+
+from app.rag import rerank as rerank_mod
+from app.rag.rerank import rerank
+
+
+class _FakeModel:
+    """Stands in for a CrossEncoder: returns a fixed score per chunk."""
+
+    def __init__(self, scores: dict[str, float]):
+        self._scores = scores
+
+    def predict(self, pairs):
+        return [self._scores[chunk] for _query, chunk in pairs]
+
+
+def test_rerank_orders_by_score_and_truncates(monkeypatch):
+    model = _FakeModel({"a": 0.1, "b": 0.9, "c": 0.5})
+    monkeypatch.setattr(rerank_mod, "_get_model", lambda: model)
+    assert rerank("q", ["a", "b", "c"], k=2) == ["b", "c"]
+
+
+def test_rerank_graceful_when_model_unavailable(monkeypatch):
+    def boom():
+        raise RuntimeError("no model / no network")
+
+    monkeypatch.setattr(rerank_mod, "_get_model", boom)
+    # Any failure returns the first k chunks unchanged (pre-rerank order).
+    assert rerank("q", ["a", "b", "c"], k=2) == ["a", "b"]
+
+
+def test_rerank_empty_returns_empty(monkeypatch):
+    assert rerank("q", [], k=3) == []


### PR DESCRIPTION
## Summary
Workstream **P** of Phase 4 (epic #70): adds an opt-in **CPU cross-encoder reranker** that re-scores the fused candidate pool from O and returns the most relevant `k`.

- **`app/rag/rerank.py`** (new) — lazy `@lru_cache` `CrossEncoder` (mirrors `embeddings.py`; `torch` imported only on first use). `rerank(query, chunks, k)` scores `(query, chunk)` pairs and returns the top `k`. **Graceful:** any failure (no model / no network / inference error) returns the pre-rerank order, logged — the request path never breaks.
- **`app/rag/store.py`** — when `RAG_RERANK_ENABLED`, `retrieve()` fetches a **pool** (`fetch_k = max(k, rag_candidate_pool)`) from the vector/hybrid path and reranks it to `k`; otherwise `fetch_k == k` and the path is unchanged. `rerank` is imported lazily so CI without `torch` is unaffected.
- **`app/config.py`** — `rag_rerank_enabled` (default **off** — avoids a cold-start model download + CPU inference on the first score-fit request), `rag_rerank_model` (`cross-encoder/ms-marco-MiniLM-L-6-v2`).

**No new dependency** — `CrossEncoder` ships with the `sentence-transformers` already in `requirements-rag.txt`. Confirmed the `CrossEncoder.predict([(q, doc), ...])` contract via Context7 (P1 Step 0).

## Test Plan
- [x] `pytest` (agent suite **126 passed**): `test_rerank.py` (ordering, graceful fallback, empty) + pool-vs-k wiring + rerank-skipped-when-disabled in `test_rag.py`
- [x] `ruff check app tests` clean
- [x] `npm run check` (web + api build, types, lint) green
- [ ] Reviewer confirms graceful fallback (no model → pre-rerank order) and the pool-not-k seam

Closes #68. Branched off `main` after O (#72) merged; Q (#69) follows after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)