### PR TITLE
feat(evals): Phase 4 · Q — retrieval-mode comparison (downstream delta)

### DIFF
--- a/EVALS.md
+++ b/EVALS.md
@@ -26,6 +26,34 @@ quality measured and gated here.
   Ragas uses an LLM judge plus the agent's existing sentence-transformers embeddings (no
   extra provider needed).
 
+## Retrieval-mode comparison (Phase 4)
+
+Hybrid retrieval (dense pgvector + Postgres FTS via RRF) and the CPU cross-encoder
+reranker are **measured, not assumed**. `evals/retrieval.py` runs the *same*
+fit-score eval under each retrieval mode — only the retrieved evidence changes — so
+the table is a true **downstream delta**:
+
+- **off** — no resume evidence (JD only); the no-retrieval baseline.
+- **vector** — dense pgvector only.
+- **hybrid** — dense + FTS fused via Reciprocal Rank Fusion.
+- **hybrid+rerank** — the hybrid pool reranked by `cross-encoder/ms-marco-MiniLM-L-6-v2`.
+
+```bash
+cd services/agent
+python -m evals.run --retrieval-modes   # writes evals/retrieval_report.{json,md}
+```
+
+Needs **both** a `DATABASE_URL` (with the `chunk_tsv` column + `embeddings_tsv_idx`
+from migration `007_fts.sql`) **and** a provider key; otherwise it writes a skipped
+report and exits 0. Hybrid modes are marked **N/A** (not silently reported as ≈vector)
+when the FTS column/index are absent, so a missing migration can't masquerade as "no
+gain". Because `off`/the default baseline feed the whole resume while retrieval modes
+feed only top-k chunks, **context-recall can fall even as faithfulness/precision rise**
+— read all four columns, not one headline.
+
+> Numbers are produced by a keyed run against the dev DB and committed alongside this
+> file as `services/agent/evals/retrieval_report.json` for auditability.
+
 ## Gold set
 
 - `evals/data/parse_job.jsonl` — 17 real JDs with expected skills / title / seniority.
@@ -61,8 +89,9 @@ and the JD-as-question framing — a known baseline to improve, not a regression
 ```bash
 cd services/agent
 pip install -r requirements-dev.txt -r requirements-evals.txt
-python -m evals.run          # writes evals/report.json + evals/report.md
-python -m evals.run --gate   # also fails (exit 1) if a metric is below threshold
+python -m evals.run               # writes evals/report.json + evals/report.md
+python -m evals.run --gate        # also fails (exit 1) if a metric is below threshold
+python -m evals.run --retrieval-modes  # per-mode retrieval comparison (needs DB + key)
 ```
 
 (`requirements-evals.txt` carries Ragas; it is intentionally **not** in the runtime

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,6 +23,14 @@ CRM and orchestration; a Python service owns the real AI.
 - **RAG on existing infra.** Embeddings live in the same Postgres via `pgvector`
   (`vector(384)`, HNSW cosine). HF `all-MiniLM-L6-v2` (PyTorch) embeds resume/JD
   text; fit scoring is grounded in retrieved resume evidence.
+- **Hybrid retrieval + reranker (Phase 4).** `app/rag/store.py:retrieve()` is the
+  single seam: it fuses the dense pgvector ranking with a Postgres full-text
+  (`tsvector`/`websearch_to_tsquery`) ranking via **Reciprocal Rank Fusion**
+  (`RAG_RETRIEVAL_MODE=hybrid`), then optionally reranks the candidate pool with a
+  CPU cross-encoder (`RAG_RERANK_ENABLED`, off by default). Every stage degrades
+  gracefully — missing FTS column → vector-only, no reranker model → pre-rerank
+  order — so retrieval never breaks the request path. The downstream quality delta
+  across modes is measured in [EVALS.md](../EVALS.md).
 - **Telemetry as a transferable pattern.** One pandas analyzer (trend, moving
   average, z-score anomalies, forecast) powers both the pipeline view and the
   synthetic EV battery-health demo — showing the approach generalizes to vehicle

--- a/services/agent/evals/retrieval.py
+++ b/services/agent/evals/retrieval.py
@@ -71,7 +71,9 @@ def _make_contexts_for(
     retrieval_mode, rerank = _MODE_TOGGLES[mode]
 
     def contexts_for(row: dict) -> list[str]:
-        # retrieve() reads its mode/rerank from settings; toggle per mode.
+        # retrieve() takes mode= but rerank is read from settings, so we toggle both
+        # here. Safe only because this eval is single-process / non-concurrent (a CLI
+        # run); run_retrieval_modes restores the original settings in its finally.
         settings.rag_retrieval_mode = retrieval_mode
         settings.rag_rerank_enabled = rerank
         return retrieve_evidence(resume_text, row["description_text"], k=k)

--- a/services/agent/evals/retrieval.py
+++ b/services/agent/evals/retrieval.py
@@ -1,0 +1,118 @@
+"""Retrieval-mode eval (Phase 4 · Q): the downstream fit-score quality delta.
+
+Runs the existing fit-score eval (rank correlation + Ragas) under each retrieval
+mode and reports a per-mode comparison:
+
+- ``off``           — no resume evidence (JD only); the true no-retrieval baseline.
+- ``vector``        — dense pgvector only.
+- ``hybrid``        — dense + Postgres FTS fused via RRF.
+- ``hybrid+rerank`` — hybrid pool reranked by the CPU cross-encoder.
+
+The point is *downstream delta*: same gold set, same scorer, only the retrieved
+context changes — so we measure what retrieval actually buys the fit score.
+
+Note: ``off`` (and today's default baseline) feed the *whole* resume, while the
+retrieval modes feed only top-k chunks. Context-recall can therefore fall even as
+faithfulness/precision rise — read all four metrics, not one headline.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+
+from app.config import settings
+from app.rag.store import retrieve_resume_evidence
+from evals.run import run_fit_score_eval
+
+logger = logging.getLogger("jobops.evals")
+
+RETRIEVAL_MODES = ("off", "vector", "hybrid", "hybrid+rerank")
+
+# (rag_retrieval_mode, rag_rerank_enabled) toggles for each evidence-bearing mode.
+_MODE_TOGGLES = {
+    "vector": ("vector", False),
+    "hybrid": ("hybrid", False),
+    "hybrid+rerank": ("hybrid", True),
+}
+_FTS_MODES = ("hybrid", "hybrid+rerank")
+
+
+def _fts_ready() -> bool:
+    """True iff the ``chunk_tsv`` column **and** ``embeddings_tsv_idx`` both exist.
+
+    Without them the O3 fallback silently makes hybrid == vector, so we'd report a
+    bogus "no gain". Checking both guards a partial migration (column created but
+    the GIN index build interrupted by the table lock)."""
+    try:
+        from app.rag.store import _connect
+
+        with _connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "select 1 from information_schema.columns "
+                "where table_name = 'embeddings' and column_name = 'chunk_tsv'"
+            )
+            has_col = cur.fetchone() is not None
+            cur.execute("select 1 from pg_indexes where indexname = 'embeddings_tsv_idx'")
+            has_idx = cur.fetchone() is not None
+        return has_col and has_idx
+    except Exception:  # noqa: BLE001 - inability to verify => treat hybrid as unavailable
+        logger.warning("Could not verify FTS readiness; treating hybrid as N/A", exc_info=True)
+        return False
+
+
+def _make_contexts_for(
+    mode: str, resume_text: str, k: int, retrieve_evidence: Callable
+) -> Callable[[dict], list[str]]:
+    """A ``contexts_for(row)`` callable for one retrieval mode."""
+    if mode == "off":
+        return lambda _row: []  # JD only — the true no-retrieval baseline
+
+    retrieval_mode, rerank = _MODE_TOGGLES[mode]
+
+    def contexts_for(row: dict) -> list[str]:
+        # retrieve() reads its mode/rerank from settings; toggle per mode.
+        settings.rag_retrieval_mode = retrieval_mode
+        settings.rag_rerank_enabled = rerank
+        return retrieve_evidence(resume_text, row["description_text"], k=k)
+
+    return contexts_for
+
+
+def run_retrieval_modes(
+    rows: list[dict],
+    resume_text: str,
+    modes: Sequence[str] = RETRIEVAL_MODES,
+    *,
+    k: int = 4,
+    retrieve_evidence: Callable = retrieve_resume_evidence,
+    score_eval: Callable = run_fit_score_eval,
+    fts_ready: Callable[[], bool] = _fts_ready,
+) -> dict[str, dict]:
+    """Run the fit-score eval under each retrieval mode; return ``{mode: metrics}``.
+
+    Hybrid modes are marked ``status="n/a"`` (not silently reported) when the FTS
+    column/index are absent. Mutated retrieval settings are restored afterwards.
+    """
+    results: dict[str, dict] = {}
+    hybrid_ok: bool | None = None  # computed once, lazily
+    original = (settings.rag_retrieval_mode, settings.rag_rerank_enabled)
+    try:
+        for mode in modes:
+            if mode in _FTS_MODES:
+                if hybrid_ok is None:
+                    hybrid_ok = fts_ready()
+                if not hybrid_ok:
+                    logger.warning("FTS column/index absent; marking %s N/A", mode)
+                    results[mode] = {
+                        "status": "n/a",
+                        "reason": "chunk_tsv / embeddings_tsv_idx absent",
+                    }
+                    continue
+            contexts_for = _make_contexts_for(mode, resume_text, k, retrieve_evidence)
+            metrics = score_eval(rows, resume_text, contexts_for=contexts_for)
+            metrics["status"] = "ok"
+            results[mode] = metrics
+    finally:
+        settings.rag_retrieval_mode, settings.rag_rerank_enabled = original
+    return results

--- a/services/agent/evals/run.py
+++ b/services/agent/evals/run.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -118,13 +119,24 @@ def run_parse_job_eval(rows: list[dict]) -> dict:
     }
 
 
-def run_fit_score_eval(rows: list[dict], resume_text: str) -> dict:
-    """Score-fit rank correlation + Ragas faithfulness/relevance/context-recall."""
-    contexts = chunk_text(resume_text)
+def run_fit_score_eval(
+    rows: list[dict],
+    resume_text: str,
+    contexts_for: Callable[[dict], list[str]] | None = None,
+) -> dict:
+    """Score-fit rank correlation + Ragas faithfulness/relevance/context-recall.
+
+    ``contexts_for`` injects the retrieved evidence per row; it defaults to the
+    whole resume chunked (today's behavior). The retrieval-mode sweep
+    (``evals.retrieval``) passes a function that returns each mode's top-k chunks
+    so the same scorer measures every retrieval mode.
+    """
+    contexts_for = contexts_for or (lambda _row: chunk_text(resume_text))
     predicted_scores, gold_labels, ragas_samples = [], [], []
     errors = 0
     for row in rows:
         expected = row["expected"]
+        contexts = contexts_for(row)
         try:
             request = ScoreFitRequest(
                 description_text=row["description_text"],

--- a/services/agent/evals/run.py
+++ b/services/agent/evals/run.py
@@ -247,7 +247,9 @@ def render_retrieval_markdown(report: dict) -> str:
     for mode in report["modes_order"]:
         metrics = report["modes"].get(mode, {})
         if metrics.get("status") == "n/a":
-            lines.append(f"| {mode} | _n/a — {metrics.get('reason')}_ |  |  |  |  |")
+            lines.append(
+                f"| {mode} | _n/a_ | _n/a_ | _n/a_ | _n/a_ | _{metrics.get('reason')}_ |"
+            )
             continue
         ragas = metrics.get("ragas", {})
         lines.append(

--- a/services/agent/evals/run.py
+++ b/services/agent/evals/run.py
@@ -226,6 +226,81 @@ def render_markdown(report: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
+def render_retrieval_markdown(report: dict) -> str:
+    lines = ["# JobOps Copilot — Retrieval-Mode Comparison", ""]
+    lines.append(f"- Generated: `{report['generated_at']}`")
+    lines.append(f"- Judge / model: `{report.get('provider') or 'n/a'}`")
+    if report["status"] != "ok":
+        lines += ["", f"> Skipped: {report.get('skipped_reason')}"]
+        return "\n".join(lines) + "\n"
+
+    lines += [
+        "",
+        "Same gold set + scorer; only the retrieved evidence changes (downstream delta).",
+        "`off` feeds **no** resume evidence (JD only); retrieval modes feed only top-k chunks,",
+        "so context-recall can fall even as faithfulness rises — read all four columns.",
+        "",
+        "| mode | fit-vs-label Spearman | faithfulness | answer relevancy | context recall "
+        "| n (errors) |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for mode in report["modes_order"]:
+        metrics = report["modes"].get(mode, {})
+        if metrics.get("status") == "n/a":
+            lines.append(f"| {mode} | _n/a — {metrics.get('reason')}_ |  |  |  |  |")
+            continue
+        ragas = metrics.get("ragas", {})
+        lines.append(
+            f"| {mode} | {metrics['rank_correlation_spearman']} "
+            f"| {ragas.get('faithfulness')} | {ragas.get('answer_relevancy')} "
+            f"| {ragas.get('context_recall')} | {metrics['n']} ({metrics['errors']}) |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def retrieval_main(output_dir: Path | None = None) -> int:
+    """Entry for ``python -m evals.run --retrieval-modes``: sweep retrieval modes
+    and write a per-mode comparison. Needs both a provider key and a database;
+    otherwise writes a skipped report and exits 0 (CI / key-less runs stay green)."""
+    logging.basicConfig(level=logging.INFO)
+    output_dir = output_dir or Path(__file__).parent
+    generated_at = datetime.now(UTC).isoformat(timespec="seconds")
+
+    from app.rag.store import rag_available
+
+    if not _provider_ready() or not rag_available():
+        reason = "no provider key configured" if not _provider_ready() else "no database configured"
+        report = {
+            "generated_at": generated_at,
+            "status": "skipped",
+            "skipped_reason": reason,
+            "provider": None,
+        }
+    else:
+        from evals.retrieval import RETRIEVAL_MODES, run_retrieval_modes
+
+        _, provider_label = get_model()
+        rows = _load_jsonl(_DATA_DIR / "fit_score.jsonl")
+        resume = (_DATA_DIR / "sample_resume.txt").read_text(encoding="utf-8")
+        report = {
+            "generated_at": generated_at,
+            "status": "ok",
+            "provider": provider_label,
+            "modes_order": list(RETRIEVAL_MODES),
+            "modes": run_retrieval_modes(rows, resume),
+        }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "retrieval_report.json").write_text(
+        json.dumps(report, indent=2) + "\n", encoding="utf-8"
+    )
+    (output_dir / "retrieval_report.md").write_text(
+        render_retrieval_markdown(report), encoding="utf-8"
+    )
+    print(render_retrieval_markdown(report))
+    return 0
+
+
 def main(output_dir: Path | None = None, gate: bool = False) -> int:
     logging.basicConfig(level=logging.INFO)
     output_dir = output_dir or Path(__file__).parent
@@ -274,4 +349,6 @@ def main(output_dir: Path | None = None, gate: bool = False) -> int:
 if __name__ == "__main__":
     import sys
 
+    if "--retrieval-modes" in sys.argv:
+        raise SystemExit(retrieval_main())
     raise SystemExit(main(gate="--gate" in sys.argv))

--- a/services/agent/tests/test_retrieval_eval.py
+++ b/services/agent/tests/test_retrieval_eval.py
@@ -59,6 +59,66 @@ def test_run_retrieval_modes_marks_hybrid_na_without_fts():
     assert result["hybrid+rerank"]["status"] == "n/a"
 
 
+def test_retrieval_main_skips_without_provider(tmp_path, monkeypatch):
+    import json
+
+    from evals import run
+
+    monkeypatch.setattr(run, "_provider_ready", lambda: False)
+    code = run.retrieval_main(output_dir=tmp_path)
+    assert code == 0
+    report = json.loads((tmp_path / "retrieval_report.json").read_text(encoding="utf-8"))
+    assert report["status"] == "skipped"
+    assert report["provider"] is None
+    assert (tmp_path / "retrieval_report.md").exists()
+
+
+def test_retrieval_main_skips_without_database(tmp_path, monkeypatch):
+    import json
+
+    from evals import run
+
+    monkeypatch.setattr(run, "_provider_ready", lambda: True)
+    monkeypatch.setattr("app.rag.store.rag_available", lambda: False)
+    code = run.retrieval_main(output_dir=tmp_path)
+    assert code == 0
+    report = json.loads((tmp_path / "retrieval_report.json").read_text(encoding="utf-8"))
+    assert report["status"] == "skipped"
+    assert "database" in report["skipped_reason"]
+
+
+def test_render_retrieval_markdown_shows_modes_and_na():
+    from evals.run import render_retrieval_markdown
+
+    report = {
+        "generated_at": "2026-06-18T00:00:00+00:00",
+        "status": "ok",
+        "provider": "openai:gpt-4o-mini",
+        "modes_order": ["off", "vector", "hybrid"],
+        "modes": {
+            "off": {
+                "status": "ok",
+                "n": 2,
+                "errors": 0,
+                "rank_correlation_spearman": 0.5,
+                "ragas": {"faithfulness": 0.8, "answer_relevancy": 0.2, "context_recall": 0.4},
+            },
+            "vector": {
+                "status": "ok",
+                "n": 2,
+                "errors": 0,
+                "rank_correlation_spearman": 0.6,
+                "ragas": {},
+            },
+            "hybrid": {"status": "n/a", "reason": "chunk_tsv / embeddings_tsv_idx absent"},
+        },
+    }
+    md = render_retrieval_markdown(report)
+    assert "| off |" in md and "0.5" in md
+    assert "| vector |" in md and "0.6" in md
+    assert "n/a" in md  # hybrid row marked unavailable
+
+
 def test_run_retrieval_modes_restores_settings():
     before = (settings.rag_retrieval_mode, settings.rag_rerank_enabled)
     retrieval.run_retrieval_modes(

--- a/services/agent/tests/test_retrieval_eval.py
+++ b/services/agent/tests/test_retrieval_eval.py
@@ -1,5 +1,7 @@
 """Retrieval-mode sweep tests — no DB/LLM (the retriever + scorer are injected)."""
 
+import pytest
+
 from app.config import settings
 from evals import retrieval
 
@@ -133,3 +135,48 @@ def test_run_retrieval_modes_restores_settings():
         fts_ready=lambda: True,
     )
     assert (settings.rag_retrieval_mode, settings.rag_rerank_enabled) == before
+
+
+def test_run_retrieval_modes_restores_settings_after_exception():
+    before = (settings.rag_retrieval_mode, settings.rag_rerank_enabled)
+
+    def boom(rows, resume_text, contexts_for):
+        raise RuntimeError("scorer blew up mid-sweep")
+
+    with pytest.raises(RuntimeError):
+        retrieval.run_retrieval_modes(
+            _rows(),
+            "resume text",
+            modes=("hybrid+rerank",),
+            retrieve_evidence=lambda *a, **k: ["c"],
+            score_eval=boom,
+            fts_ready=lambda: True,
+        )
+    # The finally must restore settings even when the sweep raises.
+    assert (settings.rag_retrieval_mode, settings.rag_rerank_enabled) == before
+
+
+def test_default_contexts_for_chunks_whole_resume(monkeypatch):
+    # The default seam (no contexts_for) must still feed the whole resume chunked.
+    from app.rag.chunk import chunk_text
+    from evals import run
+
+    resume = "Para one.\n\nPara two."
+    captured = {}
+
+    def fake_score_fit(request):
+        captured["contexts"] = list(request.retrieved_context)
+
+        class _Resp:
+            fit_score = 50
+            fit_summary = "ok"
+
+        return _Resp()
+
+    monkeypatch.setattr(run, "score_fit", fake_score_fit)
+    # Keep it hermetic/fast: don't touch the real Ragas judge or provider.
+    monkeypatch.setattr(run, "get_model", lambda: (object(), "fake:model"))
+    monkeypatch.setattr(run, "fit_ragas_scores", lambda *a, **k: {})
+    rows = [{"description_text": "jd", "expected": {"fit_label": 50, "reference": "r"}}]
+    run.run_fit_score_eval(rows, resume)  # no contexts_for -> default path
+    assert captured["contexts"] == chunk_text(resume)

--- a/services/agent/tests/test_retrieval_eval.py
+++ b/services/agent/tests/test_retrieval_eval.py
@@ -1,0 +1,75 @@
+"""Retrieval-mode sweep tests — no DB/LLM (the retriever + scorer are injected)."""
+
+from app.config import settings
+from evals import retrieval
+
+
+def _rows():
+    return [
+        {"description_text": "python backend role", "expected": {"fit_label": 80, "reference": "r"}}
+    ]
+
+
+def test_run_retrieval_modes_runs_each_mode_and_aggregates():
+    fed: dict[str, bool] = {}
+
+    def fake_retrieve(resume_text, jd, k):
+        # Reflect the per-mode settings toggles the sweep applies.
+        return [f"ctx-{settings.rag_retrieval_mode}:{settings.rag_rerank_enabled}"]
+
+    def fake_score(rows, resume_text, contexts_for):
+        ctx = contexts_for(rows[0])
+        fed[ctx[0] if ctx else "EMPTY"] = True
+        return {"rank_correlation_spearman": 0.5, "ragas": {"faithfulness": 0.8}}
+
+    result = retrieval.run_retrieval_modes(
+        _rows(),
+        "resume text",
+        modes=("off", "vector", "hybrid", "hybrid+rerank"),
+        retrieve_evidence=fake_retrieve,
+        score_eval=fake_score,
+        fts_ready=lambda: True,
+    )
+
+    assert set(result) == {"off", "vector", "hybrid", "hybrid+rerank"}
+    for metrics in result.values():
+        assert "rank_correlation_spearman" in metrics and "ragas" in metrics
+        assert metrics["status"] == "ok"
+    # "off" feeds no evidence; the three retrieval modes feed distinct toggled contexts.
+    assert "EMPTY" in fed
+    assert "ctx-vector:False" in fed
+    assert "ctx-hybrid:False" in fed
+    assert "ctx-hybrid:True" in fed
+
+
+def test_run_retrieval_modes_marks_hybrid_na_without_fts():
+    result = retrieval.run_retrieval_modes(
+        _rows(),
+        "resume text",
+        modes=("vector", "hybrid", "hybrid+rerank"),
+        retrieve_evidence=lambda *a, **k: ["c"],
+        score_eval=lambda rows, resume_text, contexts_for: {
+            "rank_correlation_spearman": 0.5,
+            "ragas": {},
+        },
+        fts_ready=lambda: False,
+    )
+    assert result["vector"]["status"] == "ok"  # vector doesn't need FTS
+    assert result["hybrid"]["status"] == "n/a"
+    assert result["hybrid+rerank"]["status"] == "n/a"
+
+
+def test_run_retrieval_modes_restores_settings():
+    before = (settings.rag_retrieval_mode, settings.rag_rerank_enabled)
+    retrieval.run_retrieval_modes(
+        _rows(),
+        "resume text",
+        modes=("hybrid+rerank",),
+        retrieve_evidence=lambda *a, **k: ["c"],
+        score_eval=lambda rows, resume_text, contexts_for: (
+            contexts_for(rows[0]),
+            {"rank_correlation_spearman": 0.5, "ragas": {}},
+        )[1],
+        fts_ready=lambda: True,
+    )
+    assert (settings.rag_retrieval_mode, settings.rag_rerank_enabled) == before


### PR DESCRIPTION
## Summary
Workstream **Q** of Phase 4 (epic #70): measures what hybrid retrieval (O) and the reranker (P) actually buy, by running the **same** fit-score eval under each retrieval mode — only the retrieved evidence changes, so the table is a true **downstream delta**.

- **`evals/run.py`** — `run_fit_score_eval` gains an optional `contexts_for(row)` seam (defaults to the whole resume chunked — unchanged behavior). New `python -m evals.run --retrieval-modes` entrypoint + `render_retrieval_markdown`; writes `evals/retrieval_report.{json,md}`, or a skipped report (exit 0) without a DB + provider key.
- **`evals/retrieval.py`** (new) — `run_retrieval_modes()` sweeps **off / vector / hybrid / hybrid+rerank**, toggling `RAG_RETRIEVAL_MODE` / `RAG_RERANK_ENABLED` per mode and restoring them after. Hybrid modes are marked **N/A** (not silently reported as ≈vector) when the `chunk_tsv` column or `embeddings_tsv_idx` are absent — guards a partial migration.
- **`EVALS.md`** + **`docs/ARCHITECTURE.md`** — retrieval-mode comparison section, run command, and a hybrid-retrieval architecture paragraph.

## Test Plan
- [x] `pytest` (agent suite **134 passed**): mode sweep aggregates per mode, off=no-evidence vs distinct toggled contexts, FTS-absent → N/A, settings restored, entrypoint skips without DB/key, render shows modes + N/A
- [x] `ruff check app evals tests` clean
- [x] `npm run check` green
- [ ] **EVALS.md numbers** — produced by a keyed run against the dev DB (see below); not generated in CI/headless (no key)

### Generating the numbers (one command)
```bash
cd services/agent
# .env needs DATABASE_URL (with migration 007 applied) + a provider key
pip install -r requirements-dev.txt -r requirements-evals.txt
python -m evals.run --retrieval-modes   # writes evals/retrieval_report.{json,md}
```
The captured `retrieval_report.json` then gets committed alongside `EVALS.md` for auditability. (`hybrid+rerank` downloads the cross-encoder on first use.)

Closes #69. Final workstream of epic #70 — after this, all three (O #67 / P #68 / Q #69) are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)