### PR TITLE
feat(api): Phase 5 · R — job-search caching + API tests in CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,9 @@ N8N_WEBHOOK_SECRET=
 ADZUNA_APP_ID=
 ADZUNA_APP_KEY=
 ADZUNA_COUNTRY=us
+# Cache identical job searches in-process to cut redundant (rate-limited) Adzuna
+# calls. Milliseconds; default 300000 (5 min). Set to 0 to disable caching.
+JOB_SEARCH_CACHE_TTL_MS=300000
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:4000
 # Optional shared secret for mutating API calls; set the same value in both variables.
 API_SHARED_SECRET=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
           CI: true
         run: npm run check
 
+      - name: Run tests
+        env:
+          CI: true
+        run: npm test
+
   agent:
     name: Agent service (Python)
     runs-on: ubuntu-latest

--- a/apps/api/src/lib/cache.test.ts
+++ b/apps/api/src/lib/cache.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { TtlCache } from './cache';
+
+/** A controllable clock so TTL behavior is deterministic (no real timers). */
+function fakeClock(start = 0) {
+  let now = start;
+  return { now: () => now, advance: (ms: number) => (now += ms) };
+}
+
+test('get returns a set value before it expires', () => {
+  const clock = fakeClock();
+  const cache = new TtlCache<number>({ ttlMs: 1000, now: clock.now });
+  cache.set('a', 42);
+  assert.equal(cache.get('a'), 42);
+  clock.advance(999);
+  assert.equal(cache.get('a'), 42);
+});
+
+test('get returns undefined once the entry has expired', () => {
+  const clock = fakeClock();
+  const cache = new TtlCache<number>({ ttlMs: 1000, now: clock.now });
+  cache.set('a', 42);
+  clock.advance(1000);
+  assert.equal(cache.get('a'), undefined);
+  assert.equal(cache.size, 0); // expired entry is evicted on read
+});
+
+test('getOrCompute computes once, then serves the cached value', async () => {
+  const cache = new TtlCache<string>({ ttlMs: 1000 });
+  let calls = 0;
+  const compute = async () => {
+    calls += 1;
+    return `v${calls}`;
+  };
+  assert.equal(await cache.getOrCompute('k', compute), 'v1');
+  assert.equal(await cache.getOrCompute('k', compute), 'v1');
+  assert.equal(calls, 1);
+});
+
+test('getOrCompute recomputes after the TTL elapses', async () => {
+  const clock = fakeClock();
+  const cache = new TtlCache<string>({ ttlMs: 1000, now: clock.now });
+  let calls = 0;
+  const compute = async () => `v${(calls += 1)}`;
+  assert.equal(await cache.getOrCompute('k', compute), 'v1');
+  clock.advance(1001);
+  assert.equal(await cache.getOrCompute('k', compute), 'v2');
+  assert.equal(calls, 2);
+});
+
+test('ttlMs <= 0 disables caching entirely', async () => {
+  const cache = new TtlCache<number>({ ttlMs: 0 });
+  cache.set('a', 1);
+  assert.equal(cache.get('a'), undefined);
+  assert.equal(cache.size, 0);
+  let calls = 0;
+  await cache.getOrCompute('k', async () => (calls += 1));
+  await cache.getOrCompute('k', async () => (calls += 1));
+  assert.equal(calls, 2); // always computes
+});
+
+test('a failed compute is not cached (next call retries)', async () => {
+  const cache = new TtlCache<string>({ ttlMs: 1000 });
+  let calls = 0;
+  const flaky = async () => {
+    calls += 1;
+    if (calls === 1) throw new Error('boom');
+    return 'ok';
+  };
+  await assert.rejects(() => cache.getOrCompute('k', flaky), /boom/);
+  assert.equal(await cache.getOrCompute('k', flaky), 'ok');
+  assert.equal(calls, 2);
+});
+
+test('evicts the oldest entry past maxEntries', () => {
+  const cache = new TtlCache<number>({ ttlMs: 1000, maxEntries: 2 });
+  cache.set('a', 1);
+  cache.set('b', 2);
+  cache.set('c', 3); // evicts 'a'
+  assert.equal(cache.get('a'), undefined);
+  assert.equal(cache.get('b'), 2);
+  assert.equal(cache.get('c'), 3);
+  assert.equal(cache.size, 2);
+});
+
+test('clear empties the cache', () => {
+  const cache = new TtlCache<number>({ ttlMs: 1000 });
+  cache.set('a', 1);
+  cache.clear();
+  assert.equal(cache.size, 0);
+  assert.equal(cache.get('a'), undefined);
+});

--- a/apps/api/src/lib/cache.test.ts
+++ b/apps/api/src/lib/cache.test.ts
@@ -84,6 +84,17 @@ test('evicts the oldest entry past maxEntries', () => {
   assert.equal(cache.size, 2);
 });
 
+test('re-setting a key refreshes its eviction position (FIFO by last write)', () => {
+  const cache = new TtlCache<number>({ ttlMs: 1000, maxEntries: 2 });
+  cache.set('a', 1);
+  cache.set('b', 2);
+  cache.set('a', 11); // 'a' is now the most-recently written, 'b' the oldest
+  cache.set('c', 3); // evicts 'b', not 'a'
+  assert.equal(cache.get('a'), 11);
+  assert.equal(cache.get('b'), undefined);
+  assert.equal(cache.get('c'), 3);
+});
+
 test('clear empties the cache', () => {
   const cache = new TtlCache<number>({ ttlMs: 1000 });
   cache.set('a', 1);

--- a/apps/api/src/lib/cache.ts
+++ b/apps/api/src/lib/cache.ts
@@ -1,0 +1,79 @@
+/**
+ * Tiny in-memory TTL cache (Phase 5 · R).
+ *
+ * Process-local and dependency-free — enough to cut redundant calls to a slow,
+ * rate-limited upstream (e.g. Adzuna) within a single API instance. Not a
+ * distributed cache; on a multi-instance deployment each instance keeps its own.
+ *
+ * Degrades safely: a non-positive `ttlMs` disables caching (every lookup misses),
+ * and a failed `getOrCompute` is never cached so the next call retries.
+ */
+export interface TtlCacheOptions {
+  /** Entry lifetime in ms. `<= 0` disables caching entirely. */
+  ttlMs: number;
+  /** FIFO eviction cap. Default 500. */
+  maxEntries?: number;
+  /** Injectable clock (defaults to `Date.now`) so TTL is testable. */
+  now?: () => number;
+}
+
+interface Entry<T> {
+  value: T;
+  expires: number;
+}
+
+export class TtlCache<T> {
+  private readonly store = new Map<string, Entry<T>>();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+  private readonly now: () => number;
+
+  constructor(options: TtlCacheOptions) {
+    this.ttlMs = options.ttlMs;
+    this.maxEntries = options.maxEntries ?? 500;
+    this.now = options.now ?? Date.now;
+  }
+
+  private get enabled(): boolean {
+    return this.ttlMs > 0;
+  }
+
+  get(key: string): T | undefined {
+    if (!this.enabled) return undefined;
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (this.now() >= entry.expires) {
+      this.store.delete(key); // lazily evict on read
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key: string, value: T): void {
+    if (!this.enabled) return;
+    // Refresh insertion order so eviction is FIFO by last write.
+    this.store.delete(key);
+    this.store.set(key, { value, expires: this.now() + this.ttlMs });
+    if (this.store.size > this.maxEntries) {
+      const oldest = this.store.keys().next().value;
+      if (oldest !== undefined) this.store.delete(oldest);
+    }
+  }
+
+  /** Return the cached value or compute, cache (on success only), and return it. */
+  async getOrCompute(key: string, compute: () => Promise<T>): Promise<T> {
+    const cached = this.get(key);
+    if (cached !== undefined) return cached;
+    const value = await compute();
+    this.set(key, value);
+    return value;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
+}

--- a/apps/api/src/lib/job-sources/cache.test.ts
+++ b/apps/api/src/lib/job-sources/cache.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { TtlCache } from '../cache';
+import { jobSearchCacheKey, withCachedSearch } from './index';
+import type { SourcedJob } from './normalize';
+import type { JobSource } from './types';
+
+function fakeClock(start = 0) {
+  let now = start;
+  return { now: () => now, advance: (ms: number) => (now += ms) };
+}
+
+function countingSource(name = 'fake'): JobSource & { calls: number } {
+  let calls = 0;
+  return {
+    name,
+    async search(query): Promise<SourcedJob[]> {
+      calls += 1;
+      return [{ title: `${query}-${calls}` } as SourcedJob];
+    },
+    get calls() {
+      return calls;
+    },
+  } as JobSource & { calls: number };
+}
+
+test('identical searches within the TTL hit the source once', async () => {
+  const source = countingSource();
+  const cache = new TtlCache<SourcedJob[]>({ ttlMs: 1000 });
+  const cached = withCachedSearch(source, cache, () => 'us');
+
+  const a = await cached.search('python', {});
+  const b = await cached.search('python', {});
+  assert.equal(source.calls, 1);
+  assert.deepEqual(a, b); // same cached array
+});
+
+test('different queries / options are cached separately', async () => {
+  const source = countingSource();
+  const cache = new TtlCache<SourcedJob[]>({ ttlMs: 1000 });
+  const cached = withCachedSearch(source, cache, () => 'us');
+
+  await cached.search('python', {});
+  await cached.search('rust', {});
+  await cached.search('python', { remoteOnly: true });
+  assert.equal(source.calls, 3);
+});
+
+test('cache expires after the TTL, re-hitting the source', async () => {
+  const source = countingSource();
+  const clock = fakeClock();
+  const cache = new TtlCache<SourcedJob[]>({ ttlMs: 1000, now: clock.now });
+  const cached = withCachedSearch(source, cache, () => 'us');
+
+  await cached.search('python', {});
+  clock.advance(1001);
+  await cached.search('python', {});
+  assert.equal(source.calls, 2);
+});
+
+test('TTL=0 disables caching (every search hits the source)', async () => {
+  const source = countingSource();
+  const cache = new TtlCache<SourcedJob[]>({ ttlMs: 0 });
+  const cached = withCachedSearch(source, cache, () => 'us');
+
+  await cached.search('python', {});
+  await cached.search('python', {});
+  assert.equal(source.calls, 2);
+});
+
+test('a failing search is not cached (next call retries)', async () => {
+  let calls = 0;
+  const flaky: JobSource = {
+    name: 'flaky',
+    async search() {
+      calls += 1;
+      if (calls === 1) throw new Error('429');
+      return [];
+    },
+  };
+  const cache = new TtlCache<SourcedJob[]>({ ttlMs: 1000 });
+  const cached = withCachedSearch(flaky, cache, () => 'us');
+
+  await assert.rejects(() => cached.search('python', {}), /429/);
+  await cached.search('python', {});
+  assert.equal(calls, 2);
+});
+
+test('the same query in a different country is a distinct key', () => {
+  const us = jobSearchCacheKey('python', {}, 'us');
+  const gb = jobSearchCacheKey('python', {}, 'gb');
+  assert.notEqual(us, gb);
+  // case/whitespace-insensitive on the query itself
+  assert.equal(jobSearchCacheKey('  Python ', {}, 'us'), jobSearchCacheKey('python', {}, 'us'));
+});

--- a/apps/api/src/lib/job-sources/cache.test.ts
+++ b/apps/api/src/lib/job-sources/cache.test.ts
@@ -32,7 +32,8 @@ test('identical searches within the TTL hit the source once', async () => {
   const a = await cached.search('python', {});
   const b = await cached.search('python', {});
   assert.equal(source.calls, 1);
-  assert.deepEqual(a, b); // same cached array
+  assert.deepEqual(a, b); // equal results...
+  assert.notEqual(a, b); // ...but a fresh copy each time (callers can't poison the cache)
 });
 
 test('different queries / options are cached separately', async () => {

--- a/apps/api/src/lib/job-sources/index.test.ts
+++ b/apps/api/src/lib/job-sources/index.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
-import { getJobSource } from './index';
+import test, { beforeEach } from 'node:test';
+import { clearJobSearchCache, getJobSource } from './index';
+
+// The job-search cache is a process-local singleton; reset it so each test sees
+// a clean slate (several tests reuse the same query under different upstreams).
+beforeEach(() => clearJobSearchCache());
 
 type StubResult = { ok: boolean; status?: number; body: unknown };
 

--- a/apps/api/src/lib/job-sources/index.ts
+++ b/apps/api/src/lib/job-sources/index.ts
@@ -1,6 +1,8 @@
+import { TtlCache } from '../cache';
 import { createAdzunaSource } from './adzuna';
 import { createRemotiveSource } from './remotive';
-import type { JobSource } from './types';
+import type { SourcedJob } from './normalize';
+import type { JobSearchOptions, JobSource } from './types';
 
 export type { JobSource, JobSearchOptions } from './types';
 export type { SourcedJob } from './normalize';
@@ -10,16 +12,78 @@ function adzunaConfigured(): boolean {
 }
 
 /**
+ * Job-search cache TTL in ms (Phase 5 · R). `JOB_SEARCH_CACHE_TTL_MS`; default 5 min.
+ * Set to `0` to disable caching (every search hits the upstream). Read once at module
+ * load — the cache is a process-local singleton shared across requests.
+ */
+function jobSearchCacheTtlMs(): number {
+  const raw = process.env.JOB_SEARCH_CACHE_TTL_MS;
+  if (raw === undefined) return 300_000;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+const jobSearchCache = new TtlCache<SourcedJob[]>({ ttlMs: jobSearchCacheTtlMs() });
+
+/** Clear the shared job-search cache (used in tests; safe to call anytime). */
+export function clearJobSearchCache(): void {
+  jobSearchCache.clear();
+}
+
+/** Stable cache key for a search. Country matters because Adzuna is region-scoped. */
+export function jobSearchCacheKey(
+  query: string,
+  opts: JobSearchOptions,
+  country: string,
+): string {
+  return JSON.stringify({
+    q: query.trim().toLowerCase(),
+    country,
+    remoteOnly: Boolean(opts.remoteOnly),
+    location: opts.location?.trim().toLowerCase() ?? null,
+    limit: opts.limit ?? null,
+  });
+}
+
+/**
+ * Wrap a source so identical searches within the TTL are served from `cache`,
+ * cutting redundant upstream calls. Only successful results are cached (errors
+ * propagate and retry), so the composite source's Remotive fallback is unaffected.
+ */
+export function withCachedSearch(
+  source: JobSource,
+  cache: TtlCache<SourcedJob[]>,
+  country: () => string,
+): JobSource {
+  return {
+    get name() {
+      return source.name;
+    },
+    search(query, opts = {}) {
+      return cache.getOrCompute(jobSearchCacheKey(query, opts, country()), () =>
+        source.search(query, opts),
+      );
+    },
+  };
+}
+
+/**
  * The active job source. When Adzuna is configured it is preferred, but any
  * failure (rate limit, 5xx, timeout) transparently falls back to Remotive — the
  * no-key source — so discovery never hard-fails on a transient upstream error.
- * `name` reflects the source actually used by the most recent `search`.
+ * `name` reflects the source actually used by the most recent `search`. Results
+ * are cached per query for `JOB_SEARCH_CACHE_TTL_MS`.
  */
 export function getJobSource(): JobSource {
-  if (!adzunaConfigured()) {
-    return createRemotiveSource();
-  }
+  const base = adzunaConfigured() ? createComposite() : createRemotiveSource();
+  return withCachedSearch(
+    base,
+    jobSearchCache,
+    () => process.env.ADZUNA_COUNTRY?.trim() || 'us',
+  );
+}
 
+function createComposite(): JobSource {
   const adzuna = createAdzunaSource();
   const remotive = createRemotiveSource();
   let used = adzuna.name;

--- a/apps/api/src/lib/job-sources/index.ts
+++ b/apps/api/src/lib/job-sources/index.ts
@@ -59,10 +59,13 @@ export function withCachedSearch(
     get name() {
       return source.name;
     },
-    search(query, opts = {}) {
-      return cache.getOrCompute(jobSearchCacheKey(query, opts, country()), () =>
+    async search(query, opts = {}) {
+      const results = await cache.getOrCompute(jobSearchCacheKey(query, opts, country()), () =>
         source.search(query, opts),
       );
+      // Copy so a caller mutating results in place can't poison the shared
+      // cached array (the cache is a process-local singleton across requests).
+      return results.slice();
     },
   };
 }
@@ -71,8 +74,9 @@ export function withCachedSearch(
  * The active job source. When Adzuna is configured it is preferred, but any
  * failure (rate limit, 5xx, timeout) transparently falls back to Remotive — the
  * no-key source — so discovery never hard-fails on a transient upstream error.
- * `name` reflects the source actually used by the most recent `search`. Results
- * are cached per query for `JOB_SEARCH_CACHE_TTL_MS`.
+ * Results are cached per query for `JOB_SEARCH_CACHE_TTL_MS`. `name` reflects the
+ * source used by the most recent *uncached* search (a cache hit doesn't re-run the
+ * source); the authoritative per-job provider is each job's `source` field.
  */
 export function getJobSource(): JobSource {
   const base = adzunaConfigured() ? createComposite() : createRemotiveSource();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,6 +37,10 @@ CRM and orchestration; a Python service owns the real AI.
   sensor data.
 - **Lean CI, full runtime.** Heavy deps (torch) are in `requirements-rag.txt` and
   imported lazily, so CI stays fast; the Docker image installs everything.
+- **Job-search caching (Phase 5).** A process-local TTL cache (`apps/api/src/lib/cache.ts`)
+  wraps the composite job source so identical searches within `JOB_SEARCH_CACHE_TTL_MS`
+  (default 5 min) skip the rate-limited Adzuna call. Only successful results are cached, so
+  the Remotive fallback still fires on upstream errors; `TTL=0` disables it.
 
 The sections below document the original CRM/data layer, which still underpins
 the system.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "typecheck:web": "npm run typecheck --workspace @jobops/web",
     "typecheck:api": "npm run typecheck --workspace @jobops/api",
     "typecheck": "npm run typecheck:web && npm run typecheck:api",
+    "test:api": "npm run test --workspace @jobops/api",
+    "test": "npm run test:api",
     "check": "npm run lint && npm run typecheck && npm run build"
   }
 }


### PR DESCRIPTION
## Summary
Workstream **R** of Phase 5 (epic #76): cut redundant calls to the rate-limited Adzuna API and close a CI gap.

- **`apps/api/src/lib/cache.ts`** (new) — generic process-local `TtlCache<T>`: `getOrCompute`, lazy expiry, FIFO eviction (`maxEntries`), injectable clock. `ttlMs<=0` disables; failed computes are never cached.
- **`apps/api/src/lib/job-sources/index.ts`** — wraps the composite source's `search` with the cache (`withCachedSearch`); identical searches within `JOB_SEARCH_CACHE_TTL_MS` (default 5 min) skip the upstream. Only **successful** results are cached, so the Remotive fallback still fires on Adzuna errors. `clearJobSearchCache()` exported for tests.
- **CI gap fixed** — the API's `node:test` suite (82 tests) was **never run in CI** (`npm run check` is lint+typecheck+build only). Added a root `npm test` + a "Run tests" step to the `verify` job.
- Docs: `.env.example` (`JOB_SEARCH_CACHE_TTL_MS`) + ARCHITECTURE.md caching note.

## Test Plan
- [x] `npm test` — **82 pass** (14 new: 8 `cache.test.ts` + 6 job-source cache cases incl. TTL expiry, separate keys, TTL=0 disable, error-not-cached, country keying)
- [x] `npm run check` (lint + typecheck + build) green
- [x] Existing job-source tests updated to reset the singleton cache between cases

Closes #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)