### PR TITLE
feat(infra): Phase 5 · T — Bicep IaC for the Azure footprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,17 @@ jobs:
 
       - name: Test (pytest)
         run: pytest
+
+  infra:
+    name: Infra (Bicep)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # Compile the Bicep to ARM — fails on any template error. No Azure login
+      # needed (az + Bicep ship on the GitHub-hosted runner).
+      - name: Validate Bicep
+        run: |
+          az bicep build --file infra/main.bicep --stdout > /dev/null
+          az bicep build-params --file infra/main.bicepparam --outfile /dev/null

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,67 @@
+# Infrastructure (Bicep) — Phase 5 · T
+
+Infrastructure-as-code for the JobOps Copilot Azure footprint. This codifies what
+[`scripts/azure/provision.sh`](../scripts/azure/provision.sh) does imperatively, so the
+environment is reviewable, diffable, and reproducible.
+
+## What it provisions
+
+`main.bicep` (resource-group scoped) declares:
+
+| Resource | Notes |
+| --- | --- |
+| App Service plan (Linux) | One `B1` plan hosting all three apps |
+| `jobops-web` | Next.js dashboard (`NODE\|20-lts`) |
+| `jobops-api` | Express API (`NODE\|20-lts`), `WEBSITE_RUN_FROM_PACKAGE=1` |
+| `jobops-agent` | Python agent (`PYTHON\|3.12`) — code-deploy path; use the container for full RAG/torch |
+| Log Analytics workspace | Backs workspace-based App Insights |
+| Application Insights | Wired into every app via `APPLICATIONINSIGHTS_CONNECTION_STRING` |
+| Postgres Flexible Server (v16) | `azure.extensions=VECTOR` for pgvector + an Allow-Azure-Services firewall rule |
+
+Outputs: the three app URLs and the Postgres FQDN.
+
+## Prerequisites
+
+- Azure CLI (`az`) with the Bicep tooling (`az bicep install`).
+- `az login` and a target resource group: `az group create -n jobops-rg -l eastus`.
+
+## Validate (no Azure login required)
+
+```bash
+az bicep build --file infra/main.bicep        # compiles to ARM; fails on any error
+az bicep build-params --file infra/main.bicepparam
+```
+
+This is what CI runs (the `infra` job in `.github/workflows/ci.yml`).
+
+## Preview & deploy
+
+Always preview against an existing environment before applying — a changed Postgres
+SKU/password can be disruptive:
+
+```bash
+# Preview the diff
+az deployment group what-if -g jobops-rg -f infra/main.bicep -p infra/main.bicepparam
+
+# Apply (pass secrets at the CLI — never commit them)
+az deployment group create -g jobops-rg -f infra/main.bicep -p infra/main.bicepparam \
+  -p postgresAdminPassword="$PG_PW" databaseUrl="$DATABASE_URL" openAiApiKey="$OPENAI_API_KEY"
+```
+
+### Secrets
+
+`postgresAdminPassword`, `databaseUrl`, and the provider keys are `@secure()` params with
+blank defaults. Supply them at deploy time via CLI `-p` overrides (above) or, preferably,
+[Key Vault references](https://learn.microsoft.com/azure/app-service/app-service-key-vault-references)
+so the App Service reads them from a vault rather than plaintext app settings.
+
+## Relationship to the deploy workflows
+
+This Bicep provisions the **infrastructure**. Application **code** is shipped separately by
+`.github/workflows/deploy-api.yml`, `deploy-web.yml`, and `azure-app-service.yml`
+(publish-profile based). After provisioning, run those, then bootstrap the schema:
+`npm run db:init --workspace @jobops/api`.
+
+> This file models desired state. It is authored and `az bicep build`-validated in CI, but
+> deploying it against the live environment requires Azure credentials and a `what-if`
+> review — that step is intentionally manual.

--- a/infra/README.md
+++ b/infra/README.md
@@ -16,9 +16,20 @@ environment is reviewable, diffable, and reproducible.
 | `jobops-agent` | Python agent (`PYTHON\|3.12`) — code-deploy path; use the container for full RAG/torch |
 | Log Analytics workspace | Backs workspace-based App Insights |
 | Application Insights | Wired into every app via `APPLICATIONINSIGHTS_CONNECTION_STRING` |
-| Postgres Flexible Server (v16) | `azure.extensions=VECTOR` for pgvector + an Allow-Azure-Services firewall rule |
+| Postgres Flexible Server (v16) | `azure.extensions=vector` for pgvector + an Allow-Azure-Services firewall rule. **Opt-in** via `createPostgres` (default `false`) — see below |
 
-Outputs: the three app URLs and the Postgres FQDN.
+Outputs: the three app URLs and (when created) the Postgres FQDN.
+
+### Postgres is opt-in
+
+`createPostgres` defaults to **`false`** so a deploy never reconciles the **existing
+production server** (`jobops`) — its admin password, SKU, and storage would otherwise be
+rewritten. The default deploy provisions the App Service + observability tier only and
+leaves the live database untouched. Set `createPostgres=true` (and supply
+`postgresAdminPassword`) for a greenfield environment.
+
+The App Service apps set `ftpsState: Disabled` / `minTlsVersion: 1.2` as hardening; the
+deploy workflows publish over SCM/zip (not FTP), so this doesn't affect them.
 
 ## Prerequisites
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,270 @@
+// JobOps Copilot — infrastructure as code (Phase 5 · T).
+//
+// Codifies the Azure footprint that scripts/azure/provision.sh creates imperatively:
+// a Linux App Service plan hosting three apps (web/api/agent), a workspace-based
+// Application Insights, and a Postgres Flexible Server with the pgvector extension
+// allow-listed. Resource-group scoped — create the RG first, then deploy here.
+//
+// Validate (no Azure login needed):   az bicep build --file infra/main.bicep
+// Preview against a subscription:      az deployment group what-if -g <rg> -f infra/main.bicep -p infra/main.bicepparam
+// Deploy:                              az deployment group create  -g <rg> -f infra/main.bicep -p infra/main.bicepparam
+//
+// NOTE: this models desired state. Against an existing deployment, ALWAYS run
+// `what-if` first — applying a fresh Postgres password/SKU can be disruptive.
+
+@description('Azure region for all resources.')
+param location string = resourceGroup().location
+
+@description('Base name; every resource name derives from it.')
+param namePrefix string = 'jobops'
+
+@description('Linux App Service plan SKU. B1 ~1.75GB RAM; bump for RAG/torch on the agent.')
+param planSku string = 'B1'
+
+@description('Postgres Flexible Server compute SKU.')
+param postgresSkuName string = 'Standard_B1ms'
+
+@description('Postgres Flexible Server tier.')
+@allowed([
+  'Burstable'
+  'GeneralPurpose'
+  'MemoryOptimized'
+])
+param postgresTier string = 'Burstable'
+
+@description('Postgres administrator login.')
+param postgresAdminUser string = 'jobopsadmin'
+
+@secure()
+@description('Postgres administrator password (required at deploy time).')
+param postgresAdminPassword string = ''
+
+@secure()
+@description('Full DATABASE_URL connection string injected into the API + agent apps.')
+param databaseUrl string = ''
+
+@description('Agent LLM provider: anthropic | openai | azure_openai | google_genai.')
+param llmProvider string = ''
+
+@secure()
+param anthropicApiKey string = ''
+
+@secure()
+param openAiApiKey string = ''
+
+@secure()
+param googleGeminiApiKey string = ''
+
+var webAppName = '${namePrefix}-web'
+var apiAppName = '${namePrefix}-api'
+var agentAppName = '${namePrefix}-agent'
+var planName = '${namePrefix}-plan'
+var logAnalyticsName = '${namePrefix}-logs'
+var appInsightsName = '${namePrefix}-insights'
+var postgresName = namePrefix
+
+var webHost = 'https://${webAppName}.azurewebsites.net'
+var apiHost = 'https://${apiAppName}.azurewebsites.net'
+var agentHost = 'https://${agentAppName}.azurewebsites.net'
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: logAnalyticsName
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalytics.id
+  }
+}
+
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: planName
+  location: location
+  kind: 'linux'
+  sku: {
+    name: planSku
+  }
+  properties: {
+    reserved: true // Linux
+  }
+}
+
+resource webApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: webAppName
+  location: location
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: 'NODE|20-lts'
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      appSettings: [
+        {
+          name: 'NEXT_PUBLIC_API_BASE_URL'
+          value: apiHost
+        }
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: appInsights.properties.ConnectionString
+        }
+        {
+          name: 'WEBSITE_RUN_FROM_PACKAGE'
+          value: '1'
+        }
+        {
+          name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
+          value: 'false'
+        }
+      ]
+    }
+  }
+}
+
+resource apiApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: apiAppName
+  location: location
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: 'NODE|20-lts'
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      appSettings: [
+        {
+          name: 'AGENT_SERVICE_URL'
+          value: agentHost
+        }
+        {
+          name: 'API_PUBLIC_BASE_URL'
+          value: apiHost
+        }
+        {
+          name: 'DATABASE_URL'
+          value: databaseUrl
+        }
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: appInsights.properties.ConnectionString
+        }
+        {
+          // WEBSITE_RUN_FROM_PACKAGE=1 mounts the deploy package read-only,
+          // avoiding the B1 big-node_modules extraction hang (see deploy-api.yml).
+          name: 'WEBSITE_RUN_FROM_PACKAGE'
+          value: '1'
+        }
+        {
+          name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
+          value: 'false'
+        }
+      ]
+    }
+  }
+}
+
+resource agentApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: agentAppName
+  location: location
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    siteConfig: {
+      // Code-deploy path (no-RAG agent). For full RAG/torch, deploy the container
+      // from services/agent/Dockerfile instead (App Service for Containers / ACA).
+      linuxFxVersion: 'PYTHON|3.12'
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      appSettings: [
+        {
+          name: 'LLM_PROVIDER'
+          value: llmProvider
+        }
+        {
+          name: 'ANTHROPIC_API_KEY'
+          value: anthropicApiKey
+        }
+        {
+          name: 'OPENAI_API_KEY'
+          value: openAiApiKey
+        }
+        {
+          name: 'GOOGLE_GEMINI_API_KEY'
+          value: googleGeminiApiKey
+        }
+        {
+          name: 'DATABASE_URL'
+          value: databaseUrl
+        }
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: appInsights.properties.ConnectionString
+        }
+        {
+          name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
+          value: 'true'
+        }
+      ]
+    }
+  }
+}
+
+resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview' = {
+  name: postgresName
+  location: location
+  sku: {
+    name: postgresSkuName
+    tier: postgresTier
+  }
+  properties: {
+    version: '16'
+    administratorLogin: postgresAdminUser
+    administratorLoginPassword: postgresAdminPassword
+    storage: {
+      storageSizeGB: 32
+    }
+    backup: {
+      backupRetentionDays: 7
+      geoRedundantBackup: 'Disabled'
+    }
+    highAvailability: {
+      mode: 'Disabled'
+    }
+  }
+}
+
+// Allow-list the pgvector extension (RAG vector store, migration 003).
+resource postgresVector 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2023-12-01-preview' = {
+  parent: postgres
+  name: 'azure.extensions'
+  properties: {
+    value: 'VECTOR'
+    source: 'user-override'
+  }
+}
+
+// Let Azure-hosted services (the App Service apps) reach Postgres.
+resource postgresAllowAzure 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2023-12-01-preview' = {
+  parent: postgres
+  name: 'AllowAzureServices'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}
+
+output webUrl string = webHost
+output apiUrl string = apiHost
+output agentUrl string = agentHost
+output postgresFqdn string = postgres.properties.fullyQualifiedDomainName

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -21,6 +21,11 @@ param namePrefix string = 'jobops'
 @description('Linux App Service plan SKU. B1 ~1.75GB RAM; bump for RAG/torch on the agent.')
 param planSku string = 'B1'
 
+@description('''Create the Postgres Flexible Server. Default false so a deploy never
+reconciles the EXISTING production server (`jobops`) — its admin password/SKU/storage
+would otherwise be rewritten. Set true only for a greenfield environment.''')
+param createPostgres bool = false
+
 @description('Postgres Flexible Server compute SKU.')
 param postgresSkuName string = 'Standard_B1ms'
 
@@ -110,6 +115,8 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
       linuxFxVersion: 'NODE|20-lts'
       ftpsState: 'Disabled'
       minTlsVersion: '1.2'
+      // Next.js standalone deploy (deploy-web.yml) runs the platform start command,
+      // so we deliberately do NOT set WEBSITE_RUN_FROM_PACKAGE here (unlike the api).
       appSettings: [
         {
           name: 'NEXT_PUBLIC_API_BASE_URL'
@@ -118,14 +125,6 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
         {
           name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
           value: appInsights.properties.ConnectionString
-        }
-        {
-          name: 'WEBSITE_RUN_FROM_PACKAGE'
-          value: '1'
-        }
-        {
-          name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
-          value: 'false'
         }
       ]
     }
@@ -220,7 +219,7 @@ resource agentApp 'Microsoft.Web/sites@2023-12-01' = {
   }
 }
 
-resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview' = {
+resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview' = if (createPostgres) {
   name: postgresName
   location: location
   sku: {
@@ -244,18 +243,19 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview'
   }
 }
 
-// Allow-list the pgvector extension (RAG vector store, migration 003).
-resource postgresVector 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2023-12-01-preview' = {
+// Allow-list the pgvector extension (RAG vector store, migration 003). Lowercase
+// `vector` to match scripts/azure/provision.sh and the Azure extension name.
+resource postgresVector 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2023-12-01-preview' = if (createPostgres) {
   parent: postgres
   name: 'azure.extensions'
   properties: {
-    value: 'VECTOR'
+    value: 'vector'
     source: 'user-override'
   }
 }
 
 // Let Azure-hosted services (the App Service apps) reach Postgres.
-resource postgresAllowAzure 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2023-12-01-preview' = {
+resource postgresAllowAzure 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2023-12-01-preview' = if (createPostgres) {
   parent: postgres
   name: 'AllowAzureServices'
   properties: {
@@ -267,4 +267,4 @@ resource postgresAllowAzure 'Microsoft.DBforPostgreSQL/flexibleServers/firewallR
 output webUrl string = webHost
 output apiUrl string = apiHost
 output agentUrl string = agentHost
-output postgresFqdn string = postgres.properties.fullyQualifiedDomainName
+output postgresFqdn string = postgres.?properties.fullyQualifiedDomainName ?? ''

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -1,0 +1,20 @@
+using './main.bicep'
+
+// Non-secret defaults — safe to commit. Tune per environment.
+param location = 'eastus'
+param namePrefix = 'jobops'
+param planSku = 'B1'
+param postgresSkuName = 'Standard_B1ms'
+param postgresTier = 'Burstable'
+param postgresAdminUser = 'jobopsadmin'
+param llmProvider = 'openai'
+
+// Secrets — leave blank here and pass at deploy time (NEVER commit real values):
+//   az deployment group create -g <rg> -f infra/main.bicep -p infra/main.bicepparam \
+//     -p postgresAdminPassword=$PG_PW databaseUrl="$DATABASE_URL" openAiApiKey=$OPENAI_API_KEY
+// Or, preferred: reference Azure Key Vault secrets (see infra/README.md).
+param postgresAdminPassword = ''
+param databaseUrl = ''
+param anthropicApiKey = ''
+param openAiApiKey = ''
+param googleGeminiApiKey = ''

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -4,6 +4,9 @@ using './main.bicep'
 param location = 'eastus'
 param namePrefix = 'jobops'
 param planSku = 'B1'
+// Default false: never reconcile the existing production `jobops` Postgres server.
+// Set true (and supply postgresAdminPassword) only for a greenfield environment.
+param createPostgres = false
 param postgresSkuName = 'Standard_B1ms'
 param postgresTier = 'Burstable'
 param postgresAdminUser = 'jobopsadmin'


### PR DESCRIPTION
## Summary
Workstream **T** of Phase 5 (epic #76): codify the Azure infrastructure as Bicep so it's reviewable, diffable, and reproducible — mirroring `scripts/azure/provision.sh`.

- **`infra/main.bicep`** (RG-scoped) — Linux App Service plan + `jobops-web` (NODE 20), `jobops-api` (NODE 20, `WEBSITE_RUN_FROM_PACKAGE=1`), `jobops-agent` (PYTHON 3.12); Log Analytics + workspace-based Application Insights wired into all three; Postgres Flexible Server (v16) with `azure.extensions=VECTOR` (pgvector) + an Allow-Azure-Services firewall rule. Outputs the app URLs + Postgres FQDN.
- **`infra/main.bicepparam`** — committable non-secret defaults; secrets are `@secure()` params supplied at deploy.
- **`infra/README.md`** — validate / what-if / deploy steps, secrets handling (CLI overrides or Key Vault refs), and how this relates to the publish-profile deploy workflows.
- **CI `infra` job** — `az bicep build` + `build-params` on every PR (no Azure login needed; az + Bicep ship on the runner).

## Test Plan
- [x] `az bicep build --file infra/main.bicep` compiles clean (7 resource types, 12 params, 4 outputs)
- [x] `az bicep build-params --file infra/main.bicepparam` compiles clean
- [x] New CI `infra` job validates both on every PR

## Not done (needs you)
Actually **deploying** this requires Azure credentials + a `what-if` review against the live environment (a changed Postgres SKU/password is disruptive). That step is intentionally manual — the template is authored + CI-validated only.

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)