### PR TITLE
feat(load): Phase 5 · S — k6 load test for the API read path

### DIFF
--- a/load/README.md
+++ b/load/README.md
@@ -42,7 +42,12 @@ The run **fails** (non-zero exit) if any threshold is breached:
 - `checks` > 99% — status codes and JSON shape as expected
 
 `readiness` accepts **200 (ready) or 503 (db unreachable)** as valid, well-formed responses
-— only a 5xx/timeout outside those, or a malformed body, counts as a failure.
+— the script widens the per-request status classifier to 200|503 so a 503 doesn't inflate
+`http_req_failed`; only a 5xx/timeout outside those, or a malformed body, counts as a failure.
+
+> A cold Azure B1 instance (or a cold DB connection on the first `/health/ready`) can spike
+> latency past the p95 budget on the opening requests of a ramp — run twice, or warm the app
+> first, when measuring steady-state.
 
 ## CI note
 

--- a/load/README.md
+++ b/load/README.md
@@ -1,0 +1,51 @@
+# Load tests (k6) — Phase 5 · S
+
+Lightweight [k6](https://k6.io) load tests for the JobOps API read path. They target the
+public liveness/readiness probes (`GET /api/health`, `GET /api/health/ready`) so they need
+no auth, while still exercising the Express stack, rate limiter, and the real DB ping under
+concurrency.
+
+## Install k6
+
+k6 is a single Go binary — **not** an npm package, so it isn't in CI or `node_modules`:
+
+```bash
+winget install k6           # Windows
+brew install k6             # macOS
+# or: https://grafana.com/docs/k6/latest/set-up/install-k6/
+```
+
+## Run
+
+```bash
+# Against a locally running API (npm run dev:api → http://127.0.0.1:4000)
+npm run loadtest
+
+# Quick 1-VU/10s smoke
+PROFILE=smoke k6 run load/api-read-path.js
+
+# Against the deployed API
+BASE_URL=https://jobops-api.azurewebsites.net k6 run load/api-read-path.js
+```
+
+| Env | Default | Meaning |
+| --- | --- | --- |
+| `BASE_URL` | `http://127.0.0.1:4000` | API base URL |
+| `PROFILE` | `load` | `load` (ramp to 10 VUs over ~60s) or `smoke` (1 VU, 10s) |
+
+## Thresholds (the pass/fail gate)
+
+The run **fails** (non-zero exit) if any threshold is breached:
+
+- `http_req_failed` < 1% — virtually no errors
+- `http_req_duration` p95 < 800ms — 95% of requests under 800ms
+- `checks` > 99% — status codes and JSON shape as expected
+
+`readiness` accepts **200 (ready) or 503 (db unreachable)** as valid, well-formed responses
+— only a 5xx/timeout outside those, or a malformed body, counts as a failure.
+
+## CI note
+
+k6 is intentionally **not** wired into CI (it needs a running target and the binary). These
+scripts are authored and syntax-checked; run them manually against a local or deployed API
+when validating capacity or after an infra change.

--- a/load/api-read-path.js
+++ b/load/api-read-path.js
@@ -54,9 +54,13 @@ export default function () {
   });
 
   group('readiness', () => {
-    const res = http.get(`${BASE_URL}/api/health/ready`);
-    // 200 (ready) or 503 (db unreachable) are both valid, well-formed responses;
-    // a 5xx/timeout outside those, or a missing status field, is a real failure.
+    // 200 (ready) or 503 (db unreachable) are both valid, well-formed responses.
+    // Widen the per-request expected-status classifier so a 503 does NOT inflate
+    // http_req_failed (k6's default treats >=400 as failed); liveness stays strict.
+    const res = http.get(`${BASE_URL}/api/health/ready`, {
+      responseCallback: http.expectedStatuses(200, 503),
+    });
+    // A 5xx/timeout outside those, or a missing status field, is a real failure.
     check(res, {
       'ready 200 or 503': (r) => r.status === 200 || r.status === 503,
       'ready has status field': (r) => typeof r.json('status') === 'string',

--- a/load/api-read-path.js
+++ b/load/api-read-path.js
@@ -1,0 +1,67 @@
+// k6 load test for the JobOps API read path (Phase 5 · S).
+//
+// Targets the public liveness/readiness probes — GET /api/health and
+// /api/health/ready — which need no auth (requireSharedApiKey only gates mutating
+// methods; the health routes don't call requireAuth). This exercises the Express
+// stack, rate limiter, and (for /ready) the real DB ping under concurrency.
+//
+// Run:
+//   k6 run load/api-read-path.js                        # local (default BASE_URL)
+//   BASE_URL=https://jobops-api.azurewebsites.net k6 run load/api-read-path.js
+//   PROFILE=smoke k6 run load/api-read-path.js          # 1 VU, 10s (quick check)
+//
+// See load/README.md for installing k6 and reading the results.
+
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://127.0.0.1:4000';
+const PROFILE = __ENV.PROFILE || 'load';
+
+// A quick single-VU smoke vs. a short ramped load. Both are deliberately modest —
+// this is a portfolio-scale B1 instance, not a stress test.
+const profiles = {
+  smoke: {
+    vus: 1,
+    duration: '10s',
+  },
+  load: {
+    stages: [
+      { duration: '20s', target: 10 }, // ramp up
+      { duration: '30s', target: 10 }, // steady
+      { duration: '10s', target: 0 }, // ramp down
+    ],
+  },
+};
+
+export const options = {
+  ...profiles[PROFILE],
+  thresholds: {
+    // <1% of requests may fail, and 95% must complete under 800ms.
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<800'],
+    checks: ['rate>0.99'],
+  },
+};
+
+export default function () {
+  group('liveness', () => {
+    const res = http.get(`${BASE_URL}/api/health`);
+    check(res, {
+      'health 200': (r) => r.status === 200,
+      'health ok:true': (r) => r.json('ok') === true,
+    });
+  });
+
+  group('readiness', () => {
+    const res = http.get(`${BASE_URL}/api/health/ready`);
+    // 200 (ready) or 503 (db unreachable) are both valid, well-formed responses;
+    // a 5xx/timeout outside those, or a missing status field, is a real failure.
+    check(res, {
+      'ready 200 or 503': (r) => r.status === 200 || r.status === 503,
+      'ready has status field': (r) => typeof r.json('status') === 'string',
+    });
+  });
+
+  sleep(1);
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typecheck": "npm run typecheck:web && npm run typecheck:api",
     "test:api": "npm run test --workspace @jobops/api",
     "test": "npm run test:api",
+    "loadtest": "k6 run load/api-read-path.js",
     "check": "npm run lint && npm run typecheck && npm run build"
   }
 }


### PR DESCRIPTION
## Summary
Workstream **S** of Phase 5 (epic #76): a k6 load test for the API read path.

- **`load/api-read-path.js`** — hits the public liveness/readiness probes (`GET /api/health`, `/api/health/ready`) under a modest ramp (10 VUs / ~60s) or a `PROFILE=smoke` quick check. `BASE_URL` targets local or deployed. Thresholds gate the run: `http_req_failed<1%`, `http_req_duration p95<800ms`, `checks>99%`. Readiness treats **200 or 503** as valid (only 5xx/timeout or malformed body fails).
- **`load/README.md`** — install k6, run profiles, interpret thresholds.
- **`npm run loadtest`** script.

## Test Plan
- [x] ESM syntax validated (`node --check --input-type=module`)
- [ ] **Executing** it needs the k6 binary + a running API target — documented, not run in CI (k6 isn't an npm dep). Run `npm run loadtest` against `npm run dev:api` or the deployed API to validate capacity.

Targets are auth-free by design (`requireSharedApiKey` only gates mutating methods; health routes don't `requireAuth`), so the test needs no secrets.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)