### PR TITLE
feat(web): Phase 5 · U — Playwright e2e smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,48 @@ jobs:
         run: |
           az bicep build --file infra/main.bicep --stdout > /dev/null
           az bicep build-params --file infra/main.bicepparam --outfile /dev/null
+
+  e2e:
+    name: Web e2e (Playwright)
+    runs-on: ubuntu-latest
+    # The Next.js app needs Clerk keys to boot, so this runs only when they're
+    # configured as secrets; otherwise it skips (the job still succeeds — no gate
+    # failure for a fork/PR without secrets). Mirrors the evals key-gating.
+    env:
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Gate on Clerk secrets
+        id: gate
+        run: |
+          if [ -n "$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" ] && [ -n "$CLERK_SECRET_KEY" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Clerk secrets not configured — skipping web e2e."
+          fi
+
+      - name: Set up Node.js
+        if: steps.gate.outputs.ready == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.gate.outputs.ready == 'true'
+        run: npm ci
+
+      - name: Install Playwright browser
+        if: steps.gate.outputs.ready == 'true'
+        run: npx playwright install --with-deps chromium
+        working-directory: apps/web
+
+      - name: Run e2e
+        if: steps.gate.outputs.ready == 'true'
+        env:
+          CI: true
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ services/agent/evals/report.md
 # NOTE: retrieval_report.{json,md} are intentionally TRACKED (not ignored): they can
 # only be produced by a keyed run against a DB with migration 007 — not by CI — so
 # they're committed for auditability. Don't add them here.
+
+# Playwright e2e artifacts
+apps/web/test-results/
+apps/web/playwright-report/
+apps/web/blob-report/
+apps/web/.cache/

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -1,0 +1,30 @@
+# Web e2e (Playwright) — Phase 5 · U
+
+Smoke tests for the web app's **public surface** — the routes `src/proxy.ts`
+(`isPublicRoute`) allows without auth: `/`, `/architecture`, `/sign-in`, `/sign-up`.
+They assert each loads (status < 400, body visible, non-empty `<title>`, no uncaught
+page errors) and that a protected route (`/dashboard`) redirects an unauthenticated
+visitor to sign-in — exercising the Clerk middleware end to end.
+
+## Prerequisites
+
+The Next.js app needs Clerk keys to boot (`ClerkProvider` + `clerkMiddleware`):
+
+- Locally: `apps/web/.env.local` already provides `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
+  and `CLERK_SECRET_KEY`.
+- CI: set those as repo **secrets**; the `e2e` job skips (and stays green) when they're absent.
+
+## Run
+
+```bash
+cd apps/web
+npm run e2e:install     # one-time: download the Chromium browser
+npm run test:e2e        # starts `next dev` and runs the suite
+
+# Against an already-running / deployed target (skips the dev server):
+E2E_BASE_URL=https://jobops-web.azurewebsites.net npm run test:e2e
+```
+
+Authenticated flows (the `(app)` routes behind sign-in) are **not** covered here — they
+need a Clerk test user / testing token. This suite deliberately stays on the public
+surface so it runs without seeded credentials.

--- a/apps/web/e2e/public-routes.spec.ts
+++ b/apps/web/e2e/public-routes.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test';
+
+// The public surface per src/proxy.ts `isPublicRoute` — reachable without auth.
+const publicRoutes = ['/', '/architecture', '/sign-in', '/sign-up'];
+
+for (const route of publicRoutes) {
+  test(`public route ${route} loads without auth`, async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    const response = await page.goto(route, { waitUntil: 'domcontentloaded' });
+
+    expect(response?.status(), `HTTP status for ${route}`).toBeLessThan(400);
+    await expect(page.locator('body')).toBeVisible();
+    expect(await page.title(), `non-empty <title> for ${route}`).not.toEqual('');
+    expect(pageErrors, `uncaught page errors on ${route}`).toEqual([]);
+  });
+}
+
+test('a protected route redirects an unauthenticated visitor to sign-in', async ({ page }) => {
+  await page.goto('/dashboard');
+  // clerkMiddleware `auth.protect()` bounces unauthenticated users to the sign-in flow.
+  await page.waitForURL(/sign-in/, { timeout: 20_000 });
+  expect(page.url()).toContain('sign-in');
+});

--- a/apps/web/e2e/public-routes.spec.ts
+++ b/apps/web/e2e/public-routes.spec.ts
@@ -12,7 +12,7 @@ for (const route of publicRoutes) {
 
     expect(response?.status(), `HTTP status for ${route}`).toBeLessThan(400);
     await expect(page.locator('body')).toBeVisible();
-    expect(await page.title(), `non-empty <title> for ${route}`).not.toEqual('');
+    expect((await page.title()).trim(), `non-empty <title> for ${route}`).not.toEqual('');
     expect(pageErrors, `uncaught page errors on ${route}`).toEqual([]);
   });
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test",
+    "e2e:install": "playwright install --with-deps chromium"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
@@ -27,6 +29,7 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Smoke e2e for the web app's public surface (Phase 5 · U). The Next.js app needs
+// Clerk keys to boot (ClerkProvider + clerkMiddleware), so these run locally with
+// apps/web/.env.local; in CI they run only when Clerk secrets are configured.
+const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3000';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  // Start the dev server unless E2E_BASE_URL points at an already-running target.
+  webServer: process.env.E2E_BASE_URL
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@tailwindcss/postcss": "^4.3.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
@@ -4972,6 +4973,23 @@
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -12040,6 +12058,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plimit-lit": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typecheck": "npm run typecheck:web && npm run typecheck:api",
     "test:api": "npm run test --workspace @jobops/api",
     "test": "npm run test:api",
+    "test:e2e": "npm run test:e2e --workspace @jobops/web",
     "loadtest": "k6 run load/api-read-path.js",
     "check": "npm run lint && npm run typecheck && npm run build"
   }


### PR DESCRIPTION
## Summary
Workstream **U** of Phase 5 (epic #76): Playwright e2e smoke tests for the web app's public surface — completing the epic.

- **`apps/web/e2e/public-routes.spec.ts`** — for each auth-free route (`/`, `/architecture`, `/sign-in`, `/sign-up`): status < 400, body visible, non-empty `<title>`, no uncaught page errors. Plus a **protected-route → sign-in redirect** test that exercises the Clerk middleware end to end.
- **`apps/web/playwright.config.ts`** — Chromium project; auto-starts `next dev` (or targets `E2E_BASE_URL`); CI-aware retries/reporter.
- **`npm run test:e2e`** + `e2e:install`; e2e README.
- **Gated CI `e2e` job** — runs only when Clerk secrets (`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`) are configured; otherwise skips and stays green (mirrors the evals key-gating, so it never blocks a secret-less PR).

## Test Plan
- [x] **Verified locally: 5/5 pass** against the real app (with `apps/web/.env.local` Clerk keys), incl. the protected-route redirect
- [x] `npm run check` (lint + typecheck + build) green with the new files
- [ ] CI `e2e` job runs for real once Clerk secrets are added to the repo (skips green until then)

Authenticated `(app)` flows aren't covered (need a Clerk test user/token) — deliberately public-surface only.

Closes #80. Final workstream of epic #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)