### PR TITLE
fix(infra): model the real Azure topology (container app, regions, Key Vault)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -17,7 +17,7 @@ locations are split across `appLocation` (default `mexicocentral`) and `platform
 | `jobops-api` | mexicocentral | Express API (`NODE\|22-lts`), `WEBSITE_RUN_FROM_PACKAGE=1` |
 | `jobops-agent` + `jobops-agent-env` | eastus | **Container App** (port 8000, external, scale 0–3) on a Container Apps managed environment — `agentImage` points at the ACR tag the container pipeline pushes |
 | Log Analytics + Application Insights | eastus | Workspace-based; wired into web/api/agent via `APPLICATIONINSIGHTS_CONNECTION_STRING` |
-| Key Vault (`jobops-kv`) | eastus | RBAC-authorized; for Key Vault-referenced secrets |
+| Key Vault (`jobops-kv`) | eastus | RBAC-authorized, provisioned for future Key Vault-referenced secrets (not yet wired as a secret source — apps still take plaintext settings today) |
 | Postgres Flexible Server (v16) | mexicocentral | `azure.extensions=vector` (pgvector) + Allow-Azure-Services firewall. **Opt-in** via `createPostgres` (default `false`) — see below |
 
 Outputs: the web/api/agent URLs and (when created) the Postgres FQDN.
@@ -34,6 +34,11 @@ production server** (`jobops`) — its admin password, SKU, and storage would ot
 rewritten. The default deploy provisions the App Service + observability tier only and
 leaves the live database untouched. Set `createPostgres=true` (and supply
 `postgresAdminPassword`) for a greenfield environment.
+
+> **Greenfield note:** a Container Apps managed environment is slow to provision; on a
+> first `create` the `jobops-agent` container app depends on `jobops-agent-env` reaching a
+> ready state. ARM handles the ordering via the implicit dependency, but expect the
+> environment step to take several minutes.
 
 The App Service apps set `ftpsState: Disabled` / `minTlsVersion: 1.2` as hardening; the
 deploy workflows publish over SCM/zip (not FTP), so this doesn't affect them.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,24 +1,31 @@
 # Infrastructure (Bicep) — Phase 5 · T
 
-Infrastructure-as-code for the JobOps Copilot Azure footprint. This codifies what
-[`scripts/azure/provision.sh`](../scripts/azure/provision.sh) does imperatively, so the
-environment is reviewable, diffable, and reproducible.
+Infrastructure-as-code for the JobOps Copilot Azure footprint. It models the **actual
+deployed topology** (verified 2026-06-18 via `az deployment group what-if` against RG
+`projects`), so the environment is reviewable, diffable, and reproducible.
 
 ## What it provisions
 
-`main.bicep` (resource-group scoped) declares:
+`main.bicep` (resource-group scoped). Resources legitimately span **two regions**, so
+locations are split across `appLocation` (default `mexicocentral`) and `platformLocation`
+(default `eastus`):
 
-| Resource | Notes |
-| --- | --- |
-| App Service plan (Linux) | One `B1` plan hosting all three apps |
-| `jobops-web` | Next.js dashboard (`NODE\|20-lts`) |
-| `jobops-api` | Express API (`NODE\|20-lts`), `WEBSITE_RUN_FROM_PACKAGE=1` |
-| `jobops-agent` | Python agent (`PYTHON\|3.12`) — code-deploy path; use the container for full RAG/torch |
-| Log Analytics workspace | Backs workspace-based App Insights |
-| Application Insights | Wired into every app via `APPLICATIONINSIGHTS_CONNECTION_STRING` |
-| Postgres Flexible Server (v16) | `azure.extensions=vector` for pgvector + an Allow-Azure-Services firewall rule. **Opt-in** via `createPostgres` (default `false`) — see below |
+| Resource | Region | Notes |
+| --- | --- | --- |
+| App Service plan (Linux, `B1`) | mexicocentral | Hosts the web + api App Services |
+| `jobops-web` | mexicocentral | Next.js dashboard (`NODE\|22-lts`) |
+| `jobops-api` | mexicocentral | Express API (`NODE\|22-lts`), `WEBSITE_RUN_FROM_PACKAGE=1` |
+| `jobops-agent` + `jobops-agent-env` | eastus | **Container App** (port 8000, external, scale 0–3) on a Container Apps managed environment — `agentImage` points at the ACR tag the container pipeline pushes |
+| Log Analytics + Application Insights | eastus | Workspace-based; wired into web/api/agent via `APPLICATIONINSIGHTS_CONNECTION_STRING` |
+| Key Vault (`jobops-kv`) | eastus | RBAC-authorized; for Key Vault-referenced secrets |
+| Postgres Flexible Server (v16) | mexicocentral | `azure.extensions=vector` (pgvector) + Allow-Azure-Services firewall. **Opt-in** via `createPostgres` (default `false`) — see below |
 
-Outputs: the three app URLs and (when created) the Postgres FQDN.
+Outputs: the web/api/agent URLs and (when created) the Postgres FQDN.
+
+> **Not managed here:** the agent's container registry (auto-named ACR) and image build/push
+> are handled by the container pipeline (`az containerapp up` / a deploy workflow), not this
+> template — `agentImage` just selects an already-published tag. A `what-if` correctly lists
+> the ACR (and the existing Postgres when `createPostgres=false`) under *Ignore*.
 
 ### Postgres is opt-in
 
@@ -34,7 +41,8 @@ deploy workflows publish over SCM/zip (not FTP), so this doesn't affect them.
 ## Prerequisites
 
 - Azure CLI (`az`) with the Bicep tooling (`az bicep install`).
-- `az login` and a target resource group: `az group create -n jobops-rg -l eastus`.
+- `az login`. The live environment is RG `projects`; for a greenfield deploy create your own
+  RG: `az group create -n <rg> -l mexicocentral`.
 
 ## Validate (no Azure login required)
 
@@ -47,17 +55,21 @@ This is what CI runs (the `infra` job in `.github/workflows/ci.yml`).
 
 ## Preview & deploy
 
-Always preview against an existing environment before applying — a changed Postgres
-SKU/password can be disruptive:
+Always preview against an existing environment before applying — a `what-if` is
+non-destructive and the authoritative fidelity check:
 
 ```bash
-# Preview the diff
-az deployment group what-if -g jobops-rg -f infra/main.bicep -p infra/main.bicepparam
+# Preview the diff against the live environment (read-only)
+az deployment group what-if -g projects -f infra/main.bicep -p infra/main.bicepparam
 
 # Apply (pass secrets at the CLI — never commit them)
-az deployment group create -g jobops-rg -f infra/main.bicep -p infra/main.bicepparam \
-  -p postgresAdminPassword="$PG_PW" databaseUrl="$DATABASE_URL" openAiApiKey="$OPENAI_API_KEY"
+az deployment group create -g projects -f infra/main.bicep -p infra/main.bicepparam \
+  -p databaseUrl="$DATABASE_URL" openAiApiKey="$OPENAI_API_KEY"
 ```
+
+A `what-if` against RG `projects` (verified 2026-06-18) lists all eight templated resources
+as present (web, api, plan, agent, agent-env, insights, logs, kv) — no spurious creates or
+deletes — with the ACR and existing Postgres correctly under *Ignore*.
 
 ### Secrets
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,29 +1,41 @@
 // JobOps Copilot — infrastructure as code (Phase 5 · T).
 //
-// Codifies the Azure footprint that scripts/azure/provision.sh creates imperatively:
-// a Linux App Service plan hosting three apps (web/api/agent), a workspace-based
-// Application Insights, and a Postgres Flexible Server with the pgvector extension
-// allow-listed. Resource-group scoped — create the RG first, then deploy here.
+// Models the ACTUAL deployed topology (verified 2026-06-18 against RG `projects`):
+//   - App Service plan (B1, Linux) + jobops-web / jobops-api (Node 22)   — mexicocentral
+//   - Postgres Flexible Server 16 (pgvector), opt-in                       — mexicocentral
+//   - Log Analytics + workspace-based Application Insights                 — eastus
+//   - Key Vault                                                           — eastus
+//   - Container Apps managed environment + jobops-agent (container)       — eastus
+// Resources legitimately span two regions, so locations are split across params.
 //
-// Validate (no Azure login needed):   az bicep build --file infra/main.bicep
-// Preview against a subscription:      az deployment group what-if -g <rg> -f infra/main.bicep -p infra/main.bicepparam
-// Deploy:                              az deployment group create  -g <rg> -f infra/main.bicep -p infra/main.bicepparam
+// Validate (no deploy):  az bicep build --file infra/main.bicep
+// Preview vs live:        az deployment group what-if -g projects -f infra/main.bicep -p infra/main.bicepparam
+// Deploy:                 az deployment group create  -g projects -f infra/main.bicep -p infra/main.bicepparam
 //
-// NOTE: this models desired state. Against an existing deployment, ALWAYS run
-// `what-if` first — applying a fresh Postgres password/SKU can be disruptive.
+// NOTE: desired-state model. Run `what-if` first — the agent's ACR + image are built/pushed
+// by the container pipeline (`az containerapp up` / a deploy workflow), not this template;
+// `agentImage` just points the container app at an already-published tag.
 
-@description('Azure region for all resources.')
-param location string = resourceGroup().location
+@description('Region for the App Service tier + Postgres (web/api/plan/db).')
+param appLocation string = 'mexicocentral'
+
+@description('Region for the platform tier (observability, Key Vault, the agent container app).')
+param platformLocation string = 'eastus'
 
 @description('Base name; every resource name derives from it.')
 param namePrefix string = 'jobops'
 
-@description('Linux App Service plan SKU. B1 ~1.75GB RAM; bump for RAG/torch on the agent.')
+@description('Linux App Service plan SKU. B1 ~1.75GB RAM.')
 param planSku string = 'B1'
 
-@description('''Create the Postgres Flexible Server. Default false so a deploy never
-reconciles the EXISTING production server (`jobops`) — its admin password/SKU/storage
-would otherwise be rewritten. Set true only for a greenfield environment.''')
+@description('Node runtime for the web + api App Services.')
+param nodeLinuxFxVersion string = 'NODE|22-lts'
+
+@description('Container image for the agent (built + pushed by the container pipeline).')
+param agentImage string = 'ca9ee6437892acr.azurecr.io/jobops-agent:latest'
+
+@description('''Create the Postgres Flexible Server. Default false so a deploy never reconciles
+the EXISTING production server (`jobops`). Set true only for a greenfield environment.''')
 param createPostgres bool = false
 
 @description('Postgres Flexible Server compute SKU.')
@@ -41,11 +53,11 @@ param postgresTier string = 'Burstable'
 param postgresAdminUser string = 'jobopsadmin'
 
 @secure()
-@description('Postgres administrator password (required at deploy time).')
+@description('Postgres administrator password (required only when createPostgres is true).')
 param postgresAdminPassword string = ''
 
 @secure()
-@description('Full DATABASE_URL connection string injected into the API + agent apps.')
+@description('Full DATABASE_URL connection string injected into the API + agent.')
 param databaseUrl string = ''
 
 @description('Agent LLM provider: anthropic | openai | azure_openai | google_genai.')
@@ -66,15 +78,18 @@ var agentAppName = '${namePrefix}-agent'
 var planName = '${namePrefix}-plan'
 var logAnalyticsName = '${namePrefix}-logs'
 var appInsightsName = '${namePrefix}-insights'
+var keyVaultName = '${namePrefix}-kv'
+var agentEnvName = '${namePrefix}-agent-env'
 var postgresName = namePrefix
 
 var webHost = 'https://${webAppName}.azurewebsites.net'
 var apiHost = 'https://${apiAppName}.azurewebsites.net'
-var agentHost = 'https://${agentAppName}.azurewebsites.net'
+
+// ---- Observability (eastus) ------------------------------------------------
 
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: logAnalyticsName
-  location: location
+  location: platformLocation
   properties: {
     sku: {
       name: 'PerGB2018'
@@ -85,7 +100,7 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
 
 resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
   name: appInsightsName
-  location: location
+  location: platformLocation
   kind: 'web'
   properties: {
     Application_Type: 'web'
@@ -93,9 +108,25 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: keyVaultName
+  location: platformLocation
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: subscription().tenantId
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+  }
+}
+
+// ---- App Service tier (mexicocentral) --------------------------------------
+
 resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
   name: planName
-  location: location
+  location: appLocation
   kind: 'linux'
   sku: {
     name: planSku
@@ -107,16 +138,14 @@ resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
 
 resource webApp 'Microsoft.Web/sites@2023-12-01' = {
   name: webAppName
-  location: location
+  location: appLocation
   properties: {
     serverFarmId: plan.id
     httpsOnly: true
     siteConfig: {
-      linuxFxVersion: 'NODE|20-lts'
+      linuxFxVersion: nodeLinuxFxVersion
       ftpsState: 'Disabled'
       minTlsVersion: '1.2'
-      // Next.js standalone deploy (deploy-web.yml) runs the platform start command,
-      // so we deliberately do NOT set WEBSITE_RUN_FROM_PACKAGE here (unlike the api).
       appSettings: [
         {
           name: 'NEXT_PUBLIC_API_BASE_URL'
@@ -133,18 +162,18 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
 
 resource apiApp 'Microsoft.Web/sites@2023-12-01' = {
   name: apiAppName
-  location: location
+  location: appLocation
   properties: {
     serverFarmId: plan.id
     httpsOnly: true
     siteConfig: {
-      linuxFxVersion: 'NODE|20-lts'
+      linuxFxVersion: nodeLinuxFxVersion
       ftpsState: 'Disabled'
       minTlsVersion: '1.2'
       appSettings: [
         {
           name: 'AGENT_SERVICE_URL'
-          value: agentHost
+          value: 'https://${agentApp.properties.configuration.ingress.fqdn}'
         }
         {
           name: 'API_PUBLIC_BASE_URL'
@@ -173,55 +202,85 @@ resource apiApp 'Microsoft.Web/sites@2023-12-01' = {
   }
 }
 
-resource agentApp 'Microsoft.Web/sites@2023-12-01' = {
-  name: agentAppName
-  location: location
+// ---- Agent: Container App (eastus) -----------------------------------------
+
+resource agentEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: agentEnvName
+  location: platformLocation
   properties: {
-    serverFarmId: plan.id
-    httpsOnly: true
-    siteConfig: {
-      // Code-deploy path (no-RAG agent). For full RAG/torch, deploy the container
-      // from services/agent/Dockerfile instead (App Service for Containers / ACA).
-      linuxFxVersion: 'PYTHON|3.12'
-      ftpsState: 'Disabled'
-      minTlsVersion: '1.2'
-      appSettings: [
-        {
-          name: 'LLM_PROVIDER'
-          value: llmProvider
-        }
-        {
-          name: 'ANTHROPIC_API_KEY'
-          value: anthropicApiKey
-        }
-        {
-          name: 'OPENAI_API_KEY'
-          value: openAiApiKey
-        }
-        {
-          name: 'GOOGLE_GEMINI_API_KEY'
-          value: googleGeminiApiKey
-        }
-        {
-          name: 'DATABASE_URL'
-          value: databaseUrl
-        }
-        {
-          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-          value: appInsights.properties.ConnectionString
-        }
-        {
-          name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
-          value: 'true'
-        }
-      ]
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
     }
   }
 }
 
+resource agentApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: agentAppName
+  location: platformLocation
+  properties: {
+    managedEnvironmentId: agentEnv.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8000
+        transport: 'auto'
+      }
+      // ACR pull auth (registries/identity) is configured by the container pipeline.
+    }
+    template: {
+      containers: [
+        {
+          name: 'agent'
+          image: agentImage
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            {
+              name: 'LLM_PROVIDER'
+              value: llmProvider
+            }
+            {
+              name: 'ANTHROPIC_API_KEY'
+              value: anthropicApiKey
+            }
+            {
+              name: 'OPENAI_API_KEY'
+              value: openAiApiKey
+            }
+            {
+              name: 'GOOGLE_GEMINI_API_KEY'
+              value: googleGeminiApiKey
+            }
+            {
+              name: 'DATABASE_URL'
+              value: databaseUrl
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              value: appInsights.properties.ConnectionString
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 3
+      }
+    }
+  }
+}
+
+// ---- Postgres Flexible Server (mexicocentral, opt-in) ----------------------
+
 resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview' = if (createPostgres) {
   name: postgresName
-  location: location
+  location: appLocation
   sku: {
     name: postgresSkuName
     tier: postgresTier
@@ -266,5 +325,5 @@ resource postgresAllowAzure 'Microsoft.DBforPostgreSQL/flexibleServers/firewallR
 
 output webUrl string = webHost
 output apiUrl string = apiHost
-output agentUrl string = agentHost
+output agentUrl string = 'https://${agentApp.properties.configuration.ingress.fqdn}'
 output postgresFqdn string = postgres.?properties.fullyQualifiedDomainName ?? ''

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -61,7 +61,7 @@ param postgresAdminPassword string = ''
 param databaseUrl string = ''
 
 @description('Agent LLM provider: anthropic | openai | azure_openai | google_genai.')
-param llmProvider string = ''
+param llmProvider string = 'openai'
 
 @secure()
 param anthropicApiKey string = ''
@@ -118,7 +118,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     }
     tenantId: subscription().tenantId
     enableRbacAuthorization: true
-    enableSoftDelete: true
+    // soft delete is on-by-default and non-disableable for this API version.
   }
 }
 

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -1,21 +1,25 @@
 using './main.bicep'
 
-// Non-secret defaults — safe to commit. Tune per environment.
-param location = 'eastus'
+// Non-secret defaults — safe to commit. Match the live topology (RG `projects`).
+param appLocation = 'mexicocentral'
+param platformLocation = 'eastus'
 param namePrefix = 'jobops'
 param planSku = 'B1'
-// Default false: never reconcile the existing production `jobops` Postgres server.
-// Set true (and supply postgresAdminPassword) only for a greenfield environment.
-param createPostgres = false
+param nodeLinuxFxVersion = 'NODE|22-lts'
+param agentImage = 'ca9ee6437892acr.azurecr.io/jobops-agent:latest'
 param postgresSkuName = 'Standard_B1ms'
 param postgresTier = 'Burstable'
 param postgresAdminUser = 'jobopsadmin'
 param llmProvider = 'openai'
 
+// Default false: never reconcile the existing production `jobops` Postgres server.
+// Set true (and supply postgresAdminPassword) only for a greenfield environment.
+param createPostgres = false
+
 // Secrets — leave blank here and pass at deploy time (NEVER commit real values):
-//   az deployment group create -g <rg> -f infra/main.bicep -p infra/main.bicepparam \
-//     -p postgresAdminPassword=$PG_PW databaseUrl="$DATABASE_URL" openAiApiKey=$OPENAI_API_KEY
-// Or, preferred: reference Azure Key Vault secrets (see infra/README.md).
+//   az deployment group create -g projects -f infra/main.bicep -p infra/main.bicepparam \
+//     -p databaseUrl="$DATABASE_URL" openAiApiKey=$OPENAI_API_KEY
+// Or, preferred: reference Azure Key Vault (jobops-kv) secrets (see infra/README.md).
 param postgresAdminPassword = ''
 param databaseUrl = ''
 param anthropicApiKey = ''


### PR DESCRIPTION
## Summary
Autonomous end-to-end verification of Phase 5 caught real drift in the Bicep merged in #82: it **misrepresented the live environment**. Verified against the subscription with `az deployment group what-if` and corrected the template to match reality.

### Drift found (live RG `projects`, via what-if + `az resource list`)
- **`jobops-agent` is a Container App** (`Microsoft.App/containerApps` + managed env, eastus, image on ACR, port 8000, scale 0–3) — the old Bicep modeled it as an `App Service` (`PYTHON|3.12`). Wrong resource type.
- **web/api run `NODE|22-lts`** — old Bicep said `NODE|20-lts`.
- **Resources span two regions** — `mexicocentral` (plan/web/api/postgres) + `eastus` (agent/observability/KV); old Bicep used one `location`.
- **Key Vault `jobops-kv`** existed and was unmodeled.

### Fix
- Split `appLocation` (mexicocentral) / `platformLocation` (eastus).
- Model the agent as `Microsoft.App/containerApps` + `managedEnvironments` (port 8000, scale 0–3, `agentImage` param).
- Add Key Vault; `NODE|22-lts`; keep Postgres opt-in (`createPostgres=false`).

## Verification (the point of this PR)
- `az bicep build` + `build-params` clean (CI `infra` job).
- **`az deployment group what-if -g projects` PASS**: all **8** templated resources (web, api, plan, agent, agent-env, insights, logs, kv) map to existing resources — **no spurious create/delete**; the auto-named ACR and the existing Postgres (createPostgres=false) correctly fall under *Ignore*. The pre-fix template would have tried to create a *new App Service* for the agent.

Part of #76 (already closed) — this corrects the T deliverable. No app/runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)