### PR TITLE
docs: mark production-grade Phases 3–5 complete + record verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,19 @@ complete:
 | 7 | Zapier/Make companion flows | ✅ |
 
 On top of the original plan, a **production-grade AI program** (epic #43) hardens the
-system for real operation — **Phase 1** (real Adzuna ingestion, Langfuse tracing, eval
-harness) and **Phase 2** (rate-limiting + cost ceiling, PII redaction, two-tier eval
-gating, prompt-injection + output-moderation guardrails) are complete; Phases 3–5
-(LangGraph/MCP/streaming, hybrid RAG/reranker, IaC/e2e/load) are deferred. Full
-breakdown in [docs/ROADMAP.md](docs/ROADMAP.md).
+system for real operation and is now **fully complete (Phases 1–5)**:
+
+| Phase | Scope | Status |
+| --- | --- | --- |
+| 1 | Real Adzuna ingestion, Langfuse tracing, eval harness (#43) | ✅ |
+| 2 | Rate-limiting + cost ceiling, PII redaction, two-tier eval gating, injection + moderation guardrails (#51) | ✅ |
+| 3 | LangGraph application-assistant + MCP (server + client) + end-to-end SSE streaming (#61) | ✅ |
+| 4 | Hybrid retrieval (pgvector + Postgres FTS via RRF) + CPU cross-encoder reranker + retrieval-mode eval (#70) | ✅ |
+| 5 | Hardening: job-search caching, Bicep IaC, k6 load test, Playwright e2e (#76) | ✅ |
+
+CI now runs the repo checks **plus the API test suite, Bicep validation, and a (secret-gated)
+web e2e job** alongside the agent/MCP pytest. Phase 4's measured retrieval gains are in
+[EVALS.md](EVALS.md); the full breakdown is in [docs/ROADMAP.md](docs/ROADMAP.md).
 
 Phase 6 hosting and data layer are fully live and verified end to end: web, API,
 and the Python agent are deployed, and the cloud Postgres carries the complete

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,6 +41,11 @@ CRM and orchestration; a Python service owns the real AI.
   wraps the composite job source so identical searches within `JOB_SEARCH_CACHE_TTL_MS`
   (default 5 min) skip the rate-limited Adzuna call. Only successful results are cached, so
   the Remotive fallback still fires on upstream errors; `TTL=0` disables it.
+- **Tested infrastructure (Phase 5).** Infra is codified as Bicep (`infra/`, `what-if`-verified
+  against the live subscription), load-tested with k6 (`load/`), and the web's public surface is
+  smoke-tested with Playwright (`apps/web/e2e/`). CI runs the repo checks **plus** the API
+  `node:test` suite, `az bicep build` validation, and a Clerk-secret-gated e2e job, alongside the
+  agent/MCP `pytest`.
 
 The sections below document the original CRM/data layer, which still underpins
 the system.

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -16,6 +16,12 @@ Phase 6 is complete — the whole stack is live on Azure:
 - **Azure Key Vault** (`jobops-kv`, RBAC) serving the App Service secrets as
   managed-identity references
 
+This footprint is now codified as **Bicep infrastructure-as-code** in [`infra/`](../infra/)
+(Phase 5 · T) — `what-if`-verified against the live `projects` resource group and validated in
+CI (`az bicep build`). See [`infra/README.md`](../infra/README.md) for the topology,
+`what-if`/deploy steps, and the Postgres opt-in flag. The imperative `scripts/azure/provision*.sh`
+scripts remain as the break-glass / historical reference.
+
 The provisioning steps below are retained as the repeatable record of how the stack
 was stood up.
 

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -45,6 +45,19 @@ intelligence.
   (#54); two-tier eval gate (key-free PR checks + main thresholds/regression) + full
   `EVALS.md` (#55); prompt-injection defense + provider-agnostic output moderation +
   groundedness (#56).
+- **Phase 3 — LangGraph + MCP + streaming (epic #61):** stateful application-assistant graph
+  (#63); end-to-end SSE streaming to the dashboard (#64); JobOps MCP server (FastMCP REST
+  bridge, #65); agent-as-MCP-client consuming external tools (#66).
+- **Phase 4 — hybrid retrieval, reranker & eval (epic #70):** hybrid retrieval (pgvector +
+  Postgres FTS via RRF, #67); CPU cross-encoder reranker (opt-in, graceful, #68); retrieval-mode
+  eval with the per-mode comparison committed to `EVALS.md` (#69). Measured: retrieval grounding
+  ≈3× faithfulness; hybrid/rerank within judge variance vs vector on the 16-row gold set.
+  Fine-tuning dropped (CPU-only infra).
+- **Phase 5 — operational hardening (epic #76):** job-search TTL cache + the API `node:test`
+  suite wired into CI (#77); Bicep IaC of the live Azure topology, CI-validated + `what-if`-verified
+  (#78); k6 load test verified against the live API (#79); Playwright e2e verified locally and
+  against the deployed web (#80). End-to-end verified 2026-06-18 (live API `db:ok`, k6 thresholds
+  pass, e2e 5/5).
 - Numbered independently of the original phases; design/plans in `docs/superpowers/`.
 
 ## What Is Live Now
@@ -98,9 +111,12 @@ intelligence.
 - Nothing blocking. All planned phases (0–11) plus the optional Phase 6
   hardening (App Insights, Key Vault) are complete. The agent Container App
   keeps its native secret store by design (Key Vault covers App Service only).
-- The **production-grade AI program** (epic #43) is complete through its Phase 1 and
-  Phase 2; its Phases 3–5 (LangGraph/MCP/streaming, hybrid RAG/reranker, IaC/e2e/load)
-  are intentionally deferred.
+- The **production-grade AI program** (epic #43) is **fully complete** — Phases 1–5
+  (LLMOps backbone, safety/guardrails, LangGraph+MCP+streaming, hybrid retrieval+reranker+eval,
+  operational hardening; epics #43/#51/#61/#70/#76) all landed and were verified end to end.
+- **Owner-gated optional follow-ups** (by design, not gaps; see `docs/ROADMAP.md`): applying the
+  Bicep to a live/greenfield RG, running k6 in CI, and activating the gated e2e CI job (needs
+  Clerk repo secrets). Fine-tuning and a larger retrieval gold set remain deferred.
 
 ## How To Verify The Live Stack
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,11 @@
 The AI-agent push ran Phase 9 -> Phase 10 -> Phase 8 -> Phase 11 -> Phase 6, all
 landed. Phase 7 (Zapier + Make companion flows) is now complete as well.
 
+On top of the original 0–11 plan, the **production-grade AI program** (epics #43 → #51 →
+#61 → #70 → #76) is **fully complete** — its Phases 1–5 (LLMOps backbone, safety/guardrails,
+LangGraph+MCP+streaming, hybrid retrieval+reranker+eval, operational hardening) all landed.
+See the dedicated section below.
+
 ## Phase 0: Project Foundation
 
 Done:
@@ -152,8 +157,9 @@ Complete:
 
 ## Production-grade AI program (beyond the original 0–11 plan)
 
-A separate hardening initiative (epic #43 → #51) that turns *"I built an AI app"* into
-*"I operate AI on real data with tracing, evals, and guardrails."* Numbered
+A separate hardening initiative (epics #43 → #51 → #61 → #70 → #76, **all complete**) that
+turns *"I built an AI app"* into *"I operate AI on real data with tracing, evals, guardrails,
+agentic orchestration, measured retrieval, and tested infrastructure."* Numbered
 **independently** of the phases above (its "Phase 1/2" are not the original Phases 1/2).
 Design + plans live under `docs/superpowers/specs|plans/`.
 
@@ -166,7 +172,7 @@ Design + plans live under `docs/superpowers/specs|plans/`.
 - **Eval harness**: deterministic parse-job metrics + Ragas score-fit on a real gold set,
   report-only CI seed (#46).
 
-### Phase 2 — Safety, guardrails & eval gating (complete)
+### Phase 2 — Safety, guardrails & eval gating (complete, epic #51)
 
 - **API edge** (#53): per-user/IP rate limiting + per-user daily AI cost ceiling + `helmet`.
 - **PII** (#54): strip contact-PII before third-party LLMs and mask it in Langfuse traces.
@@ -175,8 +181,46 @@ Design + plans live under `docs/superpowers/specs|plans/`.
 - **LLM I/O guardrails** (#56): prompt-injection defense (scan + delimit) + provider-agnostic
   output moderation + groundedness check on drafted outreach.
 
-### Deferred
+### Phase 3 — LangGraph + MCP + streaming (complete, epic #61)
 
-- Phase 3 — LangGraph + MCP + streaming.
-- Phase 4 — hybrid RAG + reranker + fine-tuning.
-- Phase 5 — IaC / e2e / caching / load test.
+- **LangGraph application-assistant** (#63): a stateful graph that scores fit, then (above a
+  threshold) researches + drafts outreach, else stops with a "pass".
+- **End-to-end SSE streaming** (#64) of the assistant run to the dashboard.
+- **JobOps MCP server** (#65): FastMCP REST bridge exposing the agent's tools over MCP.
+- **Agent as MCP client** (#66): the research agent consumes external MCP tools (Tavily fallback).
+
+### Phase 4 — Hybrid retrieval, reranker & retrieval eval (complete, epic #70)
+
+- **Hybrid retrieval** (#67): pgvector dense + Postgres full-text fused via Reciprocal Rank
+  Fusion, with graceful vector-only fallback.
+- **CPU cross-encoder reranker** (#68): opt-in, graceful, no new dependency.
+- **Retrieval-mode eval** (#69): off/vector/hybrid/hybrid+rerank downstream delta; results in
+  `EVALS.md` (retrieval grounding ≈3× faithfulness; hybrid/rerank within variance vs vector on
+  the 16-row gold set). **Fine-tuning was dropped** (CPU-only infra; needs labeled data + GPU).
+
+### Phase 5 — Operational hardening (complete, epic #76)
+
+- **Caching** (#77): in-process TTL cache for job search (cuts redundant Adzuna calls) — and the
+  API's `node:test` suite wired into CI (it wasn't run before).
+- **IaC** (#78): Bicep codifying the live Azure topology (App Service web/api, Container App
+  agent, Postgres, App Insights, Key Vault); CI-validated via `az bicep build` and `what-if`-verified
+  against the live subscription.
+- **Load test** (#79): k6 script for the API read path with pass/fail thresholds (verified
+  against the live API).
+- **e2e** (#80): Playwright smoke tests for the web public surface + protected-route redirect
+  (verified locally and against the deployed web).
+
+### Operational follow-ups (owner-gated, optional — by design, not gaps)
+
+Intentionally scoped as manual/credentialed steps in the Phase 5 plan, not required deliverables:
+
+- **Apply the Bicep** — authored + `what-if`-verified, but a real `az deployment group create`
+  against the live `projects` RG is intentionally manual (it would rewrite live app settings, and
+  the live apps use Key Vault references the template simplifies). *Recommendation:* keep it as a
+  validated reference; only `create` against a fresh greenfield RG for a from-scratch proof.
+- **k6 in CI** — k6 is a separate binary needing a running target, so it runs on demand
+  (`npm run loadtest`). *Recommendation:* optionally add a manual/scheduled workflow that installs
+  k6 and smoke-tests the deployed API.
+- **Activate the CI e2e job** — gated; skips green until `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` +
+  `CLERK_SECRET_KEY` are set as repo secrets. *Recommendation:* add Clerk test-instance keys to run
+  e2e on PRs.


### PR DESCRIPTION
## Summary
The status docs lagged reality — they still called the production-grade **Phases 3–5 "deferred"** when all three shipped and were verified end to end. Brings every status doc current.

- **README** — production-grade status table now shows Phases 1–5 ✅; notes the expanded CI (API tests + Bicep + gated e2e).
- **docs/ROADMAP.md** — full Phase 3/4/5 breakdowns; new **"Operational follow-ups (owner-gated)"** section documenting the optional residuals (apply Bicep / k6 in CI / e2e secrets) with recommendations.
- **docs/IMPLEMENTATION_STATUS.md** — Phase 3/4/5 entries + "still pending" corrected to "fully complete + owner-gated optionals".
- **docs/ARCHITECTURE.md** — "Tested infrastructure" note (Bicep/k6/Playwright + CI).
- **docs/AZURE_DEPLOYMENT.md** — pointer to the `infra/` Bicep IaC (what-if-verified).

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)