### PR TITLE
ci: on-demand k6 load-test workflow

### DIFF
--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -1,0 +1,41 @@
+# On-demand k6 load test (Phase 5 · S) — addresses the "k6 not in CI" follow-up.
+#
+# Manual only (workflow_dispatch): k6 needs a running target, so this isn't on the
+# per-PR path. Targets the public health probes (no secrets), and the script's own
+# thresholds (req_failed<1%, p95<800ms, checks>99%) fail the run on a regression.
+name: Load test (k6)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Target API base URL
+        required: true
+        default: https://jobops-api.azurewebsites.net
+      profile:
+        description: k6 profile (smoke = 1 VU/10s, load = ramp to 10 VUs)
+        type: choice
+        options:
+          - smoke
+          - load
+        default: smoke
+
+permissions:
+  contents: read
+
+jobs:
+  loadtest:
+    name: k6 (${{ inputs.profile }})
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install k6
+        uses: grafana/setup-k6-action@v1
+
+      - name: Run k6
+        env:
+          BASE_URL: ${{ inputs.base_url }}
+          PROFILE: ${{ inputs.profile }}
+        run: k6 run load/api-read-path.js


### PR DESCRIPTION
Addresses the Phase 5 *k6 not in CI* follow-up. A **manual** (`workflow_dispatch`) workflow that installs k6 and runs `load/api-read-path.js` against a chosen `BASE_URL`/`PROFILE`. Manual (not per-PR) because k6 needs a running target; targets the public health probes so no secrets are needed, and the script's thresholds (req_failed<1%, p95<800ms, checks>99%) fail the run on a regression.

Verified the script itself already runs green against the live API (smoke + 10-VU load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)