### PR TITLE
fix(web): don't mislabel an idle agent as mock; surface assistant errors

### DIFF
--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -29,7 +29,22 @@ export default async function SettingsPage() {
   ]);
 
   const provider = status?.agent.provider ?? null;
-  const providerLabel = provider ? (PROVIDER_LABELS[provider] ?? provider) : 'Not configured';
+  // The agent is a scale-to-zero Container App: when it's asleep, /api/status can't
+  // reach it within the health-check timeout, so provider/model come back empty even
+  // though a real LLM-backed agent IS configured. Distinguish "configured but idle"
+  // from "no agent / deterministic mock" so the card doesn't mislabel a sleeping agent.
+  const agentEnabled = Boolean(status?.agent.enabled);
+  const agentReachable = Boolean(status?.agent.reachable);
+  const providerLabel = provider
+    ? (PROVIDER_LABELS[provider] ?? provider)
+    : agentEnabled
+      ? 'AI agent service'
+      : 'Not configured';
+  const providerDetail = status?.agent.model
+    ? String(status.agent.model)
+    : agentEnabled
+      ? 'Idle — the agent scales to zero and wakes on the first request'
+      : 'Deterministic mock (no LLM provider attached)';
   const initial = (profile?.displayName ?? 'You').slice(0, 1).toUpperCase();
 
   const integrations = [
@@ -80,17 +95,15 @@ export default async function SettingsPage() {
       </SectionCard>
 
       <SectionCard title="AI provider" description="Configured on the server — shown here for transparency.">
-        <Card className={cn('gap-1 p-4', provider ? 'border-primary/50 bg-primary/5' : '')}>
+        <Card className={cn('gap-1 p-4', provider || agentEnabled ? 'border-primary/50 bg-primary/5' : '')}>
           <div className="flex items-center justify-between gap-2">
             <p className="text-sm font-medium">{providerLabel}</p>
             <Badge variant="secondary" className="gap-1">
-              <StatusDot on={Boolean(status?.agent.reachable && status.agent.llm_configured !== false)} />
-              {status?.agent.reachable ? 'Connected' : status?.agent.enabled ? 'Idle' : 'Mock fallback'}
+              <StatusDot on={Boolean(agentReachable && status?.agent.llm_configured !== false)} />
+              {agentReachable ? 'Connected' : agentEnabled ? 'Idle' : 'Mock fallback'}
             </Badge>
           </div>
-          <p className="text-muted-foreground text-xs">
-            {status?.agent.model ?? 'Deterministic mock (no LLM provider attached)'}
-          </p>
+          <p className="text-muted-foreground text-xs">{providerDetail}</p>
         </Card>
       </SectionCard>
 

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -35,6 +35,8 @@ export default async function SettingsPage() {
   // from "no agent / deterministic mock" so the card doesn't mislabel a sleeping agent.
   const agentEnabled = Boolean(status?.agent.enabled);
   const agentReachable = Boolean(status?.agent.reachable);
+  // Reachable AND a usable LLM key — drives both the dot and the badge text so they agree.
+  const agentConnected = agentReachable && status?.agent.llm_configured !== false;
   const providerLabel = provider
     ? (PROVIDER_LABELS[provider] ?? provider)
     : agentEnabled
@@ -99,8 +101,8 @@ export default async function SettingsPage() {
           <div className="flex items-center justify-between gap-2">
             <p className="text-sm font-medium">{providerLabel}</p>
             <Badge variant="secondary" className="gap-1">
-              <StatusDot on={Boolean(agentReachable && status?.agent.llm_configured !== false)} />
-              {agentReachable ? 'Connected' : agentEnabled ? 'Idle' : 'Mock fallback'}
+              <StatusDot on={agentConnected} />
+              {agentConnected ? 'Connected' : agentEnabled ? 'Idle' : 'Mock fallback'}
             </Badge>
           </div>
           <p className="text-muted-foreground text-xs">{providerDetail}</p>

--- a/apps/web/src/components/assistant-panel.tsx
+++ b/apps/web/src/components/assistant-panel.tsx
@@ -73,12 +73,18 @@ export function AssistantPanel() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ description_text: description, resume_text: resume }),
       });
-      if (res.status === 503) {
-        toast.error('The AI agent service is not available right now.');
-        return;
-      }
       if (!res.ok || !res.body) {
-        toast.error('Assistant run failed.');
+        // Surface the upstream reason when present (e.g. "Assistant stream unavailable")
+        // instead of a generic message, so a failed run isn't a confusing no-op.
+        let message =
+          res.status === 503 ? 'The AI agent service is not available right now.' : 'Assistant run failed.';
+        try {
+          const data = (await res.json()) as { error?: string };
+          if (data?.error) message = data.error;
+        } catch {
+          // non-JSON body — keep the default message
+        }
+        toast.error(message);
         return;
       }
       const reader = res.body.getReader();


### PR DESCRIPTION
## Summary
Two UX fixes found during the live end-to-end test pass.

**#4 — Settings "AI provider" card mislabeled a sleeping agent as mock.** The agent is a scale-to-zero Container App; when asleep, `/api/status` can't reach its `/health` within the timeout, so `provider`/`model` come back empty. The card then showed **"Not configured / Deterministic mock"** even though a real OpenAI-backed agent is configured. Now distinguishes **configured-but-idle** (`agent.enabled`) → "AI agent service · Idle — wakes on first request" from **no agent** → "Deterministic mock". Warm agent still shows "OpenAI · gpt-… · Connected".

**#3 — Assistant errors are now specific.** A failed run surfaces the upstream `{error}` message (e.g. the agent's reason) instead of a generic "Assistant run failed."

## Context
Companion to the **agent redeploy** (done separately, not a PR): the deployed agent image was 8 days stale (June 10) and lacked the Phase 3 `/assistant/stream` endpoint — I rebuilt + redeployed it, which fixes the Assistant and makes Phase 4 hybrid retrieval live. This PR is the UX polish on top.

## Test Plan
- [x] `lint:web` + `typecheck:web` pass
- [ ] After merge + web deploy: Settings shows "Idle"/"Connected" (not "mock"); assistant errors show specific message