### PR TITLE
feat(ops): one-command agent deploy + CI build-push (anti stale-agent)

### DIFF
--- a/.github/workflows/deploy-agent.yml
+++ b/.github/workflows/deploy-agent.yml
@@ -1,0 +1,61 @@
+# Build + push the agent image to ACR on any agent change.
+#
+# Why only build+push (not a full deploy): the Azure tenant blocks the service principal
+# GitHub Actions would need to call ARM, so CI can't run `az containerapp update`. Instead
+# CI keeps a freshly-built image in ACR and loudly reminds you to activate it locally with
+# `scripts/azure/deploy-agent.sh --activate <sha>` (uses your interactive `az login`).
+# This removes the slow local Torch build from the activation step and makes a stale agent
+# impossible to forget (every agent change produces a run + a reminder).
+name: Build agent image (ACR)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/agent/**'
+      - '.github/workflows/deploy-agent.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-agent
+  cancel-in-progress: false
+
+jobs:
+  build-push:
+    name: Build + push agent image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      ACR: ca9ee6437892acr
+      IMAGE: ca9ee6437892acr.azurecr.io/jobops-agent
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Log in to ACR
+        run: echo "${{ secrets.ACR_PASSWORD }}" | docker login "${ACR}.azurecr.io" -u "${{ secrets.ACR_USERNAME }}" --password-stdin
+
+      - name: Build (linux/amd64) + push
+        run: |
+          docker build --platform linux/amd64 -t "${IMAGE}:${GITHUB_SHA}" -t "${IMAGE}:latest" services/agent
+          docker push "${IMAGE}:${GITHUB_SHA}"
+          docker push "${IMAGE}:latest"
+
+      - name: Activation reminder
+        run: |
+          {
+            echo "## ⚠️ Agent image built & pushed — NOT yet activated"
+            echo ""
+            echo "CI cannot update the Container App (the Azure-for-Students tenant blocks the service"
+            echo "principal needed to call ARM). **Activate the new image locally:**"
+            echo ""
+            echo '```bash'
+            echo "az login   # if your token is stale"
+            echo "bash scripts/azure/deploy-agent.sh --activate ${GITHUB_SHA}"
+            echo '```'
+            echo ""
+            echo "Image: \`${IMAGE}:${GITHUB_SHA}\` (also tagged \`:latest\`)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-agent.yml
+++ b/.github/workflows/deploy-agent.yml
@@ -59,3 +59,7 @@ jobs:
             echo ""
             echo "Image: \`${IMAGE}:${GITHUB_SHA}\` (also tagged \`:latest\`)."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Log out of ACR
+        if: always()
+        run: docker logout "${ACR}.azurecr.io"

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -125,9 +125,13 @@ Deploy workflows (canonical):
   deploys it, and gates on a `/api/health` check returning `"mode":"postgres"`.
 - **Web** — `.github/workflows/deploy-web.yml` runs on push to `main` under
   `apps/web/**` (and on manual dispatch), deploying the Next.js standalone bundle.
-- **Agent** — containerized: build `services/agent/Dockerfile`, push to ACR, then
-  `az containerapp update`. The `azure-app-service.yml` agent target is a code-deploy
-  fallback for a no-RAG agent only.
+- **Agent** — containerized. Run **`bash scripts/azure/deploy-agent.sh`** (one command:
+  build `linux/amd64` → push to ACR → `az containerapp update` → verify). CI
+  (`.github/workflows/deploy-agent.yml`) auto-builds + pushes the image on every
+  `services/agent/**` change, but **can't activate it** — the Azure-for-Students tenant
+  blocks the service principal CI would need for ARM — so it reminds you to run
+  `scripts/azure/deploy-agent.sh --activate <sha>` (skips the slow local rebuild). The
+  `azure-app-service.yml` agent target is a code-deploy fallback for a no-RAG agent only.
 
 ## Recommended Phase 6 Order
 

--- a/scripts/azure/deploy-agent.sh
+++ b/scripts/azure/deploy-agent.sh
@@ -56,7 +56,15 @@ done
 stream="$(curl -s "https://$fqdn/openapi.json" --max-time 50 | grep -c '/assistant/stream' || true)"
 
 echo ""
-echo "==> Done."
 echo "    health           : $health"
 echo "    /assistant/stream: $([ "${stream:-0}" -gt 0 ] && echo 'present ✓' || echo 'MISSING ✗')"
 echo "    agent            : https://$fqdn"
+
+# Hard-fail on a bad activation so a broken deploy can't go unnoticed (the whole
+# point of this tool is to make stale/broken agents impossible to miss).
+if [ "$health" = "200" ] && [ "${stream:-0}" -gt 0 ]; then
+  echo "==> Done ✓"
+else
+  echo "==> Verify FAILED — agent unhealthy or /assistant/stream missing" >&2
+  exit 1
+fi

--- a/scripts/azure/deploy-agent.sh
+++ b/scripts/azure/deploy-agent.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# One-command deploy for the JobOps agent (Azure Container App).
+#
+# Why this exists: unlike the API/web (auto-deployed by GitHub Actions), the agent
+# Container App has NO fully-automated CI deploy — the Azure tenant (Azure for Students
+# on purdue.edu) blocks creating the service principal that GitHub Actions would need to
+# call ARM (`az containerapp update`). A forgotten step in the manual build→push→update
+# sequence once left the deployed agent 8 days stale and broke the Assistant. This script
+# collapses that whole sequence into one command (run locally with your `az login`).
+#
+# Usage:
+#   az login                                            # if your token is stale
+#   bash scripts/azure/deploy-agent.sh                  # build + push + activate + verify
+#   bash scripts/azure/deploy-agent.sh --activate <tag> # activate an already-pushed tag
+#                                                        # (e.g. a CI-built image:  <git-sha>)
+#
+# The CI workflow .github/workflows/deploy-agent.yml auto-builds + pushes on every
+# services/agent change, so `--activate <sha>` lets you skip the slow local build.
+set -euo pipefail
+
+RG="${RG:-projects}"
+APP="${APP:-jobops-agent}"
+ACR="${ACR:-ca9ee6437892acr}"
+IMAGE="$ACR.azurecr.io/jobops-agent"
+
+activate_tag=""
+if [ "${1:-}" = "--activate" ]; then
+  activate_tag="${2:?Provide a tag, e.g. --activate <git-sha>}"
+fi
+
+if [ -z "$activate_tag" ]; then
+  TAG="${TAG:-$(date +%Y%m%d%H%M)}"
+  echo "==> Building $IMAGE:$TAG (linux/amd64, CPU torch — a few minutes)"
+  docker build --platform linux/amd64 -t "$IMAGE:$TAG" -t "$IMAGE:latest" services/agent
+  echo "==> Logging in to ACR + pushing"
+  az acr login -n "$ACR"
+  docker push "$IMAGE:$TAG"
+  docker push "$IMAGE:latest"
+  deploy_tag="$TAG"
+else
+  deploy_tag="$activate_tag"
+fi
+
+echo "==> Updating Container App $APP -> $IMAGE:$deploy_tag"
+az containerapp update -g "$RG" -n "$APP" --image "$IMAGE:$deploy_tag" -o none
+
+echo "==> Verifying the new revision (waking the scale-to-zero app)"
+fqdn="$(az containerapp show -g "$RG" -n "$APP" --query properties.configuration.ingress.fqdn -o tsv)"
+health="000"
+for _ in 1 2 3 4 5 6 7 8; do
+  health="$(curl -s -o /dev/null -w '%{http_code}' --max-time 50 "https://$fqdn/health" || true)"
+  [ "$health" = "200" ] && break
+  sleep 5
+done
+stream="$(curl -s "https://$fqdn/openapi.json" --max-time 50 | grep -c '/assistant/stream' || true)"
+
+echo ""
+echo "==> Done."
+echo "    health           : $health"
+echo "    /assistant/stream: $([ "${stream:-0}" -gt 0 ] && echo 'present ✓' || echo 'MISSING ✗')"
+echo "    agent            : https://$fqdn"


### PR DESCRIPTION
## Summary
Closes the structural gap that caused the stale-agent bug found in testing: the agent Container App had **no automated deploy**, and the manual build→push→update sequence was easy to forget (it once left the agent 8 days stale, breaking the Assistant + Phase 4 hybrid RAG).

**Full CI deploy isn't possible** — the Azure-for-Students tenant (`purdue.edu`) blocks creating the service principal GitHub Actions would need to call ARM (`az containerapp update`). Verified: `az ad sp create-for-rbac` → *"Insufficient privileges to register the application."* So:

- **`scripts/azure/deploy-agent.sh`** — one command (build `linux/amd64` → ACR push → `az containerapp update` → verify `/assistant/stream`), run locally with your `az login`. `--activate <tag>` activates an already-built image without the slow local rebuild.
- **`.github/workflows/deploy-agent.yml`** — auto **builds + pushes** the image to ACR on every `services/agent/**` change (ACR admin creds, no Azure AD), then writes a **loud Step Summary** with the exact activate command. The image is never stale in ACR, and forgetting to deploy is now impossible to miss.

## Test Plan
- [x] `bash -n` script syntax + workflow YAML valid; script marked executable
- [x] ACR admin creds set as repo secrets (`ACR_USERNAME`/`ACR_PASSWORD`)
- [ ] Merging triggers `deploy-agent.yml` (it changes the workflow path) → confirms build+push works end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)