### PR TITLE
feat(agent): authenticate the API→agent hop (QA·A, #92)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ AZURE_STORAGE_CONTAINER_NAME=
 # (services/agent). Leave blank to use the built-in deterministic mock.
 AGENT_SERVICE_URL=http://127.0.0.1:8000
 AGENT_TIMEOUT_MS=60000
+# Server-to-server shared secret for the API→agent hop (QA·A). Set the SAME value on
+# the API (AGENT_API_KEY) and the agent service. When the agent sees it set, every
+# request (except /health + docs) must carry `Authorization: Bearer <key>`. Leave
+# blank locally to disable auth. Generate with: openssl rand -hex 32
+AGENT_API_KEY=
 # LLM configuration is consumed by the Python agent service. Supported
 # providers: anthropic | azure_openai | openai | google_genai. Leave
 # LLM_PROVIDER blank to auto-select the first one with credentials.

--- a/apps/api/src/lib/agent-client.test.ts
+++ b/apps/api/src/lib/agent-client.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { agentHeaders } from './agent-client';
+
+// agentHeaders reads AGENT_API_KEY lazily, so each case toggles the env directly (QA·A).
+test('agentHeaders attaches a Bearer token when AGENT_API_KEY is set', () => {
+  process.env.AGENT_API_KEY = 'sh4red-secret';
+  try {
+    const headers = agentHeaders({ 'Content-Type': 'application/json' });
+    assert.equal(headers.Authorization, 'Bearer sh4red-secret');
+    assert.equal(headers['Content-Type'], 'application/json');
+  } finally {
+    delete process.env.AGENT_API_KEY;
+  }
+});
+
+test('agentHeaders omits Authorization when AGENT_API_KEY is unset', () => {
+  delete process.env.AGENT_API_KEY;
+  const headers = agentHeaders({ 'Content-Type': 'application/json' });
+  assert.equal('Authorization' in headers, false);
+  assert.equal(headers['Content-Type'], 'application/json');
+});
+
+test('agentHeaders works with no extra headers', () => {
+  process.env.AGENT_API_KEY = 'k';
+  try {
+    assert.equal(agentHeaders().Authorization, 'Bearer k');
+  } finally {
+    delete process.env.AGENT_API_KEY;
+  }
+});

--- a/apps/api/src/lib/agent-client.ts
+++ b/apps/api/src/lib/agent-client.ts
@@ -25,6 +25,21 @@ const AGENT_TIMEOUT_MS = Number(process.env.AGENT_TIMEOUT_MS ?? 60_000);
 // Tool-using agents (Phase 8) can take longer than the single-shot chains.
 const AGENT_TASK_TIMEOUT_MS = Number(process.env.AGENT_TASK_TIMEOUT_MS ?? 120_000);
 
+/**
+ * Build request headers for an agent call, attaching the server-to-server shared
+ * secret (QA·A) when AGENT_API_KEY is configured. The agent is reached over its
+ * public FQDN, so this Bearer token is what authenticates the API→agent hop.
+ * Read lazily (not at module load) so the env reflects the current process state.
+ */
+export function agentHeaders(extra?: Record<string, string>): Record<string, string> {
+  const headers: Record<string, string> = { ...extra };
+  const key = process.env.AGENT_API_KEY?.trim();
+  if (key) {
+    headers.Authorization = `Bearer ${key}`;
+  }
+  return headers;
+}
+
 /** Thrown when an agent task is requested but the service is not configured. */
 export class AgentDisabledError extends Error {
   constructor() {
@@ -40,7 +55,7 @@ export function isAgentEnabled(): boolean {
 async function callAgent<T>(path: string, payload: unknown, timeoutMs = AGENT_TIMEOUT_MS): Promise<T> {
   const response = await fetch(`${AGENT_URL}${path}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: agentHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify(payload),
     signal: AbortSignal.timeout(timeoutMs),
   });
@@ -103,7 +118,7 @@ export async function streamAssistantUpstream(payload: unknown): Promise<Respons
   }
   return fetch(`${AGENT_URL}/assistant/stream`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: agentHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify(payload),
     signal: AbortSignal.timeout(AGENT_TASK_TIMEOUT_MS),
   });
@@ -120,6 +135,7 @@ export async function fetchEvDemoViaAgent(): Promise<TelemetryInsights> {
     throw new AgentDisabledError();
   }
   const response = await fetch(`${AGENT_URL}/telemetry/ev-demo`, {
+    headers: agentHeaders(),
     signal: AbortSignal.timeout(AGENT_TASK_TIMEOUT_MS),
   });
   if (!response.ok) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,6 +186,20 @@ The Express API protects the expensive AI paths (Phase 2 · Workstream G):
 All guards degrade gracefully: the usage store falls back to in-memory without a
 database, and budget accounting fails open so a store hiccup never blocks AI calls.
 
+## Service-to-service auth (API to agent)
+
+The Python agent runs as a public Container App and is called by the Node API over its
+internet-facing FQDN (the two live in different regions, so network isolation isn't an
+option). Every API to agent request therefore carries a shared secret in
+`Authorization: Bearer <AGENT_API_KEY>`; the agent's middleware
+(`services/agent/app/auth.py`) rejects anything else with `401`. The liveness probe
+(`/health`) and the OpenAPI/docs surface stay open so health probes and the
+`deploy-agent.sh` verify keep working without the secret. When `AGENT_API_KEY` is unset
+the agent leaves auth disabled (local dev / before the secret is provisioned), so set the
+**same** value on the API app and the agent container in any internet-reachable
+environment. See [`docs/AZURE_DEPLOYMENT.md`](AZURE_DEPLOYMENT.md) for the provisioning
+steps.
+
 ## Privacy & PII
 
 The agent strips high-precision **contact-PII** (email / phone / URL / SSN) from

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -139,24 +139,42 @@ The agent Container App is internet-facing (the API reaches it across regions ov
 public FQDN), so it authenticates every request with a shared secret. Provision the
 **same** value on both sides once per environment:
 
+Run the steps **in this order** — the API must be sending the Bearer header before the
+agent starts enforcing, or there's a window where authenticated agent calls get 401s:
+
 ```bash
 KEY="$(openssl rand -hex 32)"
 
-# Agent (Container App): store as a secret + reference it from the AGENT_API_KEY env var
-az containerapp secret set -g projects -n jobops-agent --secrets agent-api-key="$KEY"
-az containerapp update    -g projects -n jobops-agent \
-  --set-env-vars AGENT_API_KEY=secretref:agent-api-key
-
-# API (App Service): same value as a plain app setting
+# 1. API (App Service) FIRST: same value as a plain app setting, so the API starts
+#    sending the Bearer header. Harmless while the agent isn't enforcing yet.
 az webapp config appsettings set -g projects -n jobops-api \
   --settings AGENT_API_KEY="$KEY"
+
+# 2. Agent (Container App) LAST: store the secret, then point AGENT_API_KEY at it.
+#    The `update --set-env-vars` rolls a NEW revision, which is when enforcement begins.
+az containerapp secret set -g projects -n jobops-agent --secrets agent-api-key="$KEY"
+az containerapp update     -g projects -n jobops-agent \
+  --set-env-vars AGENT_API_KEY=secretref:agent-api-key
 ```
 
-For zero downtime, set the **API** value first and the **agent** secret last: the agent
-starts enforcing the moment its secret exists, while the API harmlessly sends the Bearer
-header even before the agent enforces. The Bicep template (`infra/main.bicep`) models both
-via the `agentApiKey` secure param. `/health` + `/openapi.json` stay open, so
-`scripts/azure/deploy-agent.sh` verify is unaffected.
+The agent enforces the moment its revision picks up the secret; doing the API first means
+it's already sending the header by then (zero downtime). The Bicep template
+(`infra/main.bicep`) models both via the `agentApiKey` secure param. `/health` +
+`/openapi.json` stay open, so `scripts/azure/deploy-agent.sh` verify is unaffected.
+
+**Rotating the key later:** Container Apps secrets are app-scoped and a secret-value change
+does **not** automatically roll running replicas. Update the API setting first, then
+`az containerapp secret set` **and force a new revision** so the agent actually reloads it:
+
+```bash
+az containerapp secret set -g projects -n jobops-agent --secrets agent-api-key="$NEW_KEY"
+az containerapp revision restart -g projects -n jobops-agent \
+  --revision "$(az containerapp show -g projects -n jobops-agent \
+    --query properties.latestRevisionName -o tsv)"
+```
+
+The same caveat applies to the Bicep path: changing `agentApiKey` alone won't restart the
+agent — redeploy something that rolls a revision (or `revision restart`) for it to take effect.
 
 Verify afterwards: an unauthenticated `POST /rag/search` to the agent FQDN must return
 `401`, while the app's AI features (job analyze, score-fit, assistant) still work.

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -133,6 +133,34 @@ Deploy workflows (canonical):
   `scripts/azure/deploy-agent.sh --activate <sha>` (skips the slow local rebuild). The
   `azure-app-service.yml` agent target is a code-deploy fallback for a no-RAG agent only.
 
+## Agent service-to-service auth (AGENT_API_KEY)
+
+The agent Container App is internet-facing (the API reaches it across regions over its
+public FQDN), so it authenticates every request with a shared secret. Provision the
+**same** value on both sides once per environment:
+
+```bash
+KEY="$(openssl rand -hex 32)"
+
+# Agent (Container App): store as a secret + reference it from the AGENT_API_KEY env var
+az containerapp secret set -g projects -n jobops-agent --secrets agent-api-key="$KEY"
+az containerapp update    -g projects -n jobops-agent \
+  --set-env-vars AGENT_API_KEY=secretref:agent-api-key
+
+# API (App Service): same value as a plain app setting
+az webapp config appsettings set -g projects -n jobops-api \
+  --settings AGENT_API_KEY="$KEY"
+```
+
+For zero downtime, set the **API** value first and the **agent** secret last: the agent
+starts enforcing the moment its secret exists, while the API harmlessly sends the Bearer
+header even before the agent enforces. The Bicep template (`infra/main.bicep`) models both
+via the `agentApiKey` secure param. `/health` + `/openapi.json` stay open, so
+`scripts/azure/deploy-agent.sh` verify is unaffected.
+
+Verify afterwards: an unauthenticated `POST /rag/search` to the agent FQDN must return
+`401`, while the app's AI features (job analyze, score-fit, assistant) still work.
+
 ## Recommended Phase 6 Order
 
 1. Deploy the Next.js dashboard to Azure Static Web Apps or another Azure web host.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -60,6 +60,12 @@ param postgresAdminPassword string = ''
 @description('Full DATABASE_URL connection string injected into the API + agent.')
 param databaseUrl string = ''
 
+@secure()
+@description('''Server-to-server shared secret authenticating the API->agent hop (QA·A).
+Set on the API as AGENT_API_KEY and on the agent as a container secret; when blank the
+agent leaves auth disabled. Generate with e.g. `openssl rand -hex 32`.''')
+param agentApiKey string = ''
+
 @description('Agent LLM provider: anthropic | openai | azure_openai | google_genai.')
 param llmProvider string = 'openai'
 
@@ -176,6 +182,10 @@ resource apiApp 'Microsoft.Web/sites@2023-12-01' = {
           value: 'https://${agentApp.properties.configuration.ingress.fqdn}'
         }
         {
+          name: 'AGENT_API_KEY'
+          value: agentApiKey
+        }
+        {
           name: 'API_PUBLIC_BASE_URL'
           value: apiHost
         }
@@ -229,6 +239,14 @@ resource agentApp 'Microsoft.App/containerApps@2024-03-01' = {
         targetPort: 8000
         transport: 'auto'
       }
+      // Server-to-server shared secret (QA·A): the agent is internet-facing (the API
+      // reaches it across regions over this FQDN), so every request must carry it.
+      secrets: [
+        {
+          name: 'agent-api-key'
+          value: agentApiKey
+        }
+      ]
       // ACR pull auth (registries/identity) is configured by the container pipeline.
     }
     template: {
@@ -241,6 +259,10 @@ resource agentApp 'Microsoft.App/containerApps@2024-03-01' = {
             memory: '1Gi'
           }
           env: [
+            {
+              name: 'AGENT_API_KEY'
+              secretRef: 'agent-api-key'
+            }
             {
               name: 'LLM_PROVIDER'
               value: llmProvider

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -245,6 +245,9 @@ resource agentApp 'Microsoft.App/containerApps@2024-03-01' = {
       }
       // Server-to-server shared secret (QA·A): the agent is internet-facing (the API
       // reaches it across regions over this FQDN), so every request must carry it.
+      // NOTE: Container Apps secrets are app-scoped and a value change does NOT auto-roll
+      // running revisions — after rotating `agentApiKey`, restart/roll a revision so the
+      // agent reloads it (see docs/AZURE_DEPLOYMENT.md "Rotating the key later").
       secrets: [
         {
           name: 'agent-api-key'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -182,6 +182,10 @@ resource apiApp 'Microsoft.Web/sites@2023-12-01' = {
           value: 'https://${agentApp.properties.configuration.ingress.fqdn}'
         }
         {
+          // Plain app setting from a @secure() param (App Service encrypts settings at
+          // rest), matching how databaseUrl is injected below. The agent side uses a
+          // proper Container App secret (configuration.secrets). Promote to a Key Vault
+          // reference if the API control-plane threat model warrants it.
           name: 'AGENT_API_KEY'
           value: agentApiKey
         }

--- a/services/agent/app/auth.py
+++ b/services/agent/app/auth.py
@@ -1,0 +1,49 @@
+"""Server-to-server authentication for the agent service (QA·A).
+
+The agent runs as a public Container App and is called over its internet-facing
+FQDN by the Node API (different compute, different region), so network isolation
+isn't available. Every request must therefore present the shared secret in the
+``Authorization: Bearer <AGENT_API_KEY>`` (or ``X-Agent-Key``) header.
+
+Exemptions: the liveness probe and the OpenAPI/docs surface stay open so the
+container health probe and ``scripts/azure/deploy-agent.sh`` verify keep working
+without the secret. When ``AGENT_API_KEY`` is unset, auth is disabled entirely
+(local dev / before the secret is provisioned in prod).
+"""
+
+from __future__ import annotations
+
+import hmac
+from collections.abc import Mapping
+
+from app.config import settings
+
+# Reachable without the shared secret: container liveness probe + the API schema
+# /docs (used by health probes and the deploy-agent.sh `/openapi.json` verify).
+PUBLIC_PATHS: frozenset[str] = frozenset(
+    {"/health", "/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}
+)
+
+
+def extract_key(headers: Mapping[str, str]) -> str | None:
+    """Pull the shared secret from the Authorization (Bearer) or X-Agent-Key header."""
+    authorization = headers.get("authorization")
+    if authorization and authorization[:7].lower() == "bearer ":
+        return authorization[7:].strip()
+    return headers.get("x-agent-key")
+
+
+def is_authorized(path: str, headers: Mapping[str, str]) -> bool:
+    """True when the request may proceed.
+
+    Allows everything when no key is configured (auth disabled), always allows the
+    public probe/docs paths, otherwise requires a constant-time match of the secret.
+    """
+    expected = settings.agent_api_key
+    if not expected:
+        return True
+    if path in PUBLIC_PATHS:
+        return True
+    provided = extract_key(headers) or ""
+    # constant-time compare; compare_digest also returns False on length mismatch.
+    return hmac.compare_digest(provided, expected)

--- a/services/agent/app/auth.py
+++ b/services/agent/app/auth.py
@@ -18,18 +18,22 @@ from collections.abc import Mapping
 
 from app.config import settings
 
-# Reachable without the shared secret: container liveness probe + the API schema
-# /docs (used by health probes and the deploy-agent.sh `/openapi.json` verify).
-PUBLIC_PATHS: frozenset[str] = frozenset(
-    {"/health", "/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}
-)
+# Reachable without the shared secret, kept minimal on purpose:
+#   /health       -> container liveness probe + the API's agent-status check
+#   /openapi.json -> the scripts/azure/deploy-agent.sh verify greps it for routes
+# The rendered doc explorers (/docs, /redoc) are deliberately NOT exempt so an
+# unauthenticated caller can't browse the full route map on an internet-facing service.
+PUBLIC_PATHS: frozenset[str] = frozenset({"/health", "/openapi.json"})
 
 
 def extract_key(headers: Mapping[str, str]) -> str | None:
     """Pull the shared secret from the Authorization (Bearer) or X-Agent-Key header."""
     authorization = headers.get("authorization")
-    if authorization and authorization[:7].lower() == "bearer ":
-        return authorization[7:].strip()
+    if authorization:
+        # Tolerant of multiple spaces/tabs between scheme and token (RFC 7235).
+        parts = authorization.split(None, 1)
+        if len(parts) == 2 and parts[0].lower() == "bearer":
+            return parts[1].strip()
     return headers.get("x-agent-key")
 
 

--- a/services/agent/app/config.py
+++ b/services/agent/app/config.py
@@ -41,6 +41,13 @@ class Settings(BaseSettings):
     request_timeout: int = 60
     llm_temperature: float = 0.2
 
+    # Server-to-server auth (QA·A). The agent is reached over its public Container App
+    # FQDN by the Node API (separate compute/region), so it can't rely on network
+    # isolation. When set, every request must carry this secret in the
+    # `Authorization: Bearer <key>` (or `X-Agent-Key`) header. Unset → auth disabled
+    # (local dev / before the secret is provisioned). Health + docs stay open.
+    agent_api_key: str | None = None
+
     # Optional web-search tool for the research agent (Phase 8)
     tavily_api_key: str | None = None
 

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -12,12 +12,13 @@ import logging
 import os
 import uuid
 
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
 from langgraph.types import Command
 from pydantic import BaseModel, Field
 
 from app.agents.runner import run_interview_prep, run_research, run_skill_gap
+from app.auth import is_authorized
 from app.chains.draft_outreach import draft_outreach
 from app.chains.parse_job import parse_job
 from app.chains.score_fit import score_fit
@@ -74,6 +75,17 @@ app = FastAPI(
     version="0.1.0",
     summary="Real-LLM analysis and agent orchestration for JobOps Copilot.",
 )
+
+
+@app.middleware("http")
+async def _enforce_agent_key(request: Request, call_next):
+    """Reject any request lacking the server-to-server shared secret (QA·A).
+
+    No-op when AGENT_API_KEY is unset; health + docs are always exempt.
+    """
+    if not is_authorized(request.url.path, request.headers):
+        return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
+    return await call_next(request)
 
 
 def _require_llm() -> None:

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -81,9 +81,15 @@ app = FastAPI(
 async def _enforce_agent_key(request: Request, call_next):
     """Reject any request lacking the server-to-server shared secret (QA·A).
 
-    No-op when AGENT_API_KEY is unset; health + docs are always exempt.
+    No-op when AGENT_API_KEY is unset; /health + /openapi.json are always exempt.
     """
     if not is_authorized(request.url.path, request.headers):
+        # Log the rejection (never the attempted key) so scanning is visible in
+        # App Insights — the absence of this trace would hide the very attack this guards.
+        client = request.client.host if request.client else "unknown"
+        logger.warning(
+            "agent auth rejected: %s %s from %s", request.method, request.url.path, client
+        )
         return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
     return await call_next(request)
 

--- a/services/agent/tests/test_auth.py
+++ b/services/agent/tests/test_auth.py
@@ -67,12 +67,31 @@ def test_openapi_exempt_without_key(monkeypatch):
     assert client.get("/openapi.json").status_code == 200
 
 
+def test_docs_explorer_not_exempt(monkeypatch):
+    # The rendered doc UI must NOT be browsable unauthenticated (attack-surface).
+    monkeypatch.setattr(settings, "agent_api_key", KEY)
+    assert client.get("/docs").status_code == 401
+    assert client.get("/redoc").status_code == 401
+
+
+def test_unknown_path_fails_closed(monkeypatch):
+    # Any path outside the route table AND the public allowlist must be denied.
+    monkeypatch.setattr(settings, "agent_api_key", KEY)
+    assert auth.is_authorized("/some/unmapped/route", {}) is False
+
+
+def test_extract_key_tolerates_extra_whitespace():
+    assert auth.extract_key({"authorization": f"Bearer  {KEY}"}) == KEY  # two spaces
+    assert auth.extract_key({"authorization": f"bearer {KEY}"}) == KEY  # lowercase scheme
+
+
 def test_is_authorized_unit(monkeypatch):
     monkeypatch.setattr(settings, "agent_api_key", KEY)
     assert auth.is_authorized("/rag/search", {"authorization": f"Bearer {KEY}"}) is True
     assert auth.is_authorized("/rag/search", {"authorization": "Bearer wrong"}) is False
     assert auth.is_authorized("/rag/search", {}) is False  # length mismatch handled
     assert auth.is_authorized("/health", {}) is True  # exempt
+    assert auth.is_authorized("/docs", {}) is False  # doc UI not exempt
     monkeypatch.setattr(settings, "agent_api_key", None)
     assert auth.is_authorized("/rag/search", {}) is True  # disabled
 

--- a/services/agent/tests/test_auth.py
+++ b/services/agent/tests/test_auth.py
@@ -1,0 +1,83 @@
+"""Server-to-server auth middleware tests (QA·A).
+
+Proves the previously-open agent rejects unauthenticated calls once AGENT_API_KEY
+is set, while keeping the health/docs probe paths open and staying a no-op when
+no key is configured.
+"""
+
+from fastapi.testclient import TestClient
+
+import app.auth as auth
+import app.main as main
+from app.config import settings
+
+client = TestClient(main.app)
+
+KEY = "s3cret-shared-key"
+
+
+def test_auth_disabled_when_key_unset(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", None)
+    # No Authorization header, yet a protected path is reachable (mock fallback story).
+    res = client.post("/rag/search", json={"query": "x"})
+    assert res.status_code != 401
+
+
+def test_protected_path_rejected_without_key(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", KEY)
+    res = client.post("/rag/search", json={"query": "x", "user_id": "victim"})
+    assert res.status_code == 401
+
+
+def test_protected_path_rejected_with_wrong_key(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", KEY)
+    res = client.post(
+        "/rag/search",
+        json={"query": "x"},
+        headers={"Authorization": "Bearer not-the-key"},
+    )
+    assert res.status_code == 401
+
+
+def test_protected_path_allowed_with_bearer_key(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", KEY)
+    monkeypatch.setattr(main, "rag_available", lambda: False)  # short-circuit to 503, past auth
+    res = client.post(
+        "/rag/search",
+        json={"query": "x"},
+        headers={"Authorization": f"Bearer {KEY}"},
+    )
+    assert res.status_code != 401
+
+
+def test_protected_path_allowed_with_x_agent_key(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", KEY)
+    monkeypatch.setattr(main, "rag_available", lambda: False)
+    res = client.post("/rag/search", json={"query": "x"}, headers={"X-Agent-Key": KEY})
+    assert res.status_code != 401
+
+
+def test_health_exempt_without_key(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", KEY)
+    assert client.get("/health").status_code == 200
+
+
+def test_openapi_exempt_without_key(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", KEY)
+    assert client.get("/openapi.json").status_code == 200
+
+
+def test_is_authorized_unit(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", KEY)
+    assert auth.is_authorized("/rag/search", {"authorization": f"Bearer {KEY}"}) is True
+    assert auth.is_authorized("/rag/search", {"authorization": "Bearer wrong"}) is False
+    assert auth.is_authorized("/rag/search", {}) is False  # length mismatch handled
+    assert auth.is_authorized("/health", {}) is True  # exempt
+    monkeypatch.setattr(settings, "agent_api_key", None)
+    assert auth.is_authorized("/rag/search", {}) is True  # disabled
+
+
+def test_extract_key_unit():
+    assert auth.extract_key({"authorization": f"Bearer {KEY}"}) == KEY
+    assert auth.extract_key({"x-agent-key": KEY}) == KEY
+    assert auth.extract_key({}) is None


### PR DESCRIPTION
## Summary
Closes the **CRITICAL** finding from the QA audit (#92, part of epic #91): the agent Container App was internet-facing with **no auth** — an unauthenticated `POST /rag/search` with an arbitrary `user_id` returned `200`, enabling cross-tenant read/poison of resume embeddings and unbounded LLM/embedding cost (billing DoS).

`ingress.external:false` isn't viable (the API is a separate App Service in another region reaching the agent over its public FQDN), so this adds a **server-to-server shared secret**.

- **agent** — middleware (`services/agent/app/auth.py`) requires `Authorization: Bearer <AGENT_API_KEY>` (or `X-Agent-Key`) on every route except `/health` + the OpenAPI/docs surface; constant-time compare (`hmac.compare_digest`). No-op when `AGENT_API_KEY` is unset (local dev / pre-provisioning).
- **api** — `agent-client` sends the Bearer token on every agent call via a central `agentHeaders()` helper (`callAgent`, assistant stream, ev-demo GET); reads env lazily.
- **infra** — Bicep models the secret on both sides via a new `agentApiKey` secure param (API app setting + agent container secret).
- **docs** — ARCHITECTURE trust-boundary section + AZURE_DEPLOYMENT provisioning runbook; `.env.example` documents `AGENT_API_KEY`.

## Test Plan
- [x] Agent: full `pytest` green + `ruff`; new `test_auth.py` proves unauth `/rag/search` → **401**, exempt `/health` + `/openapi.json` open, Bearer/X-Agent-Key accepted, wrong/absent key rejected, disabled when unset.
- [x] API: `npm test` **86 pass** (+3 new `agent-client.test.ts`), `typecheck` + `lint` clean.
- [x] Bicep compiles (`az bicep build`).
- [ ] Post-merge (needs `az`): provision `AGENT_API_KEY` on API + agent (runbook in AZURE_DEPLOYMENT.md), activate new agent image, verify unauth `/rag/search` → 401 and app AI still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)