### PR TITLE
fix(api): weekly-report export best-effort — no more 500 (QA·C, #94)

### DIFF
--- a/apps/api/src/lib/report-export.test.ts
+++ b/apps/api/src/lib/report-export.test.ts
@@ -39,7 +39,7 @@ test('exportWeeklyReportMarkdown returns a URL (no throw) when the local write f
     delete process.env.AZURE_STORAGE_CONTAINER_NAME;
     process.chdir(tempDir);
     // Block `data/report-exports` by planting a FILE where the dir must be created,
-    // so mkdir(recursive) fails with ENOTDIR/EEXIST — a stand-in for the read-only FS.
+    // so mkdir(recursive) fails with EEXIST — a stand-in for the read-only prod FS.
     await mkdir(join(tempDir, 'data'));
     await writeFile(join(tempDir, 'data', 'report-exports'), 'not a directory');
 

--- a/apps/api/src/lib/report-export.test.ts
+++ b/apps/api/src/lib/report-export.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { exportWeeklyReportMarkdown } from '@/lib/report-export';
+import type { WeeklyReportRecord } from '@/types';
+
+function sampleReport(): WeeklyReportRecord {
+  return {
+    id: 'report-1',
+    weekStart: '2026-05-18',
+    weekEnd: '2026-05-24',
+    jobsDiscovered: 1,
+    jobsShortlisted: 1,
+    jobsApplied: 0,
+    outreachDrafted: 0,
+    outreachSent: 0,
+    responsesReceived: 0,
+    interviews: 0,
+    commonMissingSkills: [],
+    recommendations: [],
+    reportMarkdown: '# Weekly report\n',
+    createdAt: new Date().toISOString(),
+  };
+}
+
+// QA·C: the prod App Service filesystem is read-only (WEBSITE_RUN_FROM_PACKAGE=1), so the
+// best-effort local write must never bubble up as a 500 — report generation must succeed
+// and return the DB-backed API export URL.
+test('exportWeeklyReportMarkdown returns a URL (no throw) when the local write fails', async () => {
+  const originalCwd = process.cwd();
+  const conn = process.env.AZURE_STORAGE_CONNECTION_STRING;
+  const container = process.env.AZURE_STORAGE_CONTAINER_NAME;
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-export-readonly-'));
+
+  try {
+    delete process.env.AZURE_STORAGE_CONNECTION_STRING; // force the no-blob local path
+    delete process.env.AZURE_STORAGE_CONTAINER_NAME;
+    process.chdir(tempDir);
+    // Block `data/report-exports` by planting a FILE where the dir must be created,
+    // so mkdir(recursive) fails with ENOTDIR/EEXIST — a stand-in for the read-only FS.
+    await mkdir(join(tempDir, 'data'));
+    await writeFile(join(tempDir, 'data', 'report-exports'), 'not a directory');
+
+    const url = await exportWeeklyReportMarkdown(sampleReport(), {
+      publicBaseUrl: 'https://jobops-api.example.net',
+    });
+
+    assert.equal(url, 'https://jobops-api.example.net/api/reports/report-1/export');
+  } finally {
+    process.chdir(originalCwd);
+    if (conn === undefined) delete process.env.AZURE_STORAGE_CONNECTION_STRING;
+    else process.env.AZURE_STORAGE_CONNECTION_STRING = conn;
+    if (container === undefined) delete process.env.AZURE_STORAGE_CONTAINER_NAME;
+    else process.env.AZURE_STORAGE_CONTAINER_NAME = container;
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/apps/api/src/lib/report-export.ts
+++ b/apps/api/src/lib/report-export.ts
@@ -24,12 +24,26 @@ export function buildWeeklyReportExportUrl(report: WeeklyReportRecord, publicBas
   return new URL(`/api/reports/${report.id}/export`, normalizeBaseUrl(publicBaseUrl)).href;
 }
 
-async function writeLocalExport(report: WeeklyReportRecord, markdown: string) {
-  const localPath = buildLocalWeeklyReportExportPath(report);
-  await mkdir(join(process.cwd(), 'data', 'report-exports'), { recursive: true });
-  await writeFile(localPath, markdown, 'utf8');
-
-  return localPath;
+/**
+ * Best-effort local cache of the export markdown. Never throws: the prod App Service
+ * filesystem is read-only (WEBSITE_RUN_FROM_PACKAGE=1), and the download route
+ * (`/api/reports/:id/export`) regenerates from the DB-stored markdown when this file
+ * is absent — so a failed write must not break report generation (QA·C). Returns the
+ * written path, or null when the write was skipped/failed.
+ */
+async function writeLocalExport(report: WeeklyReportRecord, markdown: string): Promise<string | null> {
+  try {
+    const localPath = buildLocalWeeklyReportExportPath(report);
+    await mkdir(join(process.cwd(), 'data', 'report-exports'), { recursive: true });
+    await writeFile(localPath, markdown, 'utf8');
+    return localPath;
+  } catch (error) {
+    console.warn(
+      'Local weekly-report export write failed (read-only filesystem?); the download route will fall back to the stored markdown.',
+      error,
+    );
+    return null;
+  }
 }
 
 export async function exportWeeklyReportMarkdown(
@@ -43,10 +57,11 @@ export async function exportWeeklyReportMarkdown(
     process.env.AZURE_BLOB_REPORTS_CONTAINER?.trim();
   const publicBaseUrl =
     options.publicBaseUrl?.trim() ?? process.env.API_PUBLIC_BASE_URL?.trim() ?? 'http://127.0.0.1:4000';
+  const apiExportUrl = buildWeeklyReportExportUrl(report, publicBaseUrl);
 
   if (!connectionString || !containerName) {
     await writeLocalExport(report, markdown);
-    return buildWeeklyReportExportUrl(report, publicBaseUrl);
+    return apiExportUrl;
   }
 
   try {
@@ -67,8 +82,8 @@ export async function exportWeeklyReportMarkdown(
     await writeLocalExport(report, markdown);
     return blobClient.url;
   } catch (error) {
-    console.warn('Azure Blob export failed; falling back to local file export.', error);
+    console.warn('Azure Blob export failed; returning the API export URL (DB-backed).', error);
     await writeLocalExport(report, markdown);
-    return buildWeeklyReportExportUrl(report, publicBaseUrl);
+    return apiExportUrl;
   }
 }

--- a/apps/api/src/lib/report-export.ts
+++ b/apps/api/src/lib/report-export.ts
@@ -57,11 +57,12 @@ export async function exportWeeklyReportMarkdown(
     process.env.AZURE_BLOB_REPORTS_CONTAINER?.trim();
   const publicBaseUrl =
     options.publicBaseUrl?.trim() ?? process.env.API_PUBLIC_BASE_URL?.trim() ?? 'http://127.0.0.1:4000';
-  const apiExportUrl = buildWeeklyReportExportUrl(report, publicBaseUrl);
 
   if (!connectionString || !containerName) {
     await writeLocalExport(report, markdown);
-    return apiExportUrl;
+    // Built only on the fallback paths: the blob-success branch returns blobClient.url
+    // and must not depend on (or throw on) a malformed request-derived base URL.
+    return buildWeeklyReportExportUrl(report, publicBaseUrl);
   }
 
   try {
@@ -84,6 +85,6 @@ export async function exportWeeklyReportMarkdown(
   } catch (error) {
     console.warn('Azure Blob export failed; returning the API export URL (DB-backed).', error);
     await writeLocalExport(report, markdown);
-    return apiExportUrl;
+    return buildWeeklyReportExportUrl(report, publicBaseUrl);
   }
 }


### PR DESCRIPTION
## Summary
Fixes the **HIGH** finding #94 (epic #91): `POST /api/ai/generate-weekly-report` returned a **500 in prod**. The App Service filesystem is read-only (`WEBSITE_RUN_FROM_PACKAGE=1`), so `exportWeeklyReportMarkdown`'s local-file write threw an unhandled error — and that write ran in *every* branch, including after a successful blob upload. The report was generated but never returned to the user.

- `writeLocalExport` is now **best-effort**: it logs a warning and returns `null` on failure instead of throwing. The download route (`/api/reports/:id/export`) already falls back to the DB-stored markdown when the local file is absent, so the write is purely a cache.
- `exportWeeklyReportMarkdown` returns the DB-backed **API export URL** when there's no blob config or the upload fails, and the blob URL only on a genuine successful upload.
- Same latent 500 on the **n8n weekly path** is fixed (shared helper).

## Test Plan
- [x] New `report-export.test.ts` proves a failed local write returns a URL instead of throwing (simulates the read-only FS).
- [x] `npm test` **84 pass**, `typecheck` + `lint` clean.
- [x] Existing happy-path report test (writable temp dir) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)