### PR TITLE
feat(api): graceful shutdown on SIGTERM/SIGINT (QA·E, #96)

### DIFF
--- a/apps/api/src/lib/app-insights.ts
+++ b/apps/api/src/lib/app-insights.ts
@@ -28,3 +28,15 @@ export function startAppInsights(): boolean {
     return false;
   }
 }
+
+/**
+ * Best-effort flush of buffered telemetry, e.g. on graceful shutdown so the last items
+ * before a deploy aren't lost. No-op when telemetry isn't active; never throws.
+ */
+export async function flushAppInsights(): Promise<void> {
+  try {
+    await appInsights.defaultClient?.flush();
+  } catch {
+    // Telemetry must never block or crash shutdown.
+  }
+}

--- a/apps/api/src/lib/shutdown.test.ts
+++ b/apps/api/src/lib/shutdown.test.ts
@@ -64,21 +64,29 @@ test('runGracefulShutdown exits 1 when draining throws', async () => {
 
 test('runGracefulShutdown force-exits 1 when the drain hangs past the timeout', async () => {
   let exitCode: number | undefined;
-  const exited = new Promise<void>((resolve) => {
-    void runGracefulShutdown({
-      closeServer: () => new Promise<void>(() => {}), // never resolves (stuck connection)
-      closePool: async () => {},
-      onExit: (code) => {
-        exitCode = code;
-        resolve();
-      },
-      timeoutMs: 20,
-      log: noop,
-    });
+  // A stuck connection: closeServer doesn't resolve until we release it. The force-exit
+  // timer must fire first (exit 1); we release afterwards so the promise still settles
+  // cleanly (in production process.exit ends it, but the test must not dangle).
+  let releaseServer = () => {};
+  const serverStuck = new Promise<void>((resolve) => {
+    releaseServer = resolve;
   });
 
-  await exited;
-  assert.equal(exitCode, 1);
+  const run = runGracefulShutdown({
+    closeServer: () => serverStuck,
+    closePool: async () => {},
+    onExit: (code) => {
+      exitCode ??= code;
+    },
+    timeoutMs: 20,
+    log: noop,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  assert.equal(exitCode, 1); // force-exit fired while the server was still draining
+
+  releaseServer();
+  await run; // settles without a dangling promise; the late exit(0) is a no-op (settled)
 });
 
 test('runGracefulShutdown calls onExit at most once', async () => {

--- a/apps/api/src/lib/shutdown.test.ts
+++ b/apps/api/src/lib/shutdown.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runGracefulShutdown } from '@/lib/shutdown';
+
+const noop = () => {};
+
+test('runGracefulShutdown drains the server then the pool, then exits 0', async () => {
+  const order: string[] = [];
+  let exitCode: number | undefined;
+
+  await runGracefulShutdown({
+    closeServer: async () => {
+      order.push('server');
+    },
+    closePool: async () => {
+      order.push('pool');
+    },
+    onExit: (code) => {
+      exitCode = code;
+    },
+    log: noop,
+  });
+
+  assert.deepEqual(order, ['server', 'pool']);
+  assert.equal(exitCode, 0);
+});
+
+test('runGracefulShutdown exits 1 when draining throws', async () => {
+  let exitCode: number | undefined;
+
+  await runGracefulShutdown({
+    closeServer: async () => {},
+    closePool: async () => {
+      throw new Error('pool stuck');
+    },
+    onExit: (code) => {
+      exitCode = code;
+    },
+    log: noop,
+  });
+
+  assert.equal(exitCode, 1);
+});
+
+test('runGracefulShutdown force-exits 1 when the drain hangs past the timeout', async () => {
+  let exitCode: number | undefined;
+  const exited = new Promise<void>((resolve) => {
+    void runGracefulShutdown({
+      closeServer: () => new Promise<void>(() => {}), // never resolves (stuck connection)
+      closePool: async () => {},
+      onExit: (code) => {
+        exitCode = code;
+        resolve();
+      },
+      timeoutMs: 20,
+      log: noop,
+    });
+  });
+
+  await exited;
+  assert.equal(exitCode, 1);
+});
+
+test('runGracefulShutdown calls onExit at most once', async () => {
+  let exitCalls = 0;
+
+  await runGracefulShutdown({
+    closeServer: async () => {},
+    closePool: async () => {},
+    onExit: () => {
+      exitCalls += 1;
+    },
+    timeoutMs: 5,
+    log: noop,
+  });
+
+  // Give the (already-cleared) timeout a tick to prove it can't double-fire.
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(exitCalls, 1);
+});

--- a/apps/api/src/lib/shutdown.test.ts
+++ b/apps/api/src/lib/shutdown.test.ts
@@ -25,6 +25,26 @@ test('runGracefulShutdown drains the server then the pool, then exits 0', async 
   assert.equal(exitCode, 0);
 });
 
+test('runGracefulShutdown flushes telemetry after the server drains, before the pool', async () => {
+  const order: string[] = [];
+
+  await runGracefulShutdown({
+    closeServer: async () => {
+      order.push('server');
+    },
+    flushTelemetry: async () => {
+      order.push('flush');
+    },
+    closePool: async () => {
+      order.push('pool');
+    },
+    onExit: noop,
+    log: noop,
+  });
+
+  assert.deepEqual(order, ['server', 'flush', 'pool']);
+});
+
 test('runGracefulShutdown exits 1 when draining throws', async () => {
   let exitCode: number | undefined;
 

--- a/apps/api/src/lib/shutdown.ts
+++ b/apps/api/src/lib/shutdown.ts
@@ -1,4 +1,5 @@
 import type { Server } from 'node:http';
+import { flushAppInsights } from '@/lib/app-insights';
 import { closePool } from '@/lib/postgres';
 
 /**
@@ -15,14 +16,16 @@ export interface ShutdownDeps {
   closePool: () => Promise<void>;
   /** Terminate the process (injected for testability). */
   onExit: (code: number) => void;
+  /** Best-effort flush of buffered telemetry before exit. */
+  flushTelemetry?: () => Promise<void>;
   /** Force-exit budget if draining hangs (default 10s). */
   timeoutMs?: number;
   log?: (message: string) => void;
 }
 
-/** Orchestrate the drain → close-pool → exit sequence. Pure of process/signal wiring. */
+/** Orchestrate the drain → flush → close-pool → exit sequence. Pure of process/signal wiring. */
 export async function runGracefulShutdown(deps: ShutdownDeps): Promise<void> {
-  const { closeServer, closePool: drainPool, onExit, timeoutMs = 10_000 } = deps;
+  const { closeServer, closePool: drainPool, onExit, flushTelemetry, timeoutMs = 10_000 } = deps;
   const log = deps.log ?? ((message: string) => console.error(message));
 
   let settled = false;
@@ -41,6 +44,9 @@ export async function runGracefulShutdown(deps: ShutdownDeps): Promise<void> {
 
   try {
     await closeServer();
+    // Flush telemetry (best-effort) and drain the pool AFTER in-flight requests finish,
+    // since those requests may still issue DB queries.
+    if (flushTelemetry) await flushTelemetry();
     await drainPool();
     exitOnce(0);
   } catch (error) {
@@ -53,7 +59,20 @@ export async function runGracefulShutdown(deps: ShutdownDeps): Promise<void> {
 
 function closeServer(server: Server): Promise<void> {
   return new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    // A signal can arrive before the socket is listening (listen() is async); that's a
+    // clean early shutdown, not a failure.
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close((error) => {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      if (error && code !== 'ERR_SERVER_NOT_RUNNING') reject(error);
+      else resolve();
+    });
+    // Free idle keep-alive sockets so a deploy with no in-flight request drains in
+    // milliseconds and exits 0, instead of always falling through to the force-exit timeout.
+    server.closeIdleConnections();
   });
 }
 
@@ -61,6 +80,8 @@ function closeServer(server: Server): Promise<void> {
 export function registerGracefulShutdown(server: Server, timeoutMs?: number): void {
   let started = false;
   const handler = (signal: NodeJS.Signals) => {
+    // process.once dedups a repeat of the SAME signal; `started` dedups across DIFFERENT
+    // signals (e.g. SIGTERM then SIGINT) since both register this same closure.
     if (started) return;
     started = true;
     console.error(`Received ${signal}; shutting down gracefully...`);
@@ -68,6 +89,7 @@ export function registerGracefulShutdown(server: Server, timeoutMs?: number): vo
       closeServer: () => closeServer(server),
       closePool,
       onExit: (code) => process.exit(code),
+      flushTelemetry: flushAppInsights,
       timeoutMs,
     });
   };

--- a/apps/api/src/lib/shutdown.ts
+++ b/apps/api/src/lib/shutdown.ts
@@ -1,0 +1,76 @@
+import type { Server } from 'node:http';
+import { closePool } from '@/lib/postgres';
+
+/**
+ * Graceful shutdown (QA·E). Azure App Service sends SIGTERM on every deploy/restart;
+ * without a handler, in-flight requests are dropped and the Postgres pool is never
+ * drained. This stops accepting new connections, lets in-flight requests finish, closes
+ * the pool, then exits — with a hard timeout so a stuck connection can't hang the deploy.
+ */
+
+export interface ShutdownDeps {
+  /** Stop accepting connections and resolve once in-flight requests have drained. */
+  closeServer: () => Promise<void>;
+  /** Drain the database pool. */
+  closePool: () => Promise<void>;
+  /** Terminate the process (injected for testability). */
+  onExit: (code: number) => void;
+  /** Force-exit budget if draining hangs (default 10s). */
+  timeoutMs?: number;
+  log?: (message: string) => void;
+}
+
+/** Orchestrate the drain → close-pool → exit sequence. Pure of process/signal wiring. */
+export async function runGracefulShutdown(deps: ShutdownDeps): Promise<void> {
+  const { closeServer, closePool: drainPool, onExit, timeoutMs = 10_000 } = deps;
+  const log = deps.log ?? ((message: string) => console.error(message));
+
+  let settled = false;
+  const exitOnce = (code: number) => {
+    if (settled) return;
+    settled = true;
+    onExit(code);
+  };
+
+  const timer = setTimeout(() => {
+    log('Graceful shutdown timed out; forcing exit.');
+    exitOnce(1);
+  }, timeoutMs);
+  // Don't let the timer itself keep the event loop alive.
+  if (typeof timer.unref === 'function') timer.unref();
+
+  try {
+    await closeServer();
+    await drainPool();
+    exitOnce(0);
+  } catch (error) {
+    log(`Error during graceful shutdown: ${String(error)}`);
+    exitOnce(1);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+/** Wire SIGTERM/SIGINT to a one-shot graceful shutdown of the given HTTP server. */
+export function registerGracefulShutdown(server: Server, timeoutMs?: number): void {
+  let started = false;
+  const handler = (signal: NodeJS.Signals) => {
+    if (started) return;
+    started = true;
+    console.error(`Received ${signal}; shutting down gracefully...`);
+    void runGracefulShutdown({
+      closeServer: () => closeServer(server),
+      closePool,
+      onExit: (code) => process.exit(code),
+      timeoutMs,
+    });
+  };
+  process.once('SIGTERM', handler);
+  process.once('SIGINT', handler);
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -4,10 +4,14 @@ import { startAppInsights } from '@/lib/app-insights';
 startAppInsights();
 
 import { createApp } from '@/app';
+import { registerGracefulShutdown } from '@/lib/shutdown';
 
 const port = Number(process.env.PORT ?? 4000);
 const app = createApp();
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`JobOps Copilot API listening on http://localhost:${port}`);
 });
+
+// Drain in-flight requests + close the DB pool on SIGTERM/SIGINT (Azure deploy/restart).
+registerGracefulShutdown(server);


### PR DESCRIPTION
## Summary
Fixes **HIGH** #96 (epic #91). Azure App Service sends `SIGTERM` on every deploy/restart; the API had no handler, so in-flight requests were dropped and the Postgres pool was never drained.

- New `apps/api/src/lib/shutdown.ts`: `registerGracefulShutdown(server)` wires `SIGTERM`/`SIGINT` (one-shot); `runGracefulShutdown` orchestrates **drain in-flight → close pool → exit**, with a 10s hard timeout that force-exits so a stuck keep-alive connection can't hang the deploy. Exit + close are injected for testability.
- `server.ts` captures the `http.Server` and registers the handler.

## Test Plan
- [x] `npm test` **95 pass** (+4): drain-order then exit 0; exit 1 when draining throws; force-exit 1 when the drain hangs past the timeout; `onExit` called at most once.
- [x] `typecheck` + `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)