### PR TITLE
feat(agent): durable Postgres HITL checkpointer (QA·D, #95)

### DIFF
--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import uuid
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -70,10 +71,74 @@ def _configure_app_insights() -> bool:
 
 _configure_app_insights()
 
+
+# --- Assistant graph + durable HITL checkpointer (QA·D) ---------------------
+# The assistant graph is checkpointed so a run can pause at the human-review
+# interrupt and resume later — possibly on a different instance or after a
+# restart. With DATABASE_URL set we persist those checkpoints in Postgres
+# (durable); otherwise we fall back to an in-memory saver (lost on restart).
+# The Postgres saver is async-only, so the assistant run/resume/stream paths
+# all drive the graph through its async API (ainvoke/astream/aget_state).
+_assistant_graph = None
+_checkpointer_pool = None
+
+
+async def _build_durable_assistant_graph():
+    """Build the assistant graph backed by a Postgres checkpointer.
+
+    Returns ``(graph, pool)``; the caller owns closing ``pool`` on shutdown.
+    Postgres deps are imported lazily so the light CI test job (which runs
+    without DATABASE_URL and omits requirements-rag.txt) never imports them.
+    Raises on any connection/setup failure so callers can fall back to memory.
+    """
+    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+    from psycopg.rows import dict_row
+    from psycopg_pool import AsyncConnectionPool
+
+    # The saver requires autocommit + dict rows + no server-side prepared
+    # statements (the latter keeps it pgbouncer-safe). open=False so we can
+    # await .open() explicitly and surface connection errors here.
+    pool = AsyncConnectionPool(
+        conninfo=settings.database_url,
+        max_size=10,
+        open=False,
+        kwargs={"autocommit": True, "prepare_threshold": 0, "row_factory": dict_row},
+    )
+    await pool.open()
+    saver = AsyncPostgresSaver(pool)
+    await saver.setup()  # idempotent: creates the checkpoint tables if absent
+    return build_assistant_graph(checkpointer=saver), pool
+
+
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    """Upgrade the assistant graph to the durable Postgres checkpointer on
+    startup when DATABASE_URL is set; degrade to the in-memory saver on any
+    failure so a checkpointer outage never blocks the service from starting."""
+    global _assistant_graph, _checkpointer_pool
+    if settings.database_url:
+        try:
+            _assistant_graph, _checkpointer_pool = await _build_durable_assistant_graph()
+            logger.info("assistant HITL checkpointer: durable (Postgres)")
+        except Exception:  # noqa: BLE001 - degrade gracefully, never block startup
+            logger.warning(
+                "durable HITL checkpointer unavailable; using in-memory saver "
+                "(in-flight runs will not survive a restart)",
+                exc_info=True,
+            )
+    try:
+        yield
+    finally:
+        if _checkpointer_pool is not None:
+            await _checkpointer_pool.close()
+            _checkpointer_pool = None
+
+
 app = FastAPI(
     title="JobOps Copilot Agent Service",
     version="0.1.0",
     summary="Real-LLM analysis and agent orchestration for JobOps Copilot.",
+    lifespan=_lifespan,
 )
 
 
@@ -240,15 +305,27 @@ class AssistantResumeRequest(BaseModel):
     approved: bool
 
 
-_assistant_graph = None
-
-
 def _get_assistant_graph():
-    """Lazily build the checkpointed assistant graph (module-level singleton)."""
+    """Return the assistant graph singleton.
+
+    Built durably (Postgres) by the lifespan handler when DATABASE_URL is set;
+    otherwise lazily built here with the in-memory saver as a fallback.
+    """
     global _assistant_graph
     if _assistant_graph is None:
         _assistant_graph = build_assistant_graph()
     return _assistant_graph
+
+
+async def _arun(coro_fn, *args):
+    """Await an async graph call, translating provider errors into HTTP errors."""
+    try:
+        return await coro_fn(*args)
+    except LLMNotConfigured as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 - surface upstream model/network failures
+        logger.exception("agent chain failed")
+        raise HTTPException(status_code=502, detail=f"Agent chain failed: {exc}") from exc
 
 
 def _assistant_response(thread_id: str, state: dict) -> dict:
@@ -265,13 +342,13 @@ def _assistant_response(thread_id: str, state: dict) -> dict:
 
 
 @app.post("/assistant/run")
-def assistant_run_endpoint(req: AssistantRunRequest) -> dict:
+async def assistant_run_endpoint(req: AssistantRunRequest) -> dict:
     _require_llm()
     graph = _get_assistant_graph()
     thread_id = str(uuid.uuid4())
     config = {"configurable": {"thread_id": thread_id}}
-    state = _run(
-        graph.invoke,
+    state = await _arun(
+        graph.ainvoke,
         {
             "description_text": req.description_text,
             "resume_text": req.resume_text,
@@ -284,11 +361,11 @@ def assistant_run_endpoint(req: AssistantRunRequest) -> dict:
 
 
 @app.post("/assistant/resume")
-def assistant_resume_endpoint(req: AssistantResumeRequest) -> dict:
+async def assistant_resume_endpoint(req: AssistantResumeRequest) -> dict:
     _require_llm()
     graph = _get_assistant_graph()
     config = {"configurable": {"thread_id": req.thread_id}}
-    state = _run(graph.invoke, Command(resume={"approved": req.approved}), config)
+    state = await _arun(graph.ainvoke, Command(resume={"approved": req.approved}), config)
     return _assistant_response(req.thread_id, state)
 
 
@@ -307,14 +384,16 @@ async def _assistant_event_stream(payload: dict, config: dict):
             for node, delta in update.items():
                 if node == "__interrupt__":
                     awaiting = True
-                    snapshot = _assistant_response(thread_id, graph.get_state(config).values)
+                    state = (await graph.aget_state(config)).values
+                    snapshot = _assistant_response(thread_id, state)
                     snapshot["status"] = "awaiting_approval"
                     yield _sse("awaiting_approval", snapshot)
                 else:
                     status = delta.get("status") if isinstance(delta, dict) else None
                     yield _sse("status", {"node": node, "status": status})
         if not awaiting:
-            yield _sse("result", _assistant_response(thread_id, graph.get_state(config).values))
+            final = (await graph.aget_state(config)).values
+            yield _sse("result", _assistant_response(thread_id, final))
     except Exception as exc:  # noqa: BLE001 - surface streaming failures as an SSE error
         logger.exception("assistant stream failed")
         yield _sse("error", {"message": str(exc)})

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -105,9 +105,16 @@ async def _build_durable_assistant_graph():
         kwargs={"autocommit": True, "prepare_threshold": 0, "row_factory": dict_row},
     )
     await pool.open()
-    saver = AsyncPostgresSaver(pool)
-    await saver.setup()  # idempotent: creates the checkpoint tables if absent
-    return build_assistant_graph(checkpointer=saver), pool
+    # If setup() fails after a successful open() (e.g. the role can't CREATE
+    # TABLE), close the pool here — the caller never receives it, so its
+    # `finally` can't, and the open connections would otherwise leak.
+    try:
+        saver = AsyncPostgresSaver(pool)
+        await saver.setup()  # idempotent: creates the checkpoint tables if absent
+        return build_assistant_graph(checkpointer=saver), pool
+    except Exception:
+        await pool.close()
+        raise
 
 
 @asynccontextmanager
@@ -130,7 +137,10 @@ async def _lifespan(_app: FastAPI):
         yield
     finally:
         if _checkpointer_pool is not None:
-            await _checkpointer_pool.close()
+            try:
+                await _checkpointer_pool.close()
+            except Exception:  # noqa: BLE001 - never let teardown raise on shutdown
+                logger.warning("error closing HITL checkpointer pool", exc_info=True)
             _checkpointer_pool = None
 
 

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -92,6 +92,7 @@ async def _build_durable_assistant_graph():
     Raises on any connection/setup failure so callers can fall back to memory.
     """
     from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+    from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
     from psycopg.rows import dict_row
     from psycopg_pool import AsyncConnectionPool
 
@@ -109,7 +110,13 @@ async def _build_durable_assistant_graph():
     # TABLE), close the pool here — the caller never receives it, so its
     # `finally` can't, and the open connections would otherwise leak.
     try:
-        saver = AsyncPostgresSaver(pool)
+        # Strict msgpack: restrict checkpoint deserialization to a built-in
+        # allowlist of safe types. The default is permissive, which lets anyone
+        # who can write checkpoint rows trigger code execution on resume. Our
+        # graph only persists JSON-native state plus langgraph control types
+        # (Interrupt/Command/…), all of which are in the safe allowlist.
+        serde = JsonPlusSerializer(allowed_msgpack_modules=None)
+        saver = AsyncPostgresSaver(pool, serde=serde)
         await saver.setup()  # idempotent: creates the checkpoint tables if absent
         return build_assistant_graph(checkpointer=saver), pool
     except Exception:

--- a/services/agent/requirements-rag.txt
+++ b/services/agent/requirements-rag.txt
@@ -3,3 +3,7 @@
 # these lazily, so unit tests run without torch installed.
 psycopg[binary]>=3.2,<4
 sentence-transformers>=3.0,<6
+# Durable HITL checkpointer (QA·D). Lazily imported only when DATABASE_URL is set, so
+# CI's light test job (which omits this file) stays green on the InMemorySaver fallback.
+langgraph-checkpoint-postgres>=3.1,<4
+psycopg-pool>=3.2,<4

--- a/services/agent/tests/test_assistant_checkpointer.py
+++ b/services/agent/tests/test_assistant_checkpointer.py
@@ -5,6 +5,8 @@ logic around it: durable when DATABASE_URL + build succeed, in-memory fallback
 when it's unset or the build fails, and the pool always closed on shutdown.
 """
 
+import asyncio
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -70,3 +72,37 @@ def test_degrades_when_durable_build_fails(monkeypatch):
         # No durable graph -> lazy in-memory fallback applies.
         assert main._assistant_graph is None
         assert main._checkpointer_pool is None
+
+
+def test_build_closes_pool_when_setup_fails(monkeypatch):
+    """If the pool opens but setup() fails, the build must close the pool
+    itself — the caller never receives it, so it can't be torn down later."""
+    import langgraph.checkpoint.postgres.aio as pg_aio
+    import psycopg_pool
+
+    closed = {"value": False}
+
+    class _FakePool:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def open(self):
+            pass
+
+        async def close(self):
+            closed["value"] = True
+
+    class _FakeSaver:
+        def __init__(self, pool):
+            pass
+
+        async def setup(self):
+            raise RuntimeError("role cannot CREATE TABLE")
+
+    monkeypatch.setattr(main.settings, "database_url", "postgresql://x/db")
+    monkeypatch.setattr(psycopg_pool, "AsyncConnectionPool", _FakePool)
+    monkeypatch.setattr(pg_aio, "AsyncPostgresSaver", _FakeSaver)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(main._build_durable_assistant_graph())
+    assert closed["value"] is True

--- a/services/agent/tests/test_assistant_checkpointer.py
+++ b/services/agent/tests/test_assistant_checkpointer.py
@@ -93,7 +93,7 @@ def test_build_closes_pool_when_setup_fails(monkeypatch):
             closed["value"] = True
 
     class _FakeSaver:
-        def __init__(self, pool):
+        def __init__(self, pool, serde=None):
             pass
 
         async def setup(self):
@@ -106,3 +106,45 @@ def test_build_closes_pool_when_setup_fails(monkeypatch):
     with pytest.raises(RuntimeError):
         asyncio.run(main._build_durable_assistant_graph())
     assert closed["value"] is True
+
+
+def test_build_uses_strict_msgpack_serializer(monkeypatch):
+    """The durable saver must be built with a strict (allowlisted) serializer,
+    so tampered checkpoint rows can't trigger code execution on resume."""
+    import langgraph.checkpoint.postgres.aio as pg_aio
+    import psycopg_pool
+    from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+    captured = {}
+
+    class _FakePool:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def open(self):
+            pass
+
+        async def close(self):
+            pass
+
+    class _FakeSaver:
+        def __init__(self, pool, serde=None):
+            captured["serde"] = serde
+
+        async def setup(self):
+            pass
+
+    monkeypatch.setattr(main.settings, "database_url", "postgresql://x/db")
+    monkeypatch.setattr(psycopg_pool, "AsyncConnectionPool", _FakePool)
+    monkeypatch.setattr(pg_aio, "AsyncPostgresSaver", _FakeSaver)
+    # Bypass compile-time checkpointer validation (our fake saver isn't a real
+    # BaseCheckpointSaver); the serde is already captured at saver construction.
+    monkeypatch.setattr(main, "build_assistant_graph", lambda checkpointer=None: object())
+
+    asyncio.run(main._build_durable_assistant_graph())
+
+    serde = captured["serde"]
+    assert isinstance(serde, JsonPlusSerializer)
+    # Permissive (default, unsafe) mode keeps the marker `True`; strict mode
+    # narrows it to a built-in allowlist (here, None == SAFE_MSGPACK_TYPES only).
+    assert serde._allowed_msgpack_modules is not True

--- a/services/agent/tests/test_assistant_checkpointer.py
+++ b/services/agent/tests/test_assistant_checkpointer.py
@@ -1,0 +1,72 @@
+"""QA·D — durable HITL checkpointer wiring + graceful fallback.
+
+The real Postgres saver can't run in CI, so these tests exercise the lifespan
+logic around it: durable when DATABASE_URL + build succeed, in-memory fallback
+when it's unset or the build fails, and the pool always closed on shutdown.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main as main
+
+
+@pytest.fixture(autouse=True)
+def _restore_singleton():
+    """Lifespan mutates module globals; isolate each test from the others."""
+    graph, pool = main._assistant_graph, main._checkpointer_pool
+    main._assistant_graph, main._checkpointer_pool = None, None
+    yield
+    main._assistant_graph, main._checkpointer_pool = graph, pool
+
+
+def test_no_database_url_falls_back_to_in_memory(monkeypatch):
+    monkeypatch.setattr(main.settings, "database_url", None)
+    with TestClient(main.app):
+        # Lifespan ran but built nothing durable.
+        assert main._assistant_graph is None
+        assert main._checkpointer_pool is None
+        # The lazy fallback still yields a working (in-memory) graph.
+        assert hasattr(main._get_assistant_graph(), "ainvoke")
+
+
+def test_durable_graph_used_when_available(monkeypatch):
+    sentinel_graph = object()
+
+    class _FakePool:
+        def __init__(self):
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    pool = _FakePool()
+
+    async def _fake_build():
+        return sentinel_graph, pool
+
+    monkeypatch.setattr(main.settings, "database_url", "postgresql://x/db")
+    monkeypatch.setattr(main, "_build_durable_assistant_graph", _fake_build)
+
+    with TestClient(main.app):
+        assert main._assistant_graph is sentinel_graph
+        assert main._get_assistant_graph() is sentinel_graph
+
+    # Pool closed and reset on shutdown.
+    assert pool.closed is True
+    assert main._checkpointer_pool is None
+
+
+def test_degrades_when_durable_build_fails(monkeypatch):
+    async def _boom():
+        raise RuntimeError("postgres unreachable")
+
+    monkeypatch.setattr(main.settings, "database_url", "postgresql://x/db")
+    monkeypatch.setattr(main, "_build_durable_assistant_graph", _boom)
+
+    with TestClient(main.app) as client:
+        # Startup did not crash; service still serves.
+        assert client.get("/health").status_code == 200
+        # No durable graph -> lazy in-memory fallback applies.
+        assert main._assistant_graph is None
+        assert main._checkpointer_pool is None

--- a/services/agent/tests/test_assistant_checkpointer.py
+++ b/services/agent/tests/test_assistant_checkpointer.py
@@ -77,8 +77,9 @@ def test_degrades_when_durable_build_fails(monkeypatch):
 def test_build_closes_pool_when_setup_fails(monkeypatch):
     """If the pool opens but setup() fails, the build must close the pool
     itself — the caller never receives it, so it can't be torn down later."""
-    import langgraph.checkpoint.postgres.aio as pg_aio
-    import psycopg_pool
+    # Skip on the light CI job, which omits requirements-rag.txt (no PG deps).
+    pg_aio = pytest.importorskip("langgraph.checkpoint.postgres.aio")
+    psycopg_pool = pytest.importorskip("psycopg_pool")
 
     closed = {"value": False}
 
@@ -111,8 +112,9 @@ def test_build_closes_pool_when_setup_fails(monkeypatch):
 def test_build_uses_strict_msgpack_serializer(monkeypatch):
     """The durable saver must be built with a strict (allowlisted) serializer,
     so tampered checkpoint rows can't trigger code execution on resume."""
-    import langgraph.checkpoint.postgres.aio as pg_aio
-    import psycopg_pool
+    # Skip on the light CI job, which omits requirements-rag.txt (no PG deps).
+    pg_aio = pytest.importorskip("langgraph.checkpoint.postgres.aio")
+    psycopg_pool = pytest.importorskip("psycopg_pool")
     from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 
     captured = {}

--- a/services/agent/tests/test_assistant_stream.py
+++ b/services/agent/tests/test_assistant_stream.py
@@ -25,7 +25,7 @@ class _FakeGraph:
         else:
             yield {"pass": {"status": "passed"}}
 
-    def get_state(self, config):
+    async def aget_state(self, config):
         return _FakeState({"fit": {"fit_score": 80}, "research": {"company_summary": "ok"}})
 
 

--- a/services/agent/tests/test_endpoints.py
+++ b/services/agent/tests/test_endpoints.py
@@ -113,7 +113,7 @@ def test_assistant_run_pauses_for_approval(monkeypatch):
     monkeypatch.setattr(main, "llm_available", lambda: True)
 
     class _FakeGraph:
-        def invoke(self, payload, config=None):
+        async def ainvoke(self, payload, config=None):
             return {"__interrupt__": [object()], "fit": {"fit_score": 80},
                     "research": {"company_summary": "ok"}}
 
@@ -130,7 +130,7 @@ def test_assistant_resume_returns_draft(monkeypatch):
     monkeypatch.setattr(main, "llm_available", lambda: True)
 
     class _FakeGraph:
-        def invoke(self, payload, config=None):
+        async def ainvoke(self, payload, config=None):
             return {"status": "drafted", "draft": {"draft_text": "hi there"}}
 
     monkeypatch.setattr(main, "_get_assistant_graph", lambda: _FakeGraph())


### PR DESCRIPTION
Closes #95 (QA·D).

## Problem
The application-assistant graph pauses at a human-in-the-loop review interrupt and resumes later — possibly on a different instance or after a deploy/restart. It was checkpointed **only in memory** (`InMemorySaver`), so any restart silently dropped every in-flight run waiting on approval. Awaiting-approval state was effectively non-durable.

## Change
- **Durable checkpointer.** On startup, when `DATABASE_URL` is set, the FastAPI lifespan builds the assistant graph backed by `AsyncPostgresSaver` over a long-lived `AsyncConnectionPool` (`autocommit`, `dict_row`, `prepare_threshold=0` — pgbouncer-safe), runs the idempotent `setup()`, and closes the pool on shutdown.
- **Unified on async.** The Postgres saver is async-only, so `/assistant/run`, `/assistant/resume`, and `/assistant/stream` now drive the graph through `ainvoke` / `astream` / `aget_state` consistently (previously run/resume used sync `.invoke()` while stream used `.astream()`).
- **Graceful fallback.** Any pool/connect/setup failure logs a warning and degrades to the in-memory saver — a checkpointer outage never blocks the service from starting.
- **CI stays light.** Postgres deps are imported lazily and pinned in `requirements-rag.txt` only (`langgraph-checkpoint-postgres>=3.1,<4`, `psycopg-pool`), matching the installed `langgraph-checkpoint` 4.x line. CI installs `requirements-dev.txt` only and runs without `DATABASE_URL`, so the suite exercises the fallback path.

## Tests
- New `test_assistant_checkpointer.py`: durable graph used when the build succeeds, pool closed + reset on shutdown, and graceful degrade to in-memory when `DATABASE_URL` is unset or the build raises.
- Updated the existing assistant endpoint/stream fakes to the async graph API (`ainvoke` / `aget_state`).
- Full agent suite (151 tests) + `ruff` green locally.

> Note: the real Postgres path can't be exercised in CI; it's covered by the wiring/fallback tests plus the lazy-import design. The Dockerfile already installs `requirements-rag.txt`, so the durable deps ship in the agent image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)