### PR TITLE
chore: docs + hygiene — API_SPEC casing, robots.txt, a11y, onboarding error (QA·H, #99)

### DIFF
--- a/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
+++ b/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
@@ -160,7 +160,8 @@ export default async function JobDetailPage({ params }: JobDetailParams) {
               </Card>
               {job.outreach.length ? (
                 <Card className="gap-3 p-5">
-                  <h3 className="font-heading text-sm font-semibold">Existing drafts</h3>
+                  {/* h2 (not h3) so the document heading order doesn't skip a level (a11y). */}
+                  <h2 className="font-heading text-sm font-semibold">Existing drafts</h2>
                   {job.outreach.map((draft) => (
                     <div key={draft.id} className="bg-muted/40 space-y-2 rounded-lg p-3">
                       <div className="flex items-center justify-between gap-2">

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -16,16 +16,22 @@ export default function OnboardingPage() {
   const [fileName, setFileName] = useState<string | null>(null);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function finish() {
     setSaving(true);
+    setError(null);
     try {
       if (pendingFile) {
         await uploadResumeFile(pendingFile);
       } else if (resumeText.trim()) {
         await saveResumeText(resumeText.trim());
       } else {
-        toast.error('Add your resume to continue — upload a PDF or paste the text.');
+        // Surface the validation failure inline (a toast alone is easy to miss and
+        // disappears) in addition to the toast.
+        const message = 'Add your resume to continue — upload a PDF or paste the text.';
+        setError(message);
+        toast.error(message);
         return;
       }
       toast.success('You’re all set. Welcome to JobOps Copilot.');
@@ -89,6 +95,7 @@ export default function OnboardingPage() {
                     const file = event.target.files?.[0] ?? null;
                     setPendingFile(file);
                     setFileName(file?.name ?? null);
+                    if (file) setError(null);
                   }}
                 />
               </label>
@@ -97,12 +104,21 @@ export default function OnboardingPage() {
             <TabsContent value="paste" className="pt-4">
               <Textarea
                 value={resumeText}
-                onChange={(event) => setResumeText(event.target.value)}
+                onChange={(event) => {
+                  setResumeText(event.target.value);
+                  if (event.target.value.trim()) setError(null);
+                }}
                 placeholder="Paste your resume text here…"
                 className="min-h-48"
               />
             </TabsContent>
           </Tabs>
+
+          {error ? (
+            <p role="alert" className="text-destructive text-sm font-medium">
+              {error}
+            </p>
+          ) : null}
 
           <Button onClick={finish} disabled={saving} className="w-full">
             {saving ? <Loader2 className="size-4 animate-spin" /> : null}

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -17,6 +17,7 @@ export default function robots(): MetadataRoute.Robots {
         '/outreach',
         '/reports',
         '/assistant',
+        '/settings',
         '/onboarding',
       ],
     },

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from 'next';
+
+/**
+ * /robots.txt — JobOps Copilot is an authenticated personal job-search CRM, so the
+ * signed-in app routes and the API hold per-user data that must not be crawled or
+ * indexed. Public/marketing pages stay crawlable.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/api/',
+        '/dashboard',
+        '/jobs',
+        '/outreach',
+        '/reports',
+        '/assistant',
+        '/onboarding',
+      ],
+    },
+  };
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -11,7 +11,7 @@ export default clerkMiddleware(async (auth, request) => {
 
 export const config = {
   matcher: [
-    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|txt|xml)).*)',
     '/(api|trpc)(.*)',
   ],
 };

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -2,6 +2,13 @@
 
 The API exposes jobs and AI endpoints backed by either the local file store or PostgreSQL, depending on whether `DATABASE_URL` is configured. In the default local setup the file store keeps the CRM state persistent between API restarts. When `DATABASE_URL` is present, the API switches to the Postgres-backed store and reports that in `/api/health`.
 
+### Field casing
+
+The casing is intentionally split by layer, and the examples below reflect the real payloads:
+
+- **CRM resources are `camelCase`** — the jobs routes (`/api/jobs`), the stored `analysis` object, saved reports (`GET /api/reports`), and outreach records. These are the API's own persisted shapes.
+- **The AI and n8n endpoints are `snake_case`** — `/api/ai/parse-job`, `/api/ai/score-fit`, `/api/ai/draft-outreach`, `/api/ai/generate-weekly-report`, and `/api/n8n/*` return (and accept) the Python agent service's payload as a passthrough, which is `snake_case` end to end (e.g. `fit_score`, `required_skills`). The web app reads the `camelCase` stored `analysis` for display rather than these raw responses.
+
 ## Health
 
 ### `GET /api/health`
@@ -139,6 +146,8 @@ Validation rules:
 - `priority` must be `high`, `medium`, or `low`.
 - `fitScore` must be a number between 0 and 100.
 - `nextActionDue` must be a valid date if provided.
+
+> **No `DELETE` for jobs.** Jobs are never hard-deleted — they are archived by `PATCH`-ing `status` to `archived`, which preserves history and analytics. The only resource with a `DELETE` endpoint is saved searches (`DELETE /api/saved-searches/:id`).
 
 ## AI
 


### PR DESCRIPTION
Closes #99 (QA·H). Five low-risk docs/hygiene items.

## 1. API_SPEC.md casing
The audit assumed snake_case in the spec was stale, but the impl is intentionally **mixed**: CRM resources (`/api/jobs`, stored `analysis`, `GET /api/reports`, outreach) are camelCase, while the AI/n8n endpoints (`parse-job`, `score-fit`, `draft-outreach`, `generate-weekly-report`, `/api/n8n/*`) pass the Python agent's snake_case payload straight through. The existing examples already match reality — so this documents the **convention** (and that the web reads the camelCase stored `analysis` for display), rather than rewriting. _Per your "docs match reality" call._

## 2. `.gitignore` exports
The generated exports (`apps/api/data/report-exports/`) are already gitignored (line 24) and nothing is tracked — confirmed, no change needed.

## 3. robots.txt
Added an App Router `robots.ts` producing a valid `/robots.txt` that disallows the authenticated app routes (`/dashboard`, `/jobs`, …) and `/api` — per-user data that shouldn't be crawled/indexed — while keeping public pages crawlable.

## 4. a11y heading order
`jobs/[jobId]` jumped `h1` → `h3` ("Existing drafts") with no `h2` in between. Promoted it to `h2` (visual size unchanged) so the document heading order no longer skips a level.

## 5. Onboarding inline error
The empty-resume validation was toast-only (easy to miss, disappears). Now also surfaced inline with `role="alert"` above the Continue button, and cleared as soon as the user adds a file or pastes text.

## Verification
Web `tsc --noEmit` + `eslint` clean. No API/agent code touched (docs + web only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)