### PR TITLE
fix(web): distinguish "no jobs yet" from "no matching jobs" (J2)

### DIFF
--- a/apps/web/src/components/empty-state.tsx
+++ b/apps/web/src/components/empty-state.tsx
@@ -7,11 +7,15 @@ export function EmptyState({
   description,
   actionLabel,
   actionHref,
+  onAction,
 }: {
   title: string;
   description: string;
   actionLabel?: string;
+  /** Render the action as a link. Ignored when `onAction` is provided. */
   actionHref?: string;
+  /** Render the action as a button that runs this handler (e.g. reset filters). */
+  onAction?: () => void;
 }) {
   return (
     <div className="flex flex-col items-center justify-center rounded-xl border border-dashed py-12 text-center">
@@ -20,7 +24,11 @@ export function EmptyState({
       </span>
       <h3 className="font-heading text-base font-semibold">{title}</h3>
       <p className="text-muted-foreground mt-1 max-w-sm text-sm">{description}</p>
-      {actionLabel && actionHref ? (
+      {actionLabel && onAction ? (
+        <Button onClick={onAction} variant="outline" size="sm" className="mt-4">
+          {actionLabel}
+        </Button>
+      ) : actionLabel && actionHref ? (
         <Button
           render={<Link href={actionHref}>{actionLabel}</Link>}
           variant="outline"

--- a/apps/web/src/components/jobs-table-empty-states.test.tsx
+++ b/apps/web/src/components/jobs-table-empty-states.test.tsx
@@ -57,3 +57,25 @@ it('shows the "No matching jobs" filter hint when jobs exist but none match the 
   expect(screen.getByText('No matching jobs')).toBeInTheDocument();
   expect(screen.queryByText('No jobs yet')).not.toBeInTheDocument();
 });
+
+it('reaches "No matching jobs" via the status filter, not only via search', async () => {
+  const user = userEvent.setup();
+  render(<JobsTable jobs={[makeJob({ company: 'Northwind', status: 'discovered' })]} />);
+
+  await user.selectOptions(screen.getByRole('combobox', { name: /filter by status/i }), 'offer');
+
+  expect(screen.getByText('No matching jobs')).toBeInTheDocument();
+});
+
+it('the "Clear filters" action restores the full table', async () => {
+  const user = userEvent.setup();
+  render(<JobsTable jobs={[makeJob({ company: 'Northwind' })]} />);
+
+  await user.type(screen.getByRole('searchbox', { name: /search jobs/i }), 'zzz-no-match');
+  expect(screen.getByText('No matching jobs')).toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: /clear filters/i }));
+
+  expect(screen.queryByText('No matching jobs')).not.toBeInTheDocument();
+  expect(screen.getByText(/Northwind/)).toBeInTheDocument();
+});

--- a/apps/web/src/components/jobs-table-empty-states.test.tsx
+++ b/apps/web/src/components/jobs-table-empty-states.test.tsx
@@ -1,0 +1,59 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, it } from 'vitest';
+import type { Job } from '@/types/job';
+import { JobsTable } from './jobs-table';
+
+function makeJob(overrides: Partial<Job>): Job {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    source: 'manual',
+    company: 'Acme',
+    title: 'Engineer',
+    location: 'Remote',
+    employmentType: 'Full-time',
+    workplaceType: 'remote',
+    discoveredAt: '2026-01-01T00:00:00.000Z',
+    descriptionText: '',
+    status: 'discovered',
+    priority: 'medium',
+    fitScore: 70,
+    nextAction: '',
+    analysis: {
+      requiredSkills: [],
+      preferredSkills: [],
+      matchedSkills: [],
+      missingSkills: [],
+      atsKeywords: [],
+      fitSummary: '',
+      recommendedResumeAngle: '',
+      applyRecommendation: '',
+      confidenceScore: 0,
+      modelUsed: 'mock',
+    },
+    outreach: [],
+    ...overrides,
+  };
+}
+
+it('shows a "No jobs yet" empty state (not a filter hint) and hides the toolbar when there are zero jobs', () => {
+  render(<JobsTable jobs={[]} />);
+
+  expect(screen.getByText('No jobs yet')).toBeInTheDocument();
+  expect(screen.queryByText('No matching jobs')).not.toBeInTheDocument();
+  // The filter toolbar is pointless with no data.
+  expect(screen.queryByRole('searchbox', { name: /search jobs/i })).not.toBeInTheDocument();
+  // No "Showing 0 of 0 jobs" noise.
+  expect(screen.queryByText(/showing .* jobs/i)).not.toBeInTheDocument();
+});
+
+it('shows the "No matching jobs" filter hint when jobs exist but none match the query', async () => {
+  const user = userEvent.setup();
+  render(<JobsTable jobs={[makeJob({ company: 'Northwind' })]} />);
+
+  await user.type(screen.getByRole('searchbox', { name: /search jobs/i }), 'zzz-no-match');
+
+  expect(screen.getByText('No matching jobs')).toBeInTheDocument();
+  expect(screen.queryByText('No jobs yet')).not.toBeInTheDocument();
+});

--- a/apps/web/src/components/jobs-table.tsx
+++ b/apps/web/src/components/jobs-table.tsx
@@ -51,6 +51,7 @@ export function JobsTable({ jobs }: { jobs: Job[] }) {
   const [status, setStatus] = useState<JobStatus | 'all'>('all');
   const [priority, setPriority] = useState<JobPriority | 'all'>('all');
 
+  const hasJobs = jobs.length > 0;
   const normalizedQuery = query.trim().toLowerCase();
 
   const filteredJobs = jobs.filter((job) => {
@@ -67,45 +68,55 @@ export function JobsTable({ jobs }: { jobs: Job[] }) {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-        <div className="relative flex-1">
-          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
-          <Input
-            type="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search company, title, location…"
-            aria-label="Search jobs"
-            className="bg-card pl-8"
-          />
+      {/* No filter controls when there is nothing to filter. */}
+      {hasJobs ? (
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div className="relative flex-1">
+            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+            <Input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search company, title, location…"
+              aria-label="Search jobs"
+              className="bg-card pl-8"
+            />
+          </div>
+          <select
+            aria-label="Filter by status"
+            className={selectClass}
+            value={status}
+            onChange={(event) => setStatus(event.target.value as JobStatus | 'all')}
+          >
+            {statusOptions.map((option) => (
+              <option key={option} value={option}>
+                {option === 'all' ? 'All statuses' : option.replaceAll('_', ' ')}
+              </option>
+            ))}
+          </select>
+          <select
+            aria-label="Filter by priority"
+            className={selectClass}
+            value={priority}
+            onChange={(event) => setPriority(event.target.value as JobPriority | 'all')}
+          >
+            {priorityOptions.map((option) => (
+              <option key={option} value={option}>
+                {option === 'all' ? 'All priorities' : option}
+              </option>
+            ))}
+          </select>
         </div>
-        <select
-          aria-label="Filter by status"
-          className={selectClass}
-          value={status}
-          onChange={(event) => setStatus(event.target.value as JobStatus | 'all')}
-        >
-          {statusOptions.map((option) => (
-            <option key={option} value={option}>
-              {option === 'all' ? 'All statuses' : option.replaceAll('_', ' ')}
-            </option>
-          ))}
-        </select>
-        <select
-          aria-label="Filter by priority"
-          className={selectClass}
-          value={priority}
-          onChange={(event) => setPriority(event.target.value as JobPriority | 'all')}
-        >
-          {priorityOptions.map((option) => (
-            <option key={option} value={option}>
-              {option === 'all' ? 'All priorities' : option}
-            </option>
-          ))}
-        </select>
-      </div>
+      ) : null}
 
-      {filteredJobs.length === 0 ? (
+      {!hasJobs ? (
+        <EmptyState
+          title="No jobs yet"
+          description="Add a job (paste its description) and the AI will parse it, score your fit, and draft outreach. You can also load sample data from Settings to explore first."
+          actionLabel="Add your first job"
+          actionHref="/jobs/new"
+        />
+      ) : filteredJobs.length === 0 ? (
         <EmptyState
           title="No matching jobs"
           description="Try a different company, title, status, or priority filter."
@@ -171,9 +182,11 @@ export function JobsTable({ jobs }: { jobs: Job[] }) {
         </div>
       )}
 
-      <p className="text-muted-foreground text-xs">
-        Showing {filteredJobs.length} of {jobs.length} jobs
-      </p>
+      {hasJobs ? (
+        <p className="text-muted-foreground text-xs">
+          Showing {filteredJobs.length} of {jobs.length} jobs
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/jobs-table.tsx
+++ b/apps/web/src/components/jobs-table.tsx
@@ -54,6 +54,12 @@ export function JobsTable({ jobs }: { jobs: Job[] }) {
   const hasJobs = jobs.length > 0;
   const normalizedQuery = query.trim().toLowerCase();
 
+  function clearFilters() {
+    setQuery('');
+    setStatus('all');
+    setPriority('all');
+  }
+
   const filteredJobs = jobs.filter((job) => {
     const matchesQuery =
       !normalizedQuery ||
@@ -119,9 +125,9 @@ export function JobsTable({ jobs }: { jobs: Job[] }) {
       ) : filteredJobs.length === 0 ? (
         <EmptyState
           title="No matching jobs"
-          description="Try a different company, title, status, or priority filter."
-          actionLabel="Add a job"
-          actionHref="/jobs/new"
+          description="No jobs match your current search and filters. Try clearing them to see everything again."
+          actionLabel="Clear filters"
+          onAction={clearFilters}
         />
       ) : (
         <div className="overflow-x-auto">
@@ -183,7 +189,7 @@ export function JobsTable({ jobs }: { jobs: Job[] }) {
       )}
 
       {hasJobs ? (
-        <p className="text-muted-foreground text-xs">
+        <p role="status" aria-live="polite" className="text-muted-foreground text-xs">
           Showing {filteredJobs.length} of {jobs.length} jobs
         </p>
       ) : null}


### PR DESCRIPTION
## Finding (J2, #113 🔴)
The jobs pipeline rendered a single empty state — **"No matching jobs — Try a different company, title, status, or priority filter."** — even when the user had **zero jobs and no filters applied**. A brand-new user landing on `/jobs` was told to change filters that don't exist.

## Fix (`jobs-table.tsx`)
- **Branch the empty state** on `jobs.length === 0`:
  - No jobs at all → **"No jobs yet"** with an *Add your first job* CTA (mirrors the dashboard empty state, mentions sample data).
  - Jobs exist but the active filter/search matches none → the existing **"No matching jobs / try a different filter"** hint (now only shown when it's actually true).
- **Hide the search + status + priority toolbar** and the **"Showing X of Y jobs"** footer when there are no jobs — there's nothing to filter or count.

## Tests (`jobs-table-empty-states.test.tsx`)
- Zero jobs → "No jobs yet" shown, "No matching jobs" absent, toolbar + footer hidden.
- Jobs present + non-matching query typed → "No matching jobs" shown, "No jobs yet" absent.

## Verification
- `vitest run` (web): **12/12 pass** · `eslint .`: clean · `tsc --noEmit`: clean

Part of #113. Does not auto-merge — owner merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)