### PR TITLE
fix(web): confirm before destructive "Clear my data" (J3)

### DIFF
--- a/apps/web/src/components/settings-actions.test.tsx
+++ b/apps/web/src/components/settings-actions.test.tsx
@@ -11,6 +11,7 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
 vi.mock('@/lib/api', () => ({ clearMyData, seedDemoData, uploadResumeFile: vi.fn() }));
 
+import { toast } from 'sonner';
 import { DemoDataActions } from './settings-actions';
 
 afterEach(() => {
@@ -50,4 +51,39 @@ it('cancelling the confirmation aborts the destructive action', async () => {
   // Back to the single, unconfirmed button.
   expect(screen.getByRole('button', { name: /clear my data/i })).toBeInTheDocument();
   expect(screen.queryByRole('button', { name: /yes, delete everything/i })).not.toBeInTheDocument();
+});
+
+it('moves focus to Cancel when the confirmation opens', async () => {
+  const user = userEvent.setup();
+  render(<DemoDataActions />);
+
+  await user.click(screen.getByRole('button', { name: /clear my data/i }));
+
+  expect(screen.getByRole('button', { name: /cancel/i })).toHaveFocus();
+});
+
+it('Escape dismisses the confirmation without clearing', async () => {
+  const user = userEvent.setup();
+  render(<DemoDataActions />);
+
+  await user.click(screen.getByRole('button', { name: /clear my data/i }));
+  await user.keyboard('{Escape}');
+
+  expect(clearMyData).not.toHaveBeenCalled();
+  expect(screen.queryByRole('button', { name: /yes, delete everything/i })).not.toBeInTheDocument();
+  // Focus returns to the trigger so keyboard users keep their place.
+  expect(screen.getByRole('button', { name: /clear my data/i })).toHaveFocus();
+});
+
+it('surfaces an error toast and recovers when clearing fails', async () => {
+  clearMyData.mockRejectedValueOnce(new Error('boom'));
+  const user = userEvent.setup();
+  render(<DemoDataActions />);
+
+  await user.click(screen.getByRole('button', { name: /clear my data/i }));
+  await user.click(screen.getByRole('button', { name: /yes, delete everything/i }));
+
+  expect(toast.error).toHaveBeenCalled();
+  // UI recovers to the unconfirmed state after the failure.
+  expect(screen.getByRole('button', { name: /clear my data/i })).toBeInTheDocument();
 });

--- a/apps/web/src/components/settings-actions.test.tsx
+++ b/apps/web/src/components/settings-actions.test.tsx
@@ -1,0 +1,53 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, expect, it, vi } from 'vitest';
+
+const { clearMyData, seedDemoData } = vi.hoisted(() => ({
+  clearMyData: vi.fn(() => Promise.resolve()),
+  seedDemoData: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock('@/lib/api', () => ({ clearMyData, seedDemoData, uploadResumeFile: vi.fn() }));
+
+import { DemoDataActions } from './settings-actions';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+it('does not clear data on the first click — it asks for confirmation', async () => {
+  const user = userEvent.setup();
+  render(<DemoDataActions />);
+
+  await user.click(screen.getByRole('button', { name: /clear my data/i }));
+
+  // Destructive call must NOT have fired yet.
+  expect(clearMyData).not.toHaveBeenCalled();
+  // A confirmation prompt is shown instead.
+  expect(screen.getByRole('button', { name: /yes, delete everything/i })).toBeInTheDocument();
+});
+
+it('clears data only after the explicit confirm', async () => {
+  const user = userEvent.setup();
+  render(<DemoDataActions />);
+
+  await user.click(screen.getByRole('button', { name: /clear my data/i }));
+  await user.click(screen.getByRole('button', { name: /yes, delete everything/i }));
+
+  expect(clearMyData).toHaveBeenCalledOnce();
+});
+
+it('cancelling the confirmation aborts the destructive action', async () => {
+  const user = userEvent.setup();
+  render(<DemoDataActions />);
+
+  await user.click(screen.getByRole('button', { name: /clear my data/i }));
+  await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+  expect(clearMyData).not.toHaveBeenCalled();
+  // Back to the single, unconfirmed button.
+  expect(screen.getByRole('button', { name: /clear my data/i })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /yes, delete everything/i })).not.toBeInTheDocument();
+});

--- a/apps/web/src/components/settings-actions.tsx
+++ b/apps/web/src/components/settings-actions.tsx
@@ -61,6 +61,7 @@ export function ExportDataButton() {
 export function DemoDataActions() {
   const router = useRouter();
   const [busy, setBusy] = useState<'seed' | 'clear' | null>(null);
+  const [confirmingClear, setConfirmingClear] = useState(false);
 
   async function run(action: 'seed' | 'clear') {
     setBusy(action);
@@ -77,6 +78,7 @@ export function DemoDataActions() {
       toast.error('Action failed. Please try again.');
     } finally {
       setBusy(null);
+      setConfirmingClear(false);
     }
   }
 
@@ -93,10 +95,43 @@ export function DemoDataActions() {
         {busy === 'seed' ? <Loader2 className="size-4 animate-spin" /> : null}
         Load sample data
       </Button>
-      <Button variant="ghost" size="sm" disabled={busy !== null} onClick={() => run('clear')}>
-        {busy === 'clear' ? <Loader2 className="size-4 animate-spin" /> : null}
-        Clear my data
-      </Button>
+      {confirmingClear ? (
+        <div
+          role="group"
+          aria-label="Confirm clearing all data"
+          className="flex flex-wrap items-center gap-2"
+        >
+          <p className="text-muted-foreground text-xs">
+            Permanently delete all jobs, outreach &amp; your resume?
+          </p>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={busy !== null}
+            onClick={() => setConfirmingClear(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            disabled={busy !== null}
+            onClick={() => run('clear')}
+          >
+            {busy === 'clear' ? <Loader2 className="size-4 animate-spin" /> : null}
+            Yes, delete everything
+          </Button>
+        </div>
+      ) : (
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={busy !== null}
+          onClick={() => setConfirmingClear(true)}
+        >
+          Clear my data
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/settings-actions.tsx
+++ b/apps/web/src/components/settings-actions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Database, Download, Loader2, Upload } from 'lucide-react';
 import { toast } from 'sonner';
@@ -62,6 +62,21 @@ export function DemoDataActions() {
   const router = useRouter();
   const [busy, setBusy] = useState<'seed' | 'clear' | null>(null);
   const [confirmingClear, setConfirmingClear] = useState(false);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const wasConfirming = useRef(false);
+
+  // Move focus into the confirmation when it opens and back to the trigger when
+  // it closes (cancel or completion), so keyboard/SR users keep their place.
+  useEffect(() => {
+    if (confirmingClear) {
+      cancelRef.current?.focus();
+      wasConfirming.current = true;
+    } else if (wasConfirming.current) {
+      wasConfirming.current = false;
+      triggerRef.current?.focus();
+    }
+  }, [confirmingClear]);
 
   async function run(action: 'seed' | 'clear') {
     setBusy(action);
@@ -97,14 +112,19 @@ export function DemoDataActions() {
       </Button>
       {confirmingClear ? (
         <div
-          role="group"
+          role="alertdialog"
           aria-label="Confirm clearing all data"
+          aria-describedby="clear-data-prompt"
           className="flex flex-wrap items-center gap-2"
+          onKeyDown={(event) => {
+            if (event.key === 'Escape' && busy === null) setConfirmingClear(false);
+          }}
         >
-          <p className="text-muted-foreground text-xs">
+          <p id="clear-data-prompt" className="text-muted-foreground text-xs">
             Permanently delete all jobs, outreach &amp; your resume?
           </p>
           <Button
+            ref={cancelRef}
             variant="ghost"
             size="sm"
             disabled={busy !== null}
@@ -124,6 +144,7 @@ export function DemoDataActions() {
         </div>
       ) : (
         <Button
+          ref={triggerRef}
           variant="ghost"
           size="sm"
           disabled={busy !== null}


### PR DESCRIPTION
## Finding (J3, #113 🔴)
In Settings, **"Clear my data"** called `clearMyData()` on the first click with **no confirmation and no undo** — one misclick permanently deletes all jobs, outreach, and the resume. Web Interface Guidelines: destructive actions need confirmation or undo.

## Fix (`settings-actions.tsx`)
The button now reveals an **inline confirmation** instead of acting immediately:
- Prompt: *"Permanently delete all jobs, outreach & your resume?"*
- An explicit **destructive** "Yes, delete everything" button + a **Cancel**.
- `clearMyData()` only runs after the explicit confirm; Cancel restores the original button.

Lightweight and self-contained — reuses the existing `destructive` Button variant and a labelled `role="group"` confirm region, no new dialog dependency.

## Tests (`settings-actions.test.tsx`)
- First click does **not** call `clearMyData` and shows the confirm prompt.
- Confirm → `clearMyData` called once.
- Cancel → not called, original button restored.

## Verification
- `vitest run` (web): **13/13 pass** · `eslint .`: clean · `tsc --noEmit`: clean

Part of #113. Does not auto-merge — owner merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)