### PR TITLE
fix(web): reports show real pipeline data, not fabricated demo numbers (#118 · 1.1)

### DIFF
--- a/apps/web/src/app/(app)/reports/page.tsx
+++ b/apps/web/src/app/(app)/reports/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from 'next';
-import { CircleCheck, Download } from 'lucide-react';
+import { CircleCheck, Download, Send, Target, Briefcase, CalendarCheck } from 'lucide-react';
 import { EmptyState } from '@/components/empty-state';
 import { SectionCard } from '@/components/section-card';
 import { StatTile } from '@/components/stat-tile';
+import { Card } from '@/components/ui/card';
+import { loadJobs } from '@/lib/job-data';
 import { loadWeeklyReports } from '@/lib/report-data';
+import { getReportSnapshot } from '@/lib/report-snapshot';
 import type { WeeklyReport } from '@/types/job';
 
 export const dynamic = 'force-dynamic';
@@ -21,118 +24,109 @@ const formatDate = (value: string) => dateFormatter.format(new Date(value));
 const formatWeekRange = (report: WeeklyReport) =>
   `${formatDate(report.weekStart)} – ${formatDate(report.weekEnd)}`;
 
-// Percentage change vs the previous week (null when there's no prior report).
-function weekOverWeek(current: number, previous: number | undefined): number | undefined {
-  if (previous === undefined) return undefined;
-  if (previous === 0) return current > 0 ? 100 : 0;
-  return Math.round(((current - previous) / previous) * 100);
-}
-
 export default async function ReportsPage() {
-  const { reports } = await loadWeeklyReports();
-  const report = reports[0];
-  const prior = reports[1];
+  const [{ jobs, source }, { reports }] = await Promise.all([loadJobs(), loadWeeklyReports()]);
+  const snapshot = getReportSnapshot(jobs);
 
-  if (!report) {
+  if (jobs.length === 0) {
     return (
       <EmptyState
-        title="No weekly report yet"
-        description="Once the reporting workflow runs, the latest weekly summary will appear here."
-        actionLabel="Back to dashboard"
-        actionHref="/dashboard"
+        title="No report yet"
+        description="Your weekly report is built from the jobs you track. Add a job — your discovered, applied, outreach, and interview figures will appear here automatically."
+        actionLabel="Add your first job"
+        actionHref="/jobs/new"
       />
     );
   }
 
-  const maxSkill = Math.max(1, report.commonMissingSkills.length);
+  const topSkills = snapshot.commonMissingSkills.slice(0, 6);
+  const maxSkill = Math.max(1, topSkills.length);
 
   return (
     <div className="space-y-6">
       <div>
         <h2 className="font-heading text-2xl font-bold tracking-tight">Weekly reports</h2>
-        <p className="text-muted-foreground text-sm">
-          Latest snapshot · {formatWeekRange(report)}
-        </p>
+        <p className="text-muted-foreground text-sm">A live snapshot of your pipeline.</p>
       </div>
 
+      {source === 'seed' ? (
+        <Card className="border-amber-500/30 bg-amber-500/5 gap-1 p-4">
+          <p className="text-sm font-medium text-amber-700 dark:text-amber-400">Seed data shown</p>
+          <p className="text-muted-foreground text-sm">
+            The API is not reachable, so these figures come from local seed data. They switch to your
+            live CRM automatically once the backend is up.
+          </p>
+        </Card>
+      ) : null}
+
       <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
-        <StatTile
-          label="Discovered"
-          value={report.jobsDiscovered}
-          trend={weekOverWeek(report.jobsDiscovered, prior?.jobsDiscovered)}
-          trendLabel="week over week"
-        />
-        <StatTile
-          label="Applied"
-          value={report.jobsApplied}
-          trend={weekOverWeek(report.jobsApplied, prior?.jobsApplied)}
-          trendLabel="week over week"
-        />
-        <StatTile
-          label="Outreach sent"
-          value={report.outreachSent}
-          trend={weekOverWeek(report.outreachSent, prior?.outreachSent)}
-          trendLabel="week over week"
-        />
-        <StatTile
-          label="Interviews"
-          value={report.interviews}
-          trend={weekOverWeek(report.interviews, prior?.interviews)}
-          trendLabel="week over week"
-        />
+        <StatTile label="Discovered" value={snapshot.discovered} icon={Briefcase} />
+        <StatTile label="Applied" value={snapshot.applied} icon={Target} />
+        <StatTile label="Outreach sent" value={snapshot.outreachSent} icon={Send} />
+        <StatTile label="Interviews" value={snapshot.interviews} icon={CalendarCheck} />
       </div>
 
       <div className="grid gap-6 lg:grid-cols-2">
-        <SectionCard title="Recommendations" description="Actionable guidance from this week's report.">
-          <ul className="space-y-2.5">
-            {report.recommendations.map((item) => (
-              <li key={item} className="flex items-start gap-2 text-sm">
-                <CircleCheck className="text-primary mt-0.5 size-4 shrink-0" />
-                {item}
+        <SectionCard title="Recommendations" description="Guidance derived from your live pipeline.">
+          {snapshot.recommendations.length > 0 ? (
+            <ul className="space-y-2.5">
+              {snapshot.recommendations.map((item) => (
+                <li key={item} className="flex items-start gap-2 text-sm">
+                  <CircleCheck className="text-primary mt-0.5 size-4 shrink-0" />
+                  {item}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-muted-foreground text-sm">No recommendations yet.</p>
+          )}
+        </SectionCard>
+
+        <SectionCard title="Recurring missing skills" description="Repeated gaps across your targets.">
+          {topSkills.length > 0 ? (
+            <div className="space-y-3">
+              {topSkills.map((skill, index) => (
+                <div key={skill} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm">
+                    <span>{skill}</span>
+                  </div>
+                  <div className="bg-muted h-2 overflow-hidden rounded-full">
+                    <div
+                      className="bg-primary h-full rounded-full"
+                      style={{ width: `${100 - (index / maxSkill) * 60}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-muted-foreground text-sm">No repeated skill gaps yet.</p>
+          )}
+        </SectionCard>
+      </div>
+
+      {reports.length > 0 ? (
+        <SectionCard title="Report history" description="Saved reports in week order.">
+          <ul className="divide-border -my-1 divide-y">
+            {reports.map((item) => (
+              <li key={item.id} className="flex items-center justify-between gap-3 py-3">
+                <div>
+                  <p className="text-sm font-medium">{formatWeekRange(item)}</p>
+                  <p className="text-muted-foreground text-xs">Generated {formatDate(item.createdAt)}</p>
+                </div>
+                <a
+                  href={`/api/proxy/api/reports/${item.id}/export`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-muted-foreground hover:text-primary flex items-center gap-1 text-sm"
+                >
+                  <Download className="size-4" /> Export
+                </a>
               </li>
             ))}
           </ul>
         </SectionCard>
-
-        <SectionCard title="Recurring missing skills" description="Repeated gaps across the funnel.">
-          <div className="space-y-3">
-            {report.commonMissingSkills.map((skill, index) => (
-              <div key={skill} className="space-y-1">
-                <div className="flex items-center justify-between text-sm">
-                  <span>{skill}</span>
-                </div>
-                <div className="bg-muted h-2 overflow-hidden rounded-full">
-                  <div
-                    className="bg-primary h-full rounded-full"
-                    style={{ width: `${100 - (index / maxSkill) * 60}%` }}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
-        </SectionCard>
-      </div>
-
-      <SectionCard title="Report history" description="Saved reports in week order.">
-        <ul className="divide-border -my-1 divide-y">
-          {reports.map((item) => (
-            <li key={item.id} className="flex items-center justify-between gap-3 py-3">
-              <div>
-                <p className="text-sm font-medium">{formatWeekRange(item)}</p>
-                <p className="text-muted-foreground text-xs">Generated {formatDate(item.createdAt)}</p>
-              </div>
-              <a
-                href={`/api/proxy/api/reports/${item.id}/export`}
-                target="_blank"
-                rel="noreferrer"
-                className="text-muted-foreground hover:text-primary flex items-center gap-1 text-sm"
-              >
-                <Download className="size-4" /> Export
-              </a>
-            </li>
-          ))}
-        </ul>
-      </SectionCard>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/app/(app)/reports/page.tsx
+++ b/apps/web/src/app/(app)/reports/page.tsx
@@ -28,7 +28,10 @@ export default async function ReportsPage() {
   const [{ jobs, source }, { reports }] = await Promise.all([loadJobs(), loadWeeklyReports()]);
   const snapshot = getReportSnapshot(jobs);
 
-  if (jobs.length === 0) {
+  // Only the pure empty state when there's nothing at all. If saved reports
+  // exist (they can be generated even with zero jobs), keep rendering the page
+  // so the history/export section below stays reachable.
+  if (jobs.length === 0 && reports.length === 0) {
     return (
       <EmptyState
         title="No report yet"

--- a/apps/web/src/lib/mock-data.ts
+++ b/apps/web/src/lib/mock-data.ts
@@ -1,4 +1,4 @@
-import type { Job, JobPriority, JobStatus, WeeklyReport } from '@/types/job';
+import type { Job, JobPriority, JobStatus } from '@/types/job';
 
 export const jobStatusOrder: JobStatus[] = [
   'discovered',
@@ -217,30 +217,6 @@ export const mockJobs: Job[] = [
       modelUsed: 'mock-analysis-v1',
     },
     outreach: [],
-  },
-];
-
-export const mockWeeklyReports: WeeklyReport[] = [
-  {
-    id: 'report-01',
-    weekStart: '2026-05-11',
-    weekEnd: '2026-05-17',
-    jobsDiscovered: 14,
-    jobsShortlisted: 5,
-    jobsApplied: 2,
-    outreachDrafted: 4,
-    outreachSent: 1,
-    responsesReceived: 1,
-    interviews: 1,
-    commonMissingSkills: ['Azure Functions', 'n8n', 'HR tech', 'Program management'],
-    recommendations: [
-      'Tailor the headline toward operations automation and workflow systems.',
-      'Prioritize jobs that combine process ownership with hands-on technical delivery.',
-      'Schedule follow-ups for all drafted outreach within seven days.',
-    ],
-    reportMarkdown:
-      'This week focused on operational roles that reward workflow thinking. The strongest opportunities were the automation engineer and recruiting operations roles.',
-    createdAt: '2026-05-17T18:00:00.000Z',
   },
 ];
 

--- a/apps/web/src/lib/report-data.ts
+++ b/apps/web/src/lib/report-data.ts
@@ -1,5 +1,4 @@
-import { ApiRequestError, fetchWeeklyReports } from '@/lib/api';
-import { mockWeeklyReports } from '@/lib/mock-data';
+import { fetchWeeklyReports } from '@/lib/api';
 import type { WeeklyReport } from '@/types/job';
 
 export interface WeeklyReportDataResult {
@@ -7,27 +6,15 @@ export interface WeeklyReportDataResult {
   source: 'api' | 'seed';
 }
 
+/**
+ * Loads the user's persisted weekly reports for the history list. Returns an
+ * empty list when there are none or the API is unreachable — never fabricated
+ * demo reports (that was the source of the phantom 14/2/1/1 on new accounts).
+ */
 export async function loadWeeklyReports(): Promise<WeeklyReportDataResult> {
   try {
-    const reports = await fetchWeeklyReports();
-
-    if (reports.length > 0) {
-      return {
-        reports,
-        source: 'api',
-      };
-    }
-  } catch (error) {
-    if (!(error instanceof ApiRequestError)) {
-      return {
-        reports: mockWeeklyReports,
-        source: 'seed',
-      };
-    }
+    return { reports: await fetchWeeklyReports(), source: 'api' };
+  } catch {
+    return { reports: [], source: 'seed' };
   }
-
-  return {
-    reports: mockWeeklyReports,
-    source: 'seed',
-  };
 }

--- a/apps/web/src/lib/report-snapshot.test.ts
+++ b/apps/web/src/lib/report-snapshot.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { getReportSnapshot } from './report-snapshot';
+import type { Job, JobAnalysis, JobStatus, OutreachDraft } from '@/types/job';
+
+function analysis(missingSkills: string[] = []): JobAnalysis {
+  return {
+    requiredSkills: [],
+    preferredSkills: [],
+    matchedSkills: [],
+    missingSkills,
+    atsKeywords: [],
+    fitSummary: '',
+    recommendedResumeAngle: '',
+    applyRecommendation: '',
+    confidenceScore: 0,
+    modelUsed: 'mock-analysis-v1',
+  };
+}
+
+function job(opts: {
+  status?: JobStatus;
+  missingSkills?: string[];
+  outreach?: OutreachDraft[];
+} = {}): Job {
+  return {
+    id: `job-${Math.random().toString(36).slice(2)}`,
+    source: 'manual',
+    company: 'Acme',
+    title: 'Engineer',
+    location: 'Remote',
+    employmentType: 'Full-time',
+    workplaceType: 'remote',
+    discoveredAt: '2026-06-01T00:00:00.000Z',
+    descriptionText: '',
+    status: opts.status ?? 'discovered',
+    priority: 'medium',
+    fitScore: null,
+    nextAction: '',
+    analysis: analysis(opts.missingSkills ?? []),
+    outreach: opts.outreach ?? [],
+  };
+}
+
+function outreach(status: OutreachDraft['status']): OutreachDraft {
+  return {
+    id: `o-${Math.random().toString(36).slice(2)}`,
+    contactName: 'Pat',
+    contactRole: 'Recruiter',
+    contactSource: 'manual',
+    messageType: 'recruiter_email',
+    draftText: 'hello',
+    status,
+    createdAt: '2026-06-01T00:00:00.000Z',
+  };
+}
+
+describe('getReportSnapshot', () => {
+  it('returns all-zero metrics and no skills/recommendations for an empty pipeline', () => {
+    const snap = getReportSnapshot([]);
+
+    expect(snap.discovered).toBe(0);
+    expect(snap.applied).toBe(0);
+    expect(snap.outreachSent).toBe(0);
+    expect(snap.interviews).toBe(0);
+    expect(snap.commonMissingSkills).toEqual([]);
+    expect(snap.recommendations).toEqual([]);
+  });
+
+  it('aggregates real metrics from the live pipeline', () => {
+    const jobs = [
+      job({ status: 'discovered' }),
+      job({ status: 'applied' }),
+      job({ status: 'interview' }),
+      job({ status: 'shortlisted', outreach: [outreach('sent')] }),
+      job({ status: 'discovered', outreach: [outreach('drafted')] }),
+    ];
+
+    const snap = getReportSnapshot(jobs);
+
+    expect(snap.discovered).toBe(5); // total jobs tracked
+    expect(snap.applied).toBe(1);
+    expect(snap.interviews).toBe(1);
+    expect(snap.outreachSent).toBe(1); // only the 'sent' outreach counts
+  });
+
+  it('ranks recurring missing skills by frequency', () => {
+    const jobs = [
+      job({ missingSkills: ['Kubernetes', 'Go'] }),
+      job({ missingSkills: ['Kubernetes'] }),
+      job({ missingSkills: ['Kubernetes', 'Go'] }),
+      job({ missingSkills: ['Rust'] }),
+    ];
+
+    const snap = getReportSnapshot(jobs);
+
+    // Kubernetes (3) > Go (2) > Rust (1)
+    expect(snap.commonMissingSkills.slice(0, 3)).toEqual(['Kubernetes', 'Go', 'Rust']);
+  });
+
+  it('derives recommendations from real data, not hardcoded marketing copy', () => {
+    const jobs = [
+      job({ status: 'shortlisted', missingSkills: ['Azure Functions', 'Azure Functions'] }),
+      job({ status: 'discovered', missingSkills: ['Azure Functions'], outreach: [outreach('drafted')] }),
+    ];
+
+    const snap = getReportSnapshot(jobs);
+
+    expect(snap.recommendations.length).toBe(3);
+    // grounded in the real top gap
+    expect(snap.recommendations.some((r) => r.includes('Azure Functions'))).toBe(true);
+    // never the old fabricated bullets
+    expect(
+      snap.recommendations.includes(
+        'Tailor the headline toward operations automation and workflow systems.',
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/report-snapshot.ts
+++ b/apps/web/src/lib/report-snapshot.ts
@@ -1,0 +1,78 @@
+import type { Job } from '@/types/job';
+
+/**
+ * A live weekly-report snapshot derived from the user's REAL pipeline.
+ *
+ * Reports used to fall back to hardcoded demo numbers (14/2/1/1) for every new
+ * account; this computes the figures from actual jobs instead, mirroring how the
+ * dashboard aggregates so the two always reconcile.
+ */
+export interface ReportSnapshot {
+  discovered: number;
+  applied: number;
+  outreachSent: number;
+  interviews: number;
+  /** Recurring missing skills across the pipeline, ranked by frequency (most common first). */
+  commonMissingSkills: string[];
+  /** Honest, data-derived guidance. Empty when there is no pipeline yet. */
+  recommendations: string[];
+}
+
+function buildRecommendations(input: {
+  hasJobs: boolean;
+  applied: number;
+  shortlisted: number;
+  outreachDrafted: number;
+  outreachSent: number;
+  topSkill: string | undefined;
+}): string[] {
+  if (!input.hasJobs) return [];
+
+  return [
+    input.applied < input.shortlisted
+      ? 'Push more shortlisted roles into applications while the context is still fresh.'
+      : 'Keep following up on your strongest leads and active applications.',
+    input.outreachDrafted > input.outreachSent
+      ? 'Review your drafted outreach and send or archive what is still waiting.'
+      : 'Keep your outreach aligned to the most promising roles and contacts.',
+    input.topSkill
+      ? `Add one truthful proof point for ${input.topSkill} to reduce repeated screening friction.`
+      : 'Capture one new proof point this week so your next report has a stronger story.',
+  ];
+}
+
+export function getReportSnapshot(jobs: Job[]): ReportSnapshot {
+  const discovered = jobs.length;
+  const applied = jobs.filter((job) => job.status === 'applied').length;
+  const interviews = jobs.filter((job) => job.status === 'interview').length;
+  const shortlisted = jobs.filter((job) => job.status === 'shortlisted').length;
+
+  const drafts = jobs.flatMap((job) => job.outreach);
+  const outreachSent = drafts.filter((draft) => draft.status === 'sent' || Boolean(draft.sentAt)).length;
+  const outreachDrafted = drafts.filter(
+    (draft) => draft.status === 'drafted' || draft.status === 'approved',
+  ).length;
+
+  const skillCounts = new Map<string, number>();
+  for (const job of jobs) {
+    for (const skill of job.analysis.missingSkills) {
+      const key = skill.trim();
+      if (!key) continue;
+      skillCounts.set(key, (skillCounts.get(key) ?? 0) + 1);
+    }
+  }
+  const commonMissingSkills = [...skillCounts.entries()]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .map(([skill]) => skill);
+
+  const recommendations = buildRecommendations({
+    hasJobs: discovered > 0,
+    applied,
+    shortlisted,
+    outreachDrafted,
+    outreachSent,
+    topSkill: commonMissingSkills[0],
+  });
+
+  return { discovered, applied, outreachSent, interviews, commonMissingSkills, recommendations };
+}


### PR DESCRIPTION
## What & why
A brand-new account showed a Weekly Report with **DISCOVERED 14 / APPLIED 2 / OUTREACH SENT 1 / INTERVIEWS 1**, fake "recurring missing skills" bars, and three canned recommendations — even with **0 jobs** and an empty dashboard.

Root cause: the Reports page fell back to the hardcoded `mockWeeklyReports` array whenever the API returned zero reports (`apps/web/src/lib/report-data.ts` → `apps/web/src/lib/mock-data.ts`). The backend already returns empty for real users; the lie was purely frontend.

## Changes
- **New `getReportSnapshot(jobs)`** (`apps/web/src/lib/report-snapshot.ts`) — computes discovered / applied / outreach-sent / interviews, recurring missing skills (ranked), and data-derived recommendations from the user's **real** jobs, mirroring `getDashboardSummary` so Reports and the dashboard always reconcile (also addresses **J7** in #113).
- **Reports page** now renders that live snapshot with an honest **empty state** when there are no jobs; dropped the fabricated week-over-week trend tiles.
- **Removed** the `mockWeeklyReports` fallback and deleted the demo data.
- **Report history** lists only real persisted reports (section hidden when none); export unchanged.

## Tests
- TDD'd `getReportSnapshot` — `apps/web/src/lib/report-snapshot.test.ts` (empty pipeline → zeros/empty; real aggregation; skill ranking; recommendations grounded in real gaps, never the old marketing copy).
- `npm run typecheck:web`, `npm run lint:web`, `npm --workspace @jobops/web test` (32 passed), `npm run build:web` — all green.

## Verify
Sign in on a fresh `+clerk_test`/GitHub account → Reports shows the empty state (no 14/2/1/1). Load sample data (Settings) or add jobs → figures match the dashboard.

Part of #118 (Phase 1 — truthful data). Epic #124.
