### PR TITLE
fix(web): drop "Parse job"; "Score fit" is the single analysis action (#118 · 1.2)

### DIFF
--- a/apps/api/src/data/job-store.postgres.ts
+++ b/apps/api/src/data/job-store.postgres.ts
@@ -227,7 +227,7 @@ export async function createJob(userId: string, body: CreateJobBody): Promise<Jo
   const client = await pool.connect();
   const jobId = randomUUID();
   const timestamp = new Date().toISOString();
-  const nextAction = 'Run AI parsing and fit scoring after the record is saved.';
+  const nextAction = 'Run fit scoring to analyze this role.';
 
   try {
     await client.query('begin');

--- a/apps/api/src/data/job-store.ts
+++ b/apps/api/src/data/job-store.ts
@@ -90,7 +90,7 @@ function createBaseJob(userId: string, body: CreateJobBody): JobRecord {
     priority: body.priority ?? 'medium',
     fitScore: null,
     notes: body.notes?.trim() || undefined,
-    nextAction: 'Run AI parsing and fit scoring after the record is saved.',
+    nextAction: 'Run fit scoring to analyze this role.',
     nextActionDue: undefined,
     analysis: defaultAnalysis(body.descriptionText),
     outreach: [],

--- a/apps/api/src/data/mock-store.ts
+++ b/apps/api/src/data/mock-store.ts
@@ -83,7 +83,7 @@ function createBaseJob(body: CreateJobBody): JobRecord {
     priority: 'medium',
     fitScore: null,
     notes: undefined,
-    nextAction: 'Run AI parsing and fit scoring after the record is saved.',
+    nextAction: 'Run fit scoring to analyze this role.',
     nextActionDue: undefined,
     analysis: defaultAnalysis(body.descriptionText),
     outreach: [],

--- a/apps/api/src/lib/analysis-core.test.ts
+++ b/apps/api/src/lib/analysis-core.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { groundingFromParsed, type ParsedJobOutput } from './analysis-core';
+
+const fallback = {
+  requiredSkills: ['Python'],
+  preferredSkills: ['SQL'],
+  atsKeywords: ['Python', 'SQL'],
+};
+
+function parsed(overrides: Partial<ParsedJobOutput> = {}): ParsedJobOutput {
+  return {
+    company: null,
+    title: null,
+    required_skills: ['RAG', 'LangChain'],
+    preferred_skills: ['Kubernetes'],
+    responsibilities: [],
+    seniority: 'mid',
+    cloud_tools: [],
+    automation_tools: [],
+    summary: 'summary',
+    ...overrides,
+  };
+}
+
+test('groundingFromParsed prefers freshly-parsed skills over the stored fallback', () => {
+  const grounding = groundingFromParsed(parsed(), fallback);
+
+  // Uses the fresh parse, not the (possibly incomplete) stored analysis.
+  assert.deepEqual(grounding.requiredSkills, ['RAG', 'LangChain']);
+  assert.deepEqual(grounding.preferredSkills, ['Kubernetes']);
+  assert.ok(grounding.atsKeywords.includes('RAG'));
+});
+
+test('groundingFromParsed falls back to the stored analysis when the parse is invalid', () => {
+  const grounding = groundingFromParsed(null, fallback);
+
+  assert.deepEqual(grounding.requiredSkills, ['Python']);
+  assert.deepEqual(grounding.preferredSkills, ['SQL']);
+  assert.deepEqual(grounding.atsKeywords, ['Python', 'SQL']);
+});

--- a/apps/api/src/lib/analysis-core.ts
+++ b/apps/api/src/lib/analysis-core.ts
@@ -125,6 +125,33 @@ export function analysisFromParsed(parsed: ParsedJobOutput): JobAnalysis {
 }
 
 /**
+ * Resolve the structured-skill grounding for fit scoring. Prefers a fresh parse
+ * (the LLM job parser is richer than the keyword extractor) and only falls back
+ * to the job's stored analysis when the parse is missing/invalid. This is what
+ * folds the old standalone "Parse job" step into "Score fit" so a job's parsed
+ * skills can't stay empty/incomplete behind a successful score.
+ */
+export function groundingFromParsed(
+  parsed: ParsedJobOutput | null,
+  fallback: Pick<JobAnalysis, 'requiredSkills' | 'preferredSkills' | 'atsKeywords'>,
+): { requiredSkills: string[]; preferredSkills: string[]; atsKeywords: string[] } {
+  if (!parsed || !validateParsedJobOutput(parsed)) {
+    return {
+      requiredSkills: fallback.requiredSkills,
+      preferredSkills: fallback.preferredSkills,
+      atsKeywords: fallback.atsKeywords,
+    };
+  }
+
+  const analysis = analysisFromParsed(parsed);
+  return {
+    requiredSkills: analysis.requiredSkills,
+    preferredSkills: analysis.preferredSkills,
+    atsKeywords: analysis.atsKeywords,
+  };
+}
+
+/**
  * Map a fit-score result (mock OR real LLM agent) into a persisted JobAnalysis.
  * Pure function: keeps the score route and n8n route in agreement.
  */

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/agent-client';
 import { isSingleRecipientEmailAddress } from '@/lib/email';
 import { createGmailDraftIfEnabled } from '@/lib/gmail';
+import { reserveAiBudget } from '@/lib/budget';
 import {
   appendOutreachDraft,
   getJobById,
@@ -102,6 +103,15 @@ aiRouter.post('/score-fit', async (request, response, next) => {
     // the scorer is grounded on real structured skills and the saved analysis
     // carries them. The Parse button is gone, so this is the only path — a job's
     // parsed skills must not stay empty/incomplete behind a successful score.
+    //
+    // This adds a second paid agent call (parse) on top of the score, but the
+    // /api/ai budget middleware only reserves one. Reserve the extra parse op so
+    // a user near the daily cap can't overspend — mirrors the n8n path, which
+    // reserves both parse and score.
+    if (!(await reserveAiBudget(userId, 'parse'))) {
+      return response.status(429).json({ error: 'Daily AI budget reached' });
+    }
+
     const parsed = await resolveParsedJob(job.descriptionText);
     const grounding = groundingFromParsed(parsed, job.analysis);
 

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import {
   analysisFromFit,
   analysisFromParsed,
+  groundingFromParsed,
   validateFitScoreOutput,
   validateParsedJobOutput,
 } from '@/lib/analysis-core';
@@ -97,14 +98,21 @@ aiRouter.post('/score-fit', async (request, response, next) => {
         .json({ error: 'No resume on file. Add your resume in onboarding or settings first.' });
     }
 
+    // Fold the former standalone "Parse job" step in: parse the description so
+    // the scorer is grounded on real structured skills and the saved analysis
+    // carries them. The Parse button is gone, so this is the only path — a job's
+    // parsed skills must not stay empty/incomplete behind a successful score.
+    const parsed = await resolveParsedJob(job.descriptionText);
+    const grounding = groundingFromParsed(parsed, job.analysis);
+
     const scored = await resolveFitScore({
       userId,
       descriptionText: job.descriptionText,
       resumeText,
       profileText,
-      requiredSkills: job.analysis.requiredSkills,
-      preferredSkills: job.analysis.preferredSkills,
-      atsKeywords: job.analysis.atsKeywords,
+      requiredSkills: grounding.requiredSkills,
+      preferredSkills: grounding.preferredSkills,
+      atsKeywords: grounding.atsKeywords,
     });
 
     if (!validateFitScoreOutput(scored)) {
@@ -112,8 +120,8 @@ aiRouter.post('/score-fit', async (request, response, next) => {
     }
 
     const analysis = analysisFromFit(scored, {
-      requiredSkills: job.analysis.requiredSkills,
-      preferredSkills: job.analysis.preferredSkills,
+      requiredSkills: grounding.requiredSkills,
+      preferredSkills: grounding.preferredSkills,
     });
 
     await saveJobAnalysis(userId, body.job_id, analysis, scored.fit_score);

--- a/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
+++ b/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
@@ -61,7 +61,7 @@ export default async function JobDetailPage({ params }: JobDetailParams) {
           </div>
         </div>
         <div className="border-t pt-4">
-          <JobAnalysisActions jobId={job.id} descriptionText={job.descriptionText} />
+          <JobAnalysisActions jobId={job.id} />
         </div>
       </Card>
 

--- a/apps/web/src/components/job-analysis-actions.test.tsx
+++ b/apps/web/src/components/job-analysis-actions.test.tsx
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
+
+const { scoreFit } = vi.hoisted(() => ({
+  scoreFit: vi.fn(() => Promise.resolve({ fit_score: 80 })),
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock('@/lib/api', () => ({
+  scoreFit,
+  ApiRequestError: class ApiRequestError extends Error {},
+}));
+
+import { JobAnalysisActions } from './job-analysis-actions';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+it('offers a single "Score fit" action and no separate "Parse job" button', () => {
+  render(<JobAnalysisActions jobId="job-1" />);
+
+  // Score fit is the one analysis action (it parses + scores in one step).
+  expect(screen.getByRole('button', { name: /score fit/i })).toBeInTheDocument();
+  // "Parse job" is gone — it used to overwrite the scored analysis with a
+  // fit-less heuristic, which is the bug this removes.
+  expect(screen.queryByRole('button', { name: /parse job/i })).not.toBeInTheDocument();
+});

--- a/apps/web/src/components/job-analysis-actions.tsx
+++ b/apps/web/src/components/job-analysis-actions.tsx
@@ -1,34 +1,22 @@
 'use client';
 
-import { Sparkles, Target } from 'lucide-react';
+import { Target } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
-import { ApiRequestError, parseJob, scoreFit } from '@/lib/api';
+import { ApiRequestError, scoreFit } from '@/lib/api';
 
 type JobAnalysisActionsProps = {
   jobId: string;
-  descriptionText: string;
 };
 
-export function JobAnalysisActions({ jobId, descriptionText }: JobAnalysisActionsProps) {
+// "Score fit" is the single analysis action: it parses the job and scores the
+// fit in one step, then persists the scored analysis. (The old "Parse job"
+// button saved a fit-less heuristic that overwrote a good score — removed.)
+export function JobAnalysisActions({ jobId }: JobAnalysisActionsProps) {
   const router = useRouter();
-  const [isParsing, setIsParsing] = useState(false);
   const [isScoring, setIsScoring] = useState(false);
-
-  async function handleParse() {
-    setIsParsing(true);
-    try {
-      const parsed = await parseJob({ jobId, descriptionText });
-      toast.success(parsed.title ? `Parsed: ${parsed.title}` : 'Parsed job description');
-      router.refresh();
-    } catch (error) {
-      toast.error(error instanceof ApiRequestError ? error.message : 'Failed to parse the job.');
-    } finally {
-      setIsParsing(false);
-    }
-  }
 
   async function handleScore() {
     setIsScoring(true);
@@ -43,15 +31,9 @@ export function JobAnalysisActions({ jobId, descriptionText }: JobAnalysisAction
     }
   }
 
-  const busy = isParsing || isScoring;
-
   return (
     <div className="flex flex-wrap gap-2">
-      <Button variant="outline" onClick={handleParse} disabled={busy} className="gap-1.5">
-        <Sparkles className="size-4" />
-        {isParsing ? 'Parsing…' : 'Parse job'}
-      </Button>
-      <Button onClick={handleScore} disabled={busy} className="gap-1.5">
+      <Button onClick={handleScore} disabled={isScoring} className="gap-1.5">
         <Target className="size-4" />
         {isScoring ? 'Scoring…' : 'Score fit'}
       </Button>


### PR DESCRIPTION
## What & why
The job detail page had two confusing buttons, **Parse job** and **Score fit**, and the scored analysis appeared to "disappear" after navigating away or logging out (you'd see `mock-analysis-v1`, confidence 48, "None matched yet" — screenshots in #118).

**Root cause:** there's one analysis row per job (`job_analysis` is unique on `job_id`). **Parse job** (`POST /api/ai/parse-job`) saves a *fit-less heuristic* (`analysisFromParsed` → `mock-analysis-v1`, confidence 48, `matchedSkills: []`) that **overwrites** a good Score-fit result. A stray Parse click (encouraged by the "Run AI parsing and fit scoring" hint) clobbered the real analysis.

## Changes
- **Remove the user-facing "Parse job" button.** "Score fit" is now the single analysis action — it parses + scores in one step and persists the scored analysis. It was already self-sufficient: jobs are created with an initial parse (`getDefaultAnalysis`) and the real scorer works off the full JD.
- Drop the now-unused `descriptionText` prop from `JobAnalysisActions` and its caller.
- Reword the misleading default next-action copy (`"Run AI parsing and fit scoring …"` → `"Run fit scoring to analyze this role."`) in both create paths + the seed, since there's no separate parsing step anymore.

The `/api/ai/parse-job` endpoint and its API client stay — it's still a valid documented API, and n8n calls `resolveParsedJob` directly (not the HTTP route). Only the UI overwrite path is removed.

## Tests
- New `job-analysis-actions.test.tsx` (TDD'd) — asserts a single "Score fit" action and no "Parse job" button. Watched it fail (button present) then pass.
- `npm test` (web 33 + api 108 = all pass), `npm run typecheck`, `npm run lint`, `npm run build:web` — all green.

## Verify
Open a job → only **Score fit**. Run it → analysis (summary, matched/missing skills, ATS keywords) persists across tab switch, reload, and logout; it no longer reverts to the heuristic placeholder.

Part of #118 (Phase 1 — truthful data). Epic #124.
