### PR TITLE
fix(outreach): hide guardrail notes + keep only the latest draft (#118 · 1.3, 1.4)

### DIFF
--- a/apps/api/src/data/job-store.postgres.ts
+++ b/apps/api/src/data/job-store.postgres.ts
@@ -423,6 +423,9 @@ export async function appendOutreachDraft(
       return undefined;
     }
 
+    // Keep only the latest draft per job (replace, don't accumulate).
+    await client.query('delete from outreach where job_id::text = $1', [jobId]);
+
     const { rows } = await client.query<OutreachRow>(
       `
         insert into outreach (

--- a/apps/api/src/data/job-store.postgres.ts
+++ b/apps/api/src/data/job-store.postgres.ts
@@ -423,8 +423,9 @@ export async function appendOutreachDraft(
       return undefined;
     }
 
-    // Keep only the latest draft per job (replace, don't accumulate).
-    await client.query('delete from outreach where job_id::text = $1', [jobId]);
+    // Replace only the superseded unsent draft; preserve approved/sent/skipped
+    // rows, which carry real outreach history and dashboard/reporting state.
+    await client.query("delete from outreach where job_id::text = $1 and status = 'drafted'", [jobId]);
 
     const { rows } = await client.query<OutreachRow>(
       `

--- a/apps/api/src/data/job-store.test.ts
+++ b/apps/api/src/data/job-store.test.ts
@@ -3,7 +3,13 @@ import test from 'node:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { appendOutreachDraft, createJob, getJobById, resetJobStoreForTests } from './job-store';
+import {
+  appendOutreachDraft,
+  createJob,
+  getJobById,
+  resetJobStoreForTests,
+  updateOutreachDraft,
+} from './job-store';
 import type { OutreachDraft } from '@/types';
 
 function draft(text: string): OutreachDraft {
@@ -18,7 +24,7 @@ function draft(text: string): OutreachDraft {
   };
 }
 
-test('appendOutreachDraft keeps only the latest draft per job', async () => {
+test('appendOutreachDraft replaces the previous unsent draft per job', async () => {
   const originalCwd = process.cwd();
   delete process.env.DATABASE_URL; // force the file store
   const tempDir = await mkdtemp(join(tmpdir(), 'jobops-outreach-'));
@@ -37,9 +43,44 @@ test('appendOutreachDraft keeps only the latest draft per job', async () => {
     await appendOutreachDraft('user-1', job.id, draft('second'));
 
     const fetched = await getJobById('user-1', job.id);
-    // Only the most recent draft is kept (replace, not append).
+    // The superseded draft is dropped; only the most recent draft remains.
     assert.equal(fetched?.outreach.length, 1);
     assert.equal(fetched?.outreach[0]?.draftText, 'second');
+  } finally {
+    process.chdir(originalCwd);
+    resetJobStoreForTests();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('appendOutreachDraft preserves sent outreach history', async () => {
+  const originalCwd = process.cwd();
+  delete process.env.DATABASE_URL; // force the file store
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-outreach-'));
+
+  try {
+    process.chdir(tempDir);
+    resetJobStoreForTests();
+
+    const job = await createJob('user-1', {
+      company: 'Acme',
+      title: 'Engineer',
+      descriptionText: 'Build things with TypeScript and React.',
+    });
+
+    // First draft gets approved and sent — this is real history.
+    await appendOutreachDraft('user-1', job.id, draft('first'));
+    await updateOutreachDraft('user-1', 'outreach-first', { status: 'sent' });
+
+    // Generating a fresh draft must not wipe the sent record.
+    await appendOutreachDraft('user-1', job.id, draft('second'));
+
+    const fetched = await getJobById('user-1', job.id);
+    const texts = (fetched?.outreach ?? []).map((entry) => entry.draftText).sort();
+    assert.deepEqual(texts, ['first', 'second']);
+
+    const sent = fetched?.outreach.find((entry) => entry.id === 'outreach-first');
+    assert.equal(sent?.status, 'sent');
   } finally {
     process.chdir(originalCwd);
     resetJobStoreForTests();

--- a/apps/api/src/data/job-store.test.ts
+++ b/apps/api/src/data/job-store.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { appendOutreachDraft, createJob, getJobById, resetJobStoreForTests } from './job-store';
+import type { OutreachDraft } from '@/types';
+
+function draft(text: string): OutreachDraft {
+  return {
+    id: `outreach-${text}`,
+    contactName: 'Pat',
+    contactRole: 'Recruiter',
+    messageType: 'recruiter_email',
+    draftText: text,
+    status: 'drafted',
+    createdAt: new Date().toISOString(),
+  };
+}
+
+test('appendOutreachDraft keeps only the latest draft per job', async () => {
+  const originalCwd = process.cwd();
+  delete process.env.DATABASE_URL; // force the file store
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-outreach-'));
+
+  try {
+    process.chdir(tempDir);
+    resetJobStoreForTests();
+
+    const job = await createJob('user-1', {
+      company: 'Acme',
+      title: 'Engineer',
+      descriptionText: 'Build things with TypeScript and React.',
+    });
+
+    await appendOutreachDraft('user-1', job.id, draft('first'));
+    await appendOutreachDraft('user-1', job.id, draft('second'));
+
+    const fetched = await getJobById('user-1', job.id);
+    // Only the most recent draft is kept (replace, not append).
+    assert.equal(fetched?.outreach.length, 1);
+    assert.equal(fetched?.outreach[0]?.draftText, 'second');
+  } finally {
+    process.chdir(originalCwd);
+    resetJobStoreForTests();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/apps/api/src/data/job-store.ts
+++ b/apps/api/src/data/job-store.ts
@@ -264,8 +264,10 @@ export async function appendOutreachDraft(
       ...draft,
       jobId,
     });
-    // Keep only the latest draft per job (replace, don't accumulate).
-    job.outreach = [clonedDraft];
+    // Replace only the superseded unsent draft; preserve approved/sent/skipped
+    // rows, which carry real outreach history and dashboard/reporting state.
+    const preserved = job.outreach.filter((entry) => entry.status !== 'drafted');
+    job.outreach = [...preserved, clonedDraft];
     const jobUpdate = deriveOutreachJobUpdate(job.status, job.outreach);
 
     if (jobUpdate) {

--- a/apps/api/src/data/job-store.ts
+++ b/apps/api/src/data/job-store.ts
@@ -15,8 +15,14 @@ import { hasPostgresConnection } from '@/lib/postgres';
 import * as postgresStore from '@/data/job-store.postgres';
 import { seedJobs } from '@/data/mock-store';
 
-const dataDir = join(process.cwd(), 'data');
-const dataFile = join(dataDir, 'jobs.json');
+// Resolved per call (not once at import) so tests can redirect the store with chdir.
+function dataDir() {
+  return join(process.cwd(), 'data');
+}
+
+function dataFile() {
+  return join(dataDir(), 'jobs.json');
+}
 
 let jobsCache: JobRecord[] | null = null;
 let loadPromise: Promise<JobRecord[]> | null = null;
@@ -108,10 +114,10 @@ export function getStoreMode() {
 }
 
 async function loadJobs(): Promise<JobRecord[]> {
-  await mkdir(dataDir, { recursive: true });
+  await mkdir(dataDir(), { recursive: true });
 
   try {
-    const raw = await readFile(dataFile, 'utf8');
+    const raw = await readFile(dataFile(), 'utf8');
     const parsed = JSON.parse(raw) as unknown;
 
     if (!Array.isArray(parsed)) {
@@ -141,8 +147,8 @@ async function persistJobs() {
     return;
   }
 
-  await mkdir(dataDir, { recursive: true });
-  await writeFile(dataFile, `${JSON.stringify(jobsCache, null, 2)}\n`, 'utf8');
+  await mkdir(dataDir(), { recursive: true });
+  await writeFile(dataFile(), `${JSON.stringify(jobsCache, null, 2)}\n`, 'utf8');
 }
 
 async function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
@@ -258,7 +264,8 @@ export async function appendOutreachDraft(
       ...draft,
       jobId,
     });
-    job.outreach.push(clonedDraft);
+    // Keep only the latest draft per job (replace, don't accumulate).
+    job.outreach = [clonedDraft];
     const jobUpdate = deriveOutreachJobUpdate(job.status, job.outreach);
 
     if (jobUpdate) {
@@ -422,4 +429,10 @@ export async function seedDemoData(userId: string): Promise<void> {
     jobsCache = [...mine, ...others];
     await persistJobs();
   });
+}
+
+export function resetJobStoreForTests() {
+  jobsCache = null;
+  loadPromise = null;
+  mutationQueue = Promise.resolve();
 }

--- a/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
+++ b/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
@@ -159,8 +159,9 @@ export default async function JobDetailPage({ params }: JobDetailParams) {
               {job.outreach.length ? (
                 <Card className="gap-3 p-5">
                   {/* h2 (not h3) so the document heading order doesn't skip a level (a11y). */}
-                  <h2 className="font-heading text-sm font-semibold">Existing drafts</h2>
-                  {job.outreach.map((draft) => (
+                  <h2 className="font-heading text-sm font-semibold">Saved draft</h2>
+                  {/* Only the latest draft is kept; slice defends against any legacy rows. */}
+                  {job.outreach.slice(-1).map((draft) => (
                     <div key={draft.id} className="bg-muted/40 space-y-2 rounded-lg p-3">
                       <div className="flex items-center justify-between gap-2">
                         <p className="text-sm font-medium">

--- a/apps/web/src/components/job-outreach-actions.tsx
+++ b/apps/web/src/components/job-outreach-actions.tsx
@@ -200,7 +200,16 @@ export function JobOutreachActions({
             </div>
           </div>
           <p className="text-sm whitespace-pre-wrap">{result.draftText}</p>
-          <p className="text-muted-foreground border-t pt-2 text-xs">{result.safetyNotes}</p>
+          {result.safetyNotes.trim() ? (
+            <details className="border-t pt-2">
+              <summary className="text-muted-foreground cursor-pointer text-xs select-none">
+                Review notes
+              </summary>
+              <p className="text-muted-foreground mt-1.5 text-xs whitespace-pre-wrap">
+                {result.safetyNotes}
+              </p>
+            </details>
+          ) : null}
         </Card>
       ) : null}
     </form>

--- a/apps/web/src/components/job-outreach-actions.tsx
+++ b/apps/web/src/components/job-outreach-actions.tsx
@@ -78,7 +78,8 @@ export function JobOutreachActions({
       setResult({
         subject: draft.subject,
         draftText: draft.draft_text,
-        safetyNotes: draft.safety_notes,
+        // The live agent can omit safety_notes; default to '' so .trim() never crashes.
+        safetyNotes: draft.safety_notes ?? '',
         gmailDraftStatus: draft.gmail_draft_status,
       });
       toast.success('Draft created — review it in the inbox before sending.');


### PR DESCRIPTION
## What & why
Two outreach annoyances from #118:

**1.3 — Guardrail text under every draft.** The agent's `safety_notes` (groundedness / "UNVERIFIED claims …" text) were rendered inline beneath the draft (`job-outreach-actions.tsx:203`), so the message looked cluttered. Now tucked into a collapsed **"Review notes"** disclosure — the visible and copied message is just the email. (The copy button already excluded the notes.)

**1.4 — Drafts piled up.** Every "Generate outreach" appended a new `outreach` row and the job page listed all of them ("Existing drafts"). Now only the **latest draft per job** is kept:
- `appendOutreachDraft` replaces prior drafts — file store (`job.outreach = [draft]`) and Postgres (`delete from outreach where job_id = …` before insert).
- The page shows a single **"Saved draft"** (defensively `.slice(-1)` for any legacy rows).

## Tests
- New `job-store.test.ts` (TDD'd): append two drafts → only the latest remains. To isolate the file store, its data path now resolves per call (so a test `chdir` redirects it — matches the report store) plus a `resetJobStoreForTests` helper.
- `npm test` (web 32 + api 109 = all pass), `npm run typecheck`, `npm run lint`, `npm run build:web` — all green.

## Verify
Generate outreach twice on a job → only the most recent draft is stored/shown. The draft card shows the email only; "Review notes" is collapsed below it.

Part of #118 (Phase 1 — truthful data). Epic #124.
