### PR TITLE
fix(web): cap the job-description textarea height so it scrolls (#118 · 1.5)

### DIFF
--- a/apps/web/src/components/job-create-form.tsx
+++ b/apps/web/src/components/job-create-form.tsx
@@ -113,12 +113,14 @@ export function JobCreateForm() {
             <Sparkles className="size-3.5 text-indigo-500" /> AI extracts skills &amp; scores fit
           </span>
         </div>
+        {/* Cap the height so a long paste scrolls internally instead of pushing the
+            rest of the form off-screen (the Textarea uses field-sizing-content). */}
         <Textarea
           id="description"
           value={form.descriptionText}
           onChange={(event) => updateField('descriptionText', event.target.value)}
           placeholder="Paste the full job posting here…"
-          className="min-h-40"
+          className="max-h-80 min-h-40 overflow-y-auto"
           required
         />
         {errors.descriptionText ? (


### PR DESCRIPTION
## What & why
On `/jobs/new`, pasting a long job posting expanded the description textarea down the entire page, pushing Company / Title / URL / Workplace / Priority off-screen — you had to scroll the whole page past the textarea to reach them.

**Cause:** the shared `Textarea` uses `field-sizing-content`, which grows the element to fit its content with no upper bound.

**Fix:** cap the description field's height (`max-h-80`) and let it scroll internally (`overflow-y-auto`), so it grows to a sensible size then scrolls and the rest of the form stays in place.

Scoped to the job-create description field (className) rather than the shared `Textarea`, so other textareas (e.g. the assistant inputs) keep their current behavior.

## Tests
CSS-only change. `npm run typecheck:web`, `npm run lint:web`, `npm run build:web` — all green.

## Verify
`/jobs/new` → paste a long posting → the textarea grows to ~20rem then scrolls; the fields below stay visible.

Part of #118 (Phase 1 — truthful data). Epic #124.
