### PR TITLE
feat: pre-rank discovered jobs + score-on-open (#118 → #119 · PR A)

### DIFF
--- a/apps/api/src/lib/discovery.test.ts
+++ b/apps/api/src/lib/discovery.test.ts
@@ -157,3 +157,27 @@ test('pre-ranks each inserted job with a local-prerank analysis', async () => {
   assert.equal(analyses[0]?.modelUsed, 'local-prerank');
   assert.equal(typeof analyses[0]?.fitScore, 'number');
 });
+
+test('still counts an inserted job when pre-rank persistence fails (best-effort)', async () => {
+  // saveAnalysis is opportunistic: the job is already inserted, so a transient
+  // failure persisting the estimated fit must not abort the discovery run.
+  const created: CreateJobBody[] = [];
+  const deps: DiscoveryDeps = {
+    source: { name: 'adzuna', search: async () => [sourced('https://x/1')] },
+    listJobs: async () => [],
+    createJob: async (_userId, body) => {
+      created.push(body);
+      return { ...(body as object), id: 'job-1' } as unknown as JobRecord;
+    },
+    listSavedSearches: async () => [SEARCH],
+    getResume: async () => 'resume',
+    saveAnalysis: async () => {
+      throw new Error('analysis store unavailable');
+    },
+  };
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 1);
+  assert.equal(created.length, 1);
+});

--- a/apps/api/src/lib/discovery.test.ts
+++ b/apps/api/src/lib/discovery.test.ts
@@ -16,18 +16,31 @@ const SEARCH: SavedSearch = {
 function makeDeps(
   found: SourcedJob[],
   existing: Partial<JobRecord>[],
-): { deps: DiscoveryDeps; created: CreateJobBody[] } {
+  resume = 'TypeScript and React engineer.',
+): {
+  deps: DiscoveryDeps;
+  created: CreateJobBody[];
+  analyses: Array<{ jobId: string; fitScore?: number | null; modelUsed: string }>;
+} {
   const created: CreateJobBody[] = [];
+  const analyses: Array<{ jobId: string; fitScore?: number | null; modelUsed: string }> = [];
+  let n = 0;
   const deps: DiscoveryDeps = {
     source: { name: 'adzuna', search: async () => found },
     listJobs: async () => existing as unknown as JobRecord[],
     createJob: async (_userId, body) => {
       created.push(body);
-      return body as unknown as JobRecord;
+      n += 1;
+      return { ...(body as object), id: `job-${n}` } as unknown as JobRecord;
     },
     listSavedSearches: async () => [SEARCH],
+    getResume: async () => resume,
+    saveAnalysis: async (_userId, jobId, analysis, fitScore) => {
+      analyses.push({ jobId, fitScore, modelUsed: analysis.modelUsed });
+      return undefined;
+    },
   };
-  return { deps, created };
+  return { deps, created, analyses };
 }
 
 function sourced(url: string, overrides: Partial<SourcedJob> = {}): SourcedJob {
@@ -100,9 +113,11 @@ test('counts a concurrent duplicate insert (Postgres 23505) as skipped', async (
         throw Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
       }
       created.push(body);
-      return body as unknown as JobRecord;
+      return { ...(body as object), id: 'job-x' } as unknown as JobRecord;
     },
     listSavedSearches: async () => [SEARCH],
+    getResume: async () => 'resume',
+    saveAnalysis: async () => undefined,
   };
 
   const result = await runDiscoveryForUser('u', deps);
@@ -121,7 +136,24 @@ test('propagates non-duplicate insert errors', async () => {
       throw new Error('db down');
     },
     listSavedSearches: async () => [SEARCH],
+    getResume: async () => 'resume',
+    saveAnalysis: async () => undefined,
   };
 
   await assert.rejects(runDiscoveryForUser('u', deps), /db down/);
+});
+
+test('pre-ranks each inserted job with a local-prerank analysis', async () => {
+  const { deps, analyses } = makeDeps(
+    [sourced('https://x/1', { descriptionText: 'We use TypeScript and React.' })],
+    [],
+  );
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 1);
+  assert.equal(analyses.length, 1);
+  assert.equal(analyses[0]?.jobId, 'job-1');
+  assert.equal(analyses[0]?.modelUsed, 'local-prerank');
+  assert.equal(typeof analyses[0]?.fitScore, 'number');
 });

--- a/apps/api/src/lib/discovery.ts
+++ b/apps/api/src/lib/discovery.ts
@@ -1,5 +1,10 @@
-import { createJob as createJobStore, listJobs as listJobsStore } from '@/data/job-store';
+import {
+  createJob as createJobStore,
+  listJobs as listJobsStore,
+  saveJobAnalysis as saveJobAnalysisStore,
+} from '@/data/job-store';
 import { listSavedSearches as listSavedSearchesStore } from '@/data/saved-search-store';
+import { prerankAnalysis } from '@/lib/local-fit';
 import type { JobSource } from '@/lib/job-sources';
 import { dedupKey, fingerprintKey } from '@/lib/job-sources/normalize';
 
@@ -14,6 +19,8 @@ export interface DiscoveryDeps {
   listJobs: typeof listJobsStore;
   createJob: typeof createJobStore;
   listSavedSearches: typeof listSavedSearchesStore;
+  getResume: (userId: string) => Promise<string>;
+  saveAnalysis: typeof saveJobAnalysisStore;
 }
 
 /**
@@ -49,6 +56,7 @@ function isDuplicateKeyError(error: unknown): boolean {
 export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): Promise<DiscoveryResult> {
   const searches = await deps.listSavedSearches(userId);
   const seen = new Set((await deps.listJobs(userId)).flatMap(keysFor));
+  const resume = await deps.getResume(userId);
 
   let inserted = 0;
   let skipped = 0;
@@ -75,8 +83,12 @@ export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): 
       // copy in the same run is recognised as a duplicate.
       for (const k of keysFor(job)) seen.add(k);
       try {
-        await deps.createJob(userId, job);
+        const createdJob = await deps.createJob(userId, job);
         inserted += 1;
+        // Pre-rank: store a free estimated fit so the feed is ranked immediately;
+        // the real LLM score runs lazily when the user first opens the job.
+        const { fitScore, analysis } = prerankAnalysis(job.descriptionText ?? '', resume);
+        await deps.saveAnalysis(userId, createdJob.id, analysis, fitScore);
       } catch (error) {
         // A concurrent discovery run (manual click + n8n sweep, or two API
         // instances) can insert the same posting between building `seen` and

--- a/apps/api/src/lib/discovery.ts
+++ b/apps/api/src/lib/discovery.ts
@@ -85,10 +85,16 @@ export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): 
       try {
         const createdJob = await deps.createJob(userId, job);
         inserted += 1;
-        // Pre-rank: store a free estimated fit so the feed is ranked immediately;
-        // the real LLM score runs lazily when the user first opens the job.
-        const { fitScore, analysis } = prerankAnalysis(job.descriptionText ?? '', resume);
-        await deps.saveAnalysis(userId, createdJob.id, analysis, fitScore);
+        // Pre-rank is best-effort: the job is already inserted and counted, so a
+        // transient failure persisting the estimated fit must not abort the whole
+        // sweep. The real LLM score still runs when the user first opens the job;
+        // until then an unranked job simply sorts as having no score.
+        try {
+          const { fitScore, analysis } = prerankAnalysis(job.descriptionText ?? '', resume);
+          await deps.saveAnalysis(userId, createdJob.id, analysis, fitScore);
+        } catch {
+          // Leave the job unranked rather than failing the discovery run.
+        }
       } catch (error) {
         // A concurrent discovery run (manual click + n8n sweep, or two API
         // instances) can insert the same posting between building `seen` and

--- a/apps/api/src/lib/local-fit.test.ts
+++ b/apps/api/src/lib/local-fit.test.ts
@@ -46,4 +46,7 @@ test('prerankAnalysis builds an estimated analysis tagged local-prerank', () => 
   // … and the sentinel that marks it estimated (so the UI can upgrade on open).
   assert.equal(analysis.modelUsed, PRERANK_MODEL);
   assert.equal(PRERANK_MODEL, 'local-prerank');
+  // A matched skill must never also appear as missing.
+  const overlap = analysis.missingSkills.filter((skill) => analysis.matchedSkills.includes(skill));
+  assert.deepEqual(overlap, []);
 });

--- a/apps/api/src/lib/local-fit.test.ts
+++ b/apps/api/src/lib/local-fit.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { computeLocalFit } from './local-fit';
+
+test('scores the overlap of resume skills against job skills', () => {
+  // Description mentions TypeScript, React, Node.js (3 catalog skills).
+  // Resume covers TypeScript + React (2 of 3) → round(2/3*100) = 67.
+  const description = 'We use TypeScript, React, and Node.js daily.';
+  const resume = 'Senior engineer fluent in TypeScript and React.';
+
+  const { score, matchedSkills } = computeLocalFit(description, resume);
+
+  assert.equal(score, 67);
+  assert.deepEqual(matchedSkills.sort(), ['React', 'TypeScript']);
+});
+
+test('returns 0 with no resume', () => {
+  const result = computeLocalFit('We use TypeScript and React.', '');
+  assert.equal(result.score, 0);
+  assert.deepEqual(result.matchedSkills, []);
+});
+
+test('returns 0 when the description has no recognised skills', () => {
+  const result = computeLocalFit('A friendly team that loves coffee.', 'TypeScript React');
+  assert.equal(result.score, 0);
+  assert.deepEqual(result.matchedSkills, []);
+});
+
+test('scores 100 when the resume covers every job skill', () => {
+  const result = computeLocalFit('TypeScript and React.', 'TypeScript, React, and more.');
+  assert.equal(result.score, 100);
+});

--- a/apps/api/src/lib/local-fit.test.ts
+++ b/apps/api/src/lib/local-fit.test.ts
@@ -30,3 +30,22 @@ test('scores 100 when the resume covers every job skill', () => {
   const result = computeLocalFit('TypeScript and React.', 'TypeScript, React, and more.');
   assert.equal(result.score, 100);
 });
+
+import { PRERANK_MODEL, prerankAnalysis } from './local-fit';
+
+test('prerankAnalysis builds an estimated analysis tagged local-prerank', () => {
+  const { fitScore, analysis } = prerankAnalysis(
+    'We use TypeScript, React, and Node.js daily.',
+    'Senior engineer fluent in TypeScript and React.',
+  );
+
+  // Carries the local-fit score …
+  assert.equal(fitScore, 67);
+  // … the matched skills from the overlap …
+  assert.deepEqual(analysis.matchedSkills.sort(), ['React', 'TypeScript']);
+  // … parsed required/preferred skills from the description …
+  assert.ok(analysis.requiredSkills.length > 0);
+  // … and the sentinel that marks it estimated (so the UI can upgrade on open).
+  assert.equal(analysis.modelUsed, PRERANK_MODEL);
+  assert.equal(PRERANK_MODEL, 'local-prerank');
+});

--- a/apps/api/src/lib/local-fit.test.ts
+++ b/apps/api/src/lib/local-fit.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { computeLocalFit } from './local-fit';
+import { PRERANK_MODEL, computeLocalFit, prerankAnalysis } from './local-fit';
 
 test('scores the overlap of resume skills against job skills', () => {
   // Description mentions TypeScript, React, Node.js (3 catalog skills).
@@ -30,8 +30,6 @@ test('scores 100 when the resume covers every job skill', () => {
   const result = computeLocalFit('TypeScript and React.', 'TypeScript, React, and more.');
   assert.equal(result.score, 100);
 });
-
-import { PRERANK_MODEL, prerankAnalysis } from './local-fit';
 
 test('prerankAnalysis builds an estimated analysis tagged local-prerank', () => {
   const { fitScore, analysis } = prerankAnalysis(

--- a/apps/api/src/lib/local-fit.ts
+++ b/apps/api/src/lib/local-fit.ts
@@ -37,9 +37,18 @@ export function prerankAnalysis(
 ): { fitScore: number; analysis: JobAnalysis } {
   const { score, matchedSkills } = computeLocalFit(descriptionText, resumeText);
   const base = analysisFromParsed(parseJobDescription(descriptionText));
+  const matched = new Set(matchedSkills);
 
   return {
     fitScore: score,
-    analysis: { ...base, matchedSkills, modelUsed: PRERANK_MODEL },
+    analysis: {
+      ...base,
+      matchedSkills,
+      // Recompute missing from required minus matched so the same skill never
+      // shows as both matched and missing in the estimate (analysisFromParsed
+      // seeds missingSkills from the required list, before we know matches).
+      missingSkills: base.requiredSkills.filter((skill) => !matched.has(skill)),
+      modelUsed: PRERANK_MODEL,
+    },
   };
 }

--- a/apps/api/src/lib/local-fit.ts
+++ b/apps/api/src/lib/local-fit.ts
@@ -1,0 +1,22 @@
+import { extractKeywords } from '@/lib/analysis-core';
+
+/**
+ * Free, deterministic fit estimate: the share of a job's recognised skills that
+ * also appear in the user's resume. No LLM, no I/O. Used to pre-rank discovered
+ * postings on ingest before the (paid) LLM score runs on first open.
+ */
+export function computeLocalFit(
+  descriptionText: string,
+  resumeText: string,
+): { score: number; matchedSkills: string[] } {
+  const jobSkills = extractKeywords(descriptionText);
+  if (jobSkills.length === 0) {
+    return { score: 0, matchedSkills: [] };
+  }
+
+  const resumeLower = resumeText.toLowerCase();
+  const matchedSkills = jobSkills.filter((skill) => resumeLower.includes(skill.toLowerCase()));
+  const score = Math.round((matchedSkills.length / jobSkills.length) * 100);
+
+  return { score, matchedSkills };
+}

--- a/apps/api/src/lib/local-fit.ts
+++ b/apps/api/src/lib/local-fit.ts
@@ -1,4 +1,5 @@
-import { extractKeywords } from '@/lib/analysis-core';
+import { analysisFromParsed, extractKeywords, parseJobDescription } from '@/lib/analysis-core';
+import type { JobAnalysis } from '@/types';
 
 /**
  * Free, deterministic fit estimate: the share of a job's recognised skills that
@@ -19,4 +20,26 @@ export function computeLocalFit(
   const score = Math.round((matchedSkills.length / jobSkills.length) * 100);
 
   return { score, matchedSkills };
+}
+
+/** Sentinel `modelUsed` value marking an estimated (not-yet-LLM-scored) analysis. */
+export const PRERANK_MODEL = 'local-prerank';
+
+/**
+ * Build the provisional analysis stored for a freshly-discovered posting: the
+ * parsed required/preferred skills (so the detail page isn't empty), the
+ * local-fit matched skills + score, tagged with the `local-prerank` sentinel so
+ * the job-detail page knows to upgrade it with the real LLM score on first open.
+ */
+export function prerankAnalysis(
+  descriptionText: string,
+  resumeText: string,
+): { fitScore: number; analysis: JobAnalysis } {
+  const { score, matchedSkills } = computeLocalFit(descriptionText, resumeText);
+  const base = analysisFromParsed(parseJobDescription(descriptionText));
+
+  return {
+    fitScore: score,
+    analysis: { ...base, matchedSkills, modelUsed: PRERANK_MODEL },
+  };
 }

--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { requireUser } from '@/lib/auth';
-import { createJob, listJobs } from '@/data/job-store';
+import { createJob, listJobs, saveJobAnalysis } from '@/data/job-store';
+import { getUserProfile } from '@/data/profile-store';
 import { listSavedSearches, listUsersWithSavedSearches } from '@/data/saved-search-store';
 import { getJobSource } from '@/lib/job-sources';
 import { requireN8nWebhookSecret } from '@/lib/n8n';
@@ -13,7 +14,14 @@ export interface DiscoveryRouterDeps {
 
 const defaultDeps: DiscoveryRouterDeps = {
   runDiscovery: (userId) =>
-    runDiscoveryForUser(userId, { source: getJobSource(), listJobs, createJob, listSavedSearches }),
+    runDiscoveryForUser(userId, {
+      source: getJobSource(),
+      listJobs,
+      createJob,
+      listSavedSearches,
+      getResume: async (uid) => (await getUserProfile(uid))?.resumeText ?? '',
+      saveAnalysis: saveJobAnalysis,
+    }),
   listUsersWithSavedSearches,
 };
 

--- a/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
+++ b/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
@@ -13,7 +13,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { isHeuristicAnalysis } from '@/lib/analysis-display';
+import { isHeuristicAnalysis, isPrerankAnalysis } from '@/lib/analysis-display';
 import { formatDate } from '@/lib/format';
 import { loadJob } from '@/lib/job-data';
 
@@ -34,6 +34,8 @@ export default async function JobDetailPage({ params }: JobDetailParams) {
 
   // Surface a rule-based heuristic score plainly (QA·B); see isHeuristicAnalysis.
   const heuristic = isHeuristicAnalysis(job.analysis.modelUsed);
+  // An estimated (local-prerank) analysis upgrades to a real LLM score on open.
+  const estimated = isPrerankAnalysis(job.analysis.modelUsed);
 
   return (
     <div className="space-y-6">
@@ -61,7 +63,7 @@ export default async function JobDetailPage({ params }: JobDetailParams) {
           </div>
         </div>
         <div className="border-t pt-4">
-          <JobAnalysisActions jobId={job.id} />
+          <JobAnalysisActions jobId={job.id} autoScore={estimated} />
         </div>
       </Card>
 

--- a/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
+++ b/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
@@ -13,6 +13,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { fetchProfile } from '@/lib/api';
 import { isHeuristicAnalysis, isPrerankAnalysis } from '@/lib/analysis-display';
 import { formatDate } from '@/lib/format';
 import { loadJob } from '@/lib/job-data';
@@ -29,13 +30,21 @@ export async function generateMetadata({ params }: JobDetailParams): Promise<Met
 
 export default async function JobDetailPage({ params }: JobDetailParams) {
   const { jobId } = await params;
-  const { job, source } = await loadJob(jobId);
+  // Fetch the profile alongside the job so we can decide whether auto-scoring is
+  // even possible; a profile failure must not break the page.
+  const [{ job, source }, profile] = await Promise.all([
+    loadJob(jobId),
+    fetchProfile().catch(() => null),
+  ]);
   if (!job) notFound();
 
   // Surface a rule-based heuristic score plainly (QA·B); see isHeuristicAnalysis.
   const heuristic = isHeuristicAnalysis(job.analysis.modelUsed);
-  // An estimated (local-prerank) analysis upgrades to a real LLM score on open.
+  // Only auto-upgrade an estimated (local-prerank) job when a resume is on file:
+  // without one, /score-fit returns 400 *after* the budget guard reserves cost,
+  // so auto-firing on every open would silently drain the daily AI budget.
   const estimated = isPrerankAnalysis(job.analysis.modelUsed);
+  const autoScore = estimated && profile?.hasResume === true;
 
   return (
     <div className="space-y-6">
@@ -63,7 +72,7 @@ export default async function JobDetailPage({ params }: JobDetailParams) {
           </div>
         </div>
         <div className="border-t pt-4">
-          <JobAnalysisActions jobId={job.id} autoScore={estimated} />
+          <JobAnalysisActions jobId={job.id} autoScore={autoScore} />
         </div>
       </Card>
 

--- a/apps/web/src/components/job-analysis-actions.test.tsx
+++ b/apps/web/src/components/job-analysis-actions.test.tsx
@@ -35,3 +35,11 @@ it('auto-scores once on mount when the analysis is an estimate', async () => {
   await waitFor(() => expect(scoreFit).toHaveBeenCalledTimes(1));
   expect(scoreFit).toHaveBeenCalledWith({ jobId: 'job-1' });
 });
+
+it('does not auto-score again if it re-renders with autoScore still set', async () => {
+  const { rerender } = render(<JobAnalysisActions jobId="job-1" autoScore />);
+  await waitFor(() => expect(scoreFit).toHaveBeenCalledTimes(1));
+  rerender(<JobAnalysisActions jobId="job-1" autoScore />);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(scoreFit).toHaveBeenCalledTimes(1);
+});

--- a/apps/web/src/components/job-analysis-actions.test.tsx
+++ b/apps/web/src/components/job-analysis-actions.test.tsx
@@ -43,3 +43,11 @@ it('does not auto-score again if it re-renders with autoScore still set', async 
   await new Promise((resolve) => setTimeout(resolve, 0));
   expect(scoreFit).toHaveBeenCalledTimes(1);
 });
+
+it('auto-scores again when the same instance is reused for a different job', async () => {
+  const { rerender } = render(<JobAnalysisActions jobId="job-1" autoScore />);
+  await waitFor(() => expect(scoreFit).toHaveBeenCalledTimes(1));
+  rerender(<JobAnalysisActions jobId="job-2" autoScore />);
+  await waitFor(() => expect(scoreFit).toHaveBeenCalledTimes(2));
+  expect(scoreFit).toHaveBeenLastCalledWith({ jobId: 'job-2' });
+});

--- a/apps/web/src/components/job-analysis-actions.test.tsx
+++ b/apps/web/src/components/job-analysis-actions.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, expect, it, vi } from 'vitest';
 
 const { scoreFit } = vi.hoisted(() => ({
@@ -21,9 +21,17 @@ afterEach(() => {
 it('offers a single "Score fit" action and no separate "Parse job" button', () => {
   render(<JobAnalysisActions jobId="job-1" />);
 
-  // Score fit is the one analysis action (it parses + scores in one step).
   expect(screen.getByRole('button', { name: /score fit/i })).toBeInTheDocument();
-  // "Parse job" is gone — it used to overwrite the scored analysis with a
-  // fit-less heuristic, which is the bug this removes.
   expect(screen.queryByRole('button', { name: /parse job/i })).not.toBeInTheDocument();
+});
+
+it('does not auto-score by default', () => {
+  render(<JobAnalysisActions jobId="job-1" />);
+  expect(scoreFit).not.toHaveBeenCalled();
+});
+
+it('auto-scores once on mount when the analysis is an estimate', async () => {
+  render(<JobAnalysisActions jobId="job-1" autoScore />);
+  await waitFor(() => expect(scoreFit).toHaveBeenCalledTimes(1));
+  expect(scoreFit).toHaveBeenCalledWith({ jobId: 'job-1' });
 });

--- a/apps/web/src/components/job-analysis-actions.tsx
+++ b/apps/web/src/components/job-analysis-actions.tsx
@@ -2,38 +2,56 @@
 
 import { Target } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { ApiRequestError, scoreFit } from '@/lib/api';
 
 type JobAnalysisActionsProps = {
   jobId: string;
+  /** True when the stored analysis is a free estimate (local-prerank): upgrade it
+   *  to a real LLM score once, silently, on open. */
+  autoScore?: boolean;
 };
 
 // "Score fit" is the single analysis action: it parses the job and scores the
 // fit in one step, then persists the scored analysis. (The old "Parse job"
 // button saved a fit-less heuristic that overwrote a good score — removed.)
-export function JobAnalysisActions({ jobId }: JobAnalysisActionsProps) {
+export function JobAnalysisActions({ jobId, autoScore = false }: JobAnalysisActionsProps) {
   const router = useRouter();
   const [isScoring, setIsScoring] = useState(false);
+  const autoFired = useRef(false);
 
-  async function handleScore() {
+  async function handleScore({ silent = false }: { silent?: boolean } = {}) {
     setIsScoring(true);
     try {
       const scored = await scoreFit({ jobId });
-      toast.success(`Fit score saved: ${scored.fit_score}/100`);
+      if (!silent) toast.success(`Fit score saved: ${scored.fit_score}/100`);
       router.refresh();
     } catch (error) {
-      toast.error(error instanceof ApiRequestError ? error.message : 'Failed to score the fit.');
+      // The automatic upgrade stays quiet on failure (e.g. daily budget reached):
+      // the estimate remains and the manual button is the fallback.
+      if (!silent) {
+        toast.error(error instanceof ApiRequestError ? error.message : 'Failed to score the fit.');
+      }
     } finally {
       setIsScoring(false);
     }
   }
 
+  useEffect(() => {
+    if (autoScore && !autoFired.current) {
+      autoFired.current = true;
+      void handleScore({ silent: true });
+    }
+    // Fire at most once per mount for an estimated job; jobId/autoScore are stable
+    // for the lifetime of the detail page.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoScore, jobId]);
+
   return (
     <div className="flex flex-wrap gap-2">
-      <Button onClick={handleScore} disabled={isScoring} className="gap-1.5">
+      <Button onClick={() => void handleScore()} disabled={isScoring} className="gap-1.5">
         <Target className="size-4" />
         {isScoring ? 'Scoring…' : 'Score fit'}
       </Button>

--- a/apps/web/src/components/job-analysis-actions.tsx
+++ b/apps/web/src/components/job-analysis-actions.tsx
@@ -20,7 +20,10 @@ type JobAnalysisActionsProps = {
 export function JobAnalysisActions({ jobId, autoScore = false }: JobAnalysisActionsProps) {
   const router = useRouter();
   const [isScoring, setIsScoring] = useState(false);
-  const autoFired = useRef(false);
+  // Track which job we auto-scored, not just whether we did, so a reused
+  // component instance (client-side nav to a different job) still upgrades the
+  // new estimate exactly once.
+  const autoScoredJobId = useRef<string | null>(null);
 
   async function handleScore({ silent = false }: { silent?: boolean } = {}) {
     setIsScoring(true);
@@ -45,12 +48,12 @@ export function JobAnalysisActions({ jobId, autoScore = false }: JobAnalysisActi
   }
 
   useEffect(() => {
-    if (autoScore && !autoFired.current) {
-      autoFired.current = true;
+    if (autoScore && autoScoredJobId.current !== jobId) {
+      autoScoredJobId.current = jobId;
       void handleScore({ silent: true });
     }
     // Listing handleScore (defined inline, not memoised) would re-fire the effect
-    // on every render; the autoFired ref is the real once-per-mount guard. The
+    // on every render; the autoScoredJobId ref is the real once-per-job guard. The
     // effect only reads jobId/autoScore, so those are the deps we declare.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoScore, jobId]);

--- a/apps/web/src/components/job-analysis-actions.tsx
+++ b/apps/web/src/components/job-analysis-actions.tsx
@@ -27,12 +27,17 @@ export function JobAnalysisActions({ jobId, autoScore = false }: JobAnalysisActi
     try {
       const scored = await scoreFit({ jobId });
       if (!silent) toast.success(`Fit score saved: ${scored.fit_score}/100`);
+      // Always refresh so the upgraded score is reflected in the UI, even silently.
       router.refresh();
     } catch (error) {
-      // The automatic upgrade stays quiet on failure (e.g. daily budget reached):
-      // the estimate remains and the manual button is the fallback.
+      // The automatic upgrade stays quiet on expected failures (e.g. daily budget
+      // reached): the estimate remains and the manual button is the fallback.
       if (!silent) {
         toast.error(error instanceof ApiRequestError ? error.message : 'Failed to score the fit.');
+      } else if (!(error instanceof ApiRequestError)) {
+        // Surface unexpected failures (network/parse/bugs) to the console even in
+        // silent mode so they aren't swallowed entirely.
+        console.error('[JobAnalysisActions] auto-score failed unexpectedly', error);
       }
     } finally {
       setIsScoring(false);
@@ -44,8 +49,9 @@ export function JobAnalysisActions({ jobId, autoScore = false }: JobAnalysisActi
       autoFired.current = true;
       void handleScore({ silent: true });
     }
-    // Fire at most once per mount for an estimated job; jobId/autoScore are stable
-    // for the lifetime of the detail page.
+    // Listing handleScore (defined inline, not memoised) would re-fire the effect
+    // on every render; the autoFired ref is the real once-per-mount guard. The
+    // effect only reads jobId/autoScore, so those are the deps we declare.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoScore, jobId]);
 

--- a/apps/web/src/lib/analysis-display.test.ts
+++ b/apps/web/src/lib/analysis-display.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { PRERANK_MODEL, isPrerankAnalysis, isHeuristicAnalysis } from './analysis-display';
+import { PRERANK_MODEL, isHeuristicAnalysis, isPrerankAnalysis } from './analysis-display';
+
+describe('isHeuristicAnalysis (QA·B heuristic banner)', () => {
+  it('flags only the unambiguous fit-scorer fallback marker', () => {
+    expect(isHeuristicAnalysis('mock-fit-scorer-v1')).toBe(true);
+  });
+
+  it('does NOT flag mock-analysis-v1 (reused for real parses + new-job placeholder)', () => {
+    expect(isHeuristicAnalysis('mock-analysis-v1')).toBe(false);
+  });
+
+  it('does not flag a real model id or missing value', () => {
+    expect(isHeuristicAnalysis('anthropic:claude-sonnet-4-6')).toBe(false);
+    expect(isHeuristicAnalysis(null)).toBe(false);
+    expect(isHeuristicAnalysis(undefined)).toBe(false);
+  });
+});
 
 describe('isPrerankAnalysis', () => {
   it('is true only for the local-prerank sentinel', () => {

--- a/apps/web/src/lib/analysis-display.test.ts
+++ b/apps/web/src/lib/analysis-display.test.ts
@@ -1,18 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { isHeuristicAnalysis } from './analysis-display';
+import { PRERANK_MODEL, isPrerankAnalysis, isHeuristicAnalysis } from './analysis-display';
 
-describe('isHeuristicAnalysis (QA·B heuristic banner)', () => {
-  it('flags only the unambiguous fit-scorer fallback marker', () => {
-    expect(isHeuristicAnalysis('mock-fit-scorer-v1')).toBe(true);
+describe('isPrerankAnalysis', () => {
+  it('is true only for the local-prerank sentinel', () => {
+    expect(PRERANK_MODEL).toBe('local-prerank');
+    expect(isPrerankAnalysis('local-prerank')).toBe(true);
+    expect(isPrerankAnalysis('mock-analysis-v1')).toBe(false);
+    expect(isPrerankAnalysis(null)).toBe(false);
+    expect(isPrerankAnalysis(undefined)).toBe(false);
   });
 
-  it('does NOT flag mock-analysis-v1 (reused for real parses + new-job placeholder)', () => {
-    expect(isHeuristicAnalysis('mock-analysis-v1')).toBe(false);
-  });
-
-  it('does not flag a real model id or missing value', () => {
-    expect(isHeuristicAnalysis('anthropic:claude-sonnet-4-6')).toBe(false);
-    expect(isHeuristicAnalysis(null)).toBe(false);
-    expect(isHeuristicAnalysis(undefined)).toBe(false);
+  it('does not classify the pre-rank sentinel as a heuristic fit', () => {
+    expect(isHeuristicAnalysis('local-prerank')).toBe(false);
   });
 });

--- a/apps/web/src/lib/analysis-display.ts
+++ b/apps/web/src/lib/analysis-display.ts
@@ -12,3 +12,13 @@ export const HEURISTIC_FIT_MODEL = 'mock-fit-scorer-v1';
 export function isHeuristicAnalysis(modelUsed: string | null | undefined): boolean {
   return modelUsed === HEURISTIC_FIT_MODEL;
 }
+
+/**
+ * `local-prerank` marks a discovered job's free, estimated fit (keyword overlap
+ * only). It upgrades to a real LLM analysis the first time the job is opened.
+ */
+export const PRERANK_MODEL = 'local-prerank';
+
+export function isPrerankAnalysis(modelUsed: string | null | undefined): boolean {
+  return modelUsed === PRERANK_MODEL;
+}

--- a/docs/superpowers/plans/2026-06-24-jobs-feed-pr-a-prerank.md
+++ b/docs/superpowers/plans/2026-06-24-jobs-feed-pr-a-prerank.md
@@ -1,0 +1,687 @@
+# Jobs Feed — PR A (local pre-rank + ingest + score-on-open) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every discovered job gets a free, instant estimated fit at ingest, and the real LLM fit runs once when the user first opens the job.
+
+**Architecture:** A pure `local-fit` module computes a resume↔description keyword-overlap score. `runDiscoveryForUser` applies it to each newly-inserted posting (via the existing `saveJobAnalysis`) and tags the analysis with a `local-prerank` sentinel. The web job-detail page detects that sentinel and fires the existing `/api/ai/score-fit` endpoint once, client-side, to upgrade the estimate to a real LLM score.
+
+**Tech Stack:** TypeScript, Express, node:test + tsx (API), Vitest + Testing Library (web). Spec: `docs/superpowers/specs/2026-06-24-jobs-feed-design.md`.
+
+**Scope:** This is PR A of 4. PRs B (discovery panel + onboarding), C (recency/cards), D (cron) get their own plans.
+
+**Branch:** `feat/jobs-feed-prerank` (already created; carries the spec commit).
+
+---
+
+## File structure
+
+- **Create** `apps/api/src/lib/local-fit.ts` — pure: `computeLocalFit` (overlap math) + `prerankAnalysis` (provisional `JobAnalysis` builder). One responsibility: turn a description + resume into an estimated fit.
+- **Create** `apps/api/src/lib/local-fit.test.ts` — unit tests for the above.
+- **Modify** `apps/api/src/lib/discovery.ts` — add `getResume` + `saveAnalysis` deps; apply pre-rank after each insert.
+- **Modify** `apps/api/src/lib/discovery.test.ts` — update `makeDeps`, assert pre-rank applied.
+- **Modify** `apps/api/src/routes/discovery.ts` — wire real default deps (`getUserProfile`, `saveJobAnalysis`).
+- **Modify** `apps/web/src/lib/analysis-display.ts` — add `PRERANK_MODEL` + `isPrerankAnalysis`.
+- **Modify** `apps/web/src/lib/analysis-display.test.ts` (create if absent) — test the helper.
+- **Modify** `apps/web/src/components/job-analysis-actions.tsx` — auto-fire `scoreFit` once on mount when the analysis is a pre-rank estimate.
+- **Modify** `apps/web/src/components/job-analysis-actions.test.tsx` — test auto-fire on/off.
+- **Modify** `apps/web/src/app/(app)/jobs/[jobId]/page.tsx` — pass `autoScore` to `JobAnalysisActions`.
+
+---
+
+## Task 1: `computeLocalFit` — pure keyword-overlap score
+
+**Files:**
+- Create: `apps/api/src/lib/local-fit.ts`
+- Test: `apps/api/src/lib/local-fit.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/lib/local-fit.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { computeLocalFit } from './local-fit';
+
+test('scores the overlap of resume skills against job skills', () => {
+  // Description mentions TypeScript, React, PostgreSQL (3 catalog skills).
+  // Resume covers TypeScript + React (2 of 3) → round(2/3*100) = 67.
+  const description = 'We use TypeScript, React, and PostgreSQL daily.';
+  const resume = 'Senior engineer fluent in TypeScript and React.';
+
+  const { score, matchedSkills } = computeLocalFit(description, resume);
+
+  assert.equal(score, 67);
+  assert.deepEqual(matchedSkills.sort(), ['React', 'TypeScript']);
+});
+
+test('returns 0 with no resume', () => {
+  const result = computeLocalFit('We use TypeScript and React.', '');
+  assert.equal(result.score, 0);
+  assert.deepEqual(result.matchedSkills, []);
+});
+
+test('returns 0 when the description has no recognised skills', () => {
+  const result = computeLocalFit('A friendly team that loves coffee.', 'TypeScript React');
+  assert.equal(result.score, 0);
+  assert.deepEqual(result.matchedSkills, []);
+});
+
+test('scores 100 when the resume covers every job skill', () => {
+  const result = computeLocalFit('TypeScript and React.', 'TypeScript, React, and more.');
+  assert.equal(result.score, 100);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && node --import tsx --test --test-concurrency=1 src/lib/local-fit.test.ts`
+Expected: FAIL — `Cannot find module './local-fit'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/api/src/lib/local-fit.ts`:
+
+```ts
+import { extractKeywords } from '@/lib/analysis-core';
+
+/**
+ * Free, deterministic fit estimate: the share of a job's recognised skills that
+ * also appear in the user's resume. No LLM, no I/O. Used to pre-rank discovered
+ * postings on ingest before the (paid) LLM score runs on first open.
+ */
+export function computeLocalFit(
+  descriptionText: string,
+  resumeText: string,
+): { score: number; matchedSkills: string[] } {
+  const jobSkills = extractKeywords(descriptionText);
+  if (jobSkills.length === 0) {
+    return { score: 0, matchedSkills: [] };
+  }
+
+  const resumeLower = resumeText.toLowerCase();
+  const matchedSkills = jobSkills.filter((skill) => resumeLower.includes(skill.toLowerCase()));
+  const score = Math.round((matchedSkills.length / jobSkills.length) * 100);
+
+  return { score, matchedSkills };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && node --import tsx --test --test-concurrency=1 src/lib/local-fit.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/lib/local-fit.ts apps/api/src/lib/local-fit.test.ts
+git commit -m "feat(api): computeLocalFit — free resume↔job keyword-overlap score (#119)"
+```
+
+---
+
+## Task 2: `prerankAnalysis` — provisional JobAnalysis with the `local-prerank` sentinel
+
+**Files:**
+- Modify: `apps/api/src/lib/local-fit.ts`
+- Test: `apps/api/src/lib/local-fit.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/src/lib/local-fit.test.ts`:
+
+```ts
+import { PRERANK_MODEL, prerankAnalysis } from './local-fit';
+
+test('prerankAnalysis builds an estimated analysis tagged local-prerank', () => {
+  const { fitScore, analysis } = prerankAnalysis(
+    'We use TypeScript, React, and PostgreSQL daily.',
+    'Senior engineer fluent in TypeScript and React.',
+  );
+
+  // Carries the local-fit score …
+  assert.equal(fitScore, 67);
+  // … the matched skills from the overlap …
+  assert.deepEqual(analysis.matchedSkills.sort(), ['React', 'TypeScript']);
+  // … parsed required/preferred skills from the description …
+  assert.ok(analysis.requiredSkills.length > 0);
+  // … and the sentinel that marks it estimated (so the UI can upgrade on open).
+  assert.equal(analysis.modelUsed, PRERANK_MODEL);
+  assert.equal(PRERANK_MODEL, 'local-prerank');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && node --import tsx --test --test-concurrency=1 src/lib/local-fit.test.ts`
+Expected: FAIL — `PRERANK_MODEL`/`prerankAnalysis` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `apps/api/src/lib/local-fit.ts` — update the import line and append the builder:
+
+Change the import at the top to:
+
+```ts
+import { analysisFromParsed, extractKeywords, parseJobDescription } from '@/lib/analysis-core';
+import type { JobAnalysis } from '@/types';
+```
+
+Append at the end of the file:
+
+```ts
+/** Sentinel `modelUsed` value marking an estimated (not-yet-LLM-scored) analysis. */
+export const PRERANK_MODEL = 'local-prerank';
+
+/**
+ * Build the provisional analysis stored for a freshly-discovered posting: the
+ * parsed required/preferred skills (so the detail page isn't empty), the
+ * local-fit matched skills + score, tagged with the `local-prerank` sentinel so
+ * the job-detail page knows to upgrade it with the real LLM score on first open.
+ */
+export function prerankAnalysis(
+  descriptionText: string,
+  resumeText: string,
+): { fitScore: number; analysis: JobAnalysis } {
+  const { score, matchedSkills } = computeLocalFit(descriptionText, resumeText);
+  const base = analysisFromParsed(parseJobDescription(descriptionText));
+
+  return {
+    fitScore: score,
+    analysis: { ...base, matchedSkills, modelUsed: PRERANK_MODEL },
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && node --import tsx --test --test-concurrency=1 src/lib/local-fit.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/lib/local-fit.ts apps/api/src/lib/local-fit.test.ts
+git commit -m "feat(api): prerankAnalysis — provisional analysis with local-prerank sentinel (#119)"
+```
+
+---
+
+## Task 3: Apply pre-rank inside `runDiscoveryForUser`
+
+**Files:**
+- Modify: `apps/api/src/lib/discovery.ts`
+- Test: `apps/api/src/lib/discovery.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/api/src/lib/discovery.test.ts`, replace the `makeDeps` helper (lines 16–31) with a version that supplies the two new deps, returns created jobs with ids, and records saved analyses:
+
+```ts
+function makeDeps(
+  found: SourcedJob[],
+  existing: Partial<JobRecord>[],
+  resume = 'TypeScript and React engineer.',
+): {
+  deps: DiscoveryDeps;
+  created: CreateJobBody[];
+  analyses: Array<{ jobId: string; fitScore?: number | null; modelUsed: string }>;
+} {
+  const created: CreateJobBody[] = [];
+  const analyses: Array<{ jobId: string; fitScore?: number | null; modelUsed: string }> = [];
+  let n = 0;
+  const deps: DiscoveryDeps = {
+    source: { name: 'adzuna', search: async () => found },
+    listJobs: async () => existing as unknown as JobRecord[],
+    createJob: async (_userId, body) => {
+      created.push(body);
+      n += 1;
+      return { ...(body as object), id: `job-${n}` } as unknown as JobRecord;
+    },
+    listSavedSearches: async () => [SEARCH],
+    getResume: async () => resume,
+    saveAnalysis: async (_userId, jobId, analysis, fitScore) => {
+      analyses.push({ jobId, fitScore, modelUsed: analysis.modelUsed });
+      return undefined;
+    },
+  };
+  return { deps, created, analyses };
+}
+```
+
+Then append a new test:
+
+```ts
+test('pre-ranks each inserted job with a local-prerank analysis', async () => {
+  const { deps, analyses } = makeDeps(
+    [sourced('https://x/1', { descriptionText: 'We use TypeScript and React.' })],
+    [],
+  );
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 1);
+  assert.equal(analyses.length, 1);
+  assert.equal(analyses[0]?.jobId, 'job-1');
+  assert.equal(analyses[0]?.modelUsed, 'local-prerank');
+  assert.equal(typeof analyses[0]?.fitScore, 'number');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && node --import tsx --test --test-concurrency=1 src/lib/discovery.test.ts`
+Expected: FAIL — `getResume`/`saveAnalysis` not in `DiscoveryDeps` (type error) and the new assertions fail.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `apps/api/src/lib/discovery.ts`.
+
+Update the imports at the top:
+
+```ts
+import {
+  createJob as createJobStore,
+  listJobs as listJobsStore,
+  saveJobAnalysis as saveJobAnalysisStore,
+} from '@/data/job-store';
+import { listSavedSearches as listSavedSearchesStore } from '@/data/saved-search-store';
+import { prerankAnalysis } from '@/lib/local-fit';
+import type { JobSource } from '@/lib/job-sources';
+import { dedupKey, fingerprintKey } from '@/lib/job-sources/normalize';
+```
+
+Extend the `DiscoveryDeps` interface:
+
+```ts
+export interface DiscoveryDeps {
+  source: JobSource;
+  listJobs: typeof listJobsStore;
+  createJob: typeof createJobStore;
+  listSavedSearches: typeof listSavedSearchesStore;
+  getResume: (userId: string) => Promise<string>;
+  saveAnalysis: typeof saveJobAnalysisStore;
+}
+```
+
+In `runDiscoveryForUser`, fetch the resume once after building `seen`:
+
+```ts
+  const searches = await deps.listSavedSearches(userId);
+  const seen = new Set((await deps.listJobs(userId)).flatMap(keysFor));
+  const resume = await deps.getResume(userId);
+```
+
+Replace the successful-insert block (the `try { await deps.createJob(...); inserted += 1; }`) with one that captures the created job and pre-ranks it:
+
+```ts
+      try {
+        const createdJob = await deps.createJob(userId, job);
+        inserted += 1;
+        // Pre-rank: store a free estimated fit so the feed is ranked immediately;
+        // the real LLM score runs lazily when the user first opens the job.
+        const { fitScore, analysis } = prerankAnalysis(job.descriptionText ?? '', resume);
+        await deps.saveAnalysis(userId, createdJob.id, analysis, fitScore);
+      } catch (error) {
+```
+
+(The `catch` body — duplicate-key handling and `throw` — is unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && node --import tsx --test --test-concurrency=1 src/lib/discovery.test.ts`
+Expected: PASS (all existing tests + the new pre-rank test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/lib/discovery.ts apps/api/src/lib/discovery.test.ts
+git commit -m "feat(api): pre-rank discovered jobs with local fit on ingest (#119)"
+```
+
+---
+
+## Task 4: Wire real default deps in the discovery routes
+
+**Files:**
+- Modify: `apps/api/src/routes/discovery.ts`
+
+This is production dependency wiring (no new branch logic), verified by the type checker and the existing route tests, which inject their own deps.
+
+- [ ] **Step 1: Update the imports**
+
+Edit `apps/api/src/routes/discovery.ts` top imports:
+
+```ts
+import { Router } from 'express';
+import { requireUser } from '@/lib/auth';
+import { createJob, listJobs, saveJobAnalysis } from '@/data/job-store';
+import { getUserProfile } from '@/data/profile-store';
+import { listSavedSearches, listUsersWithSavedSearches } from '@/data/saved-search-store';
+import { getJobSource } from '@/lib/job-sources';
+import { requireN8nWebhookSecret } from '@/lib/n8n';
+import { runDiscoveryForUser, type DiscoveryResult } from '@/lib/discovery';
+```
+
+- [ ] **Step 2: Wire the new deps into `defaultDeps`**
+
+Replace the `runDiscovery` field of `defaultDeps`:
+
+```ts
+const defaultDeps: DiscoveryRouterDeps = {
+  runDiscovery: (userId) =>
+    runDiscoveryForUser(userId, {
+      source: getJobSource(),
+      listJobs,
+      createJob,
+      listSavedSearches,
+      getResume: async (id) => (await getUserProfile(id))?.resumeText ?? '',
+      saveAnalysis: saveJobAnalysis,
+    }),
+  listUsersWithSavedSearches,
+};
+```
+
+- [ ] **Step 3: Verify typecheck + discovery route tests pass**
+
+Run: `cd apps/api && npm run typecheck`
+Expected: no errors.
+
+Run: `cd apps/api && node --import tsx --test --test-concurrency=1 src/routes/discovery.test.ts`
+Expected: PASS (unchanged — route tests inject their own deps).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/routes/discovery.ts
+git commit -m "feat(api): wire resume + analysis deps into discovery defaults (#119)"
+```
+
+---
+
+## Task 5: Web — recognise the `local-prerank` sentinel
+
+**Files:**
+- Modify: `apps/web/src/lib/analysis-display.ts`
+- Test: `apps/web/src/lib/analysis-display.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/lib/analysis-display.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { PRERANK_MODEL, isPrerankAnalysis, isHeuristicAnalysis } from './analysis-display';
+
+describe('isPrerankAnalysis', () => {
+  it('is true only for the local-prerank sentinel', () => {
+    expect(PRERANK_MODEL).toBe('local-prerank');
+    expect(isPrerankAnalysis('local-prerank')).toBe(true);
+    expect(isPrerankAnalysis('mock-analysis-v1')).toBe(false);
+    expect(isPrerankAnalysis(null)).toBe(false);
+    expect(isPrerankAnalysis(undefined)).toBe(false);
+  });
+
+  it('does not classify the pre-rank sentinel as a heuristic fit', () => {
+    expect(isHeuristicAnalysis('local-prerank')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/lib/analysis-display.test.ts`
+Expected: FAIL — `PRERANK_MODEL`/`isPrerankAnalysis` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `apps/web/src/lib/analysis-display.ts`:
+
+```ts
+/**
+ * `local-prerank` marks a discovered job's free, estimated fit (keyword overlap
+ * only). It upgrades to a real LLM analysis the first time the job is opened.
+ */
+export const PRERANK_MODEL = 'local-prerank';
+
+export function isPrerankAnalysis(modelUsed: string | null | undefined): boolean {
+  return modelUsed === PRERANK_MODEL;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && npx vitest run src/lib/analysis-display.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/analysis-display.ts apps/web/src/lib/analysis-display.test.ts
+git commit -m "feat(web): recognise local-prerank estimated-analysis sentinel (#119)"
+```
+
+---
+
+## Task 6: Web — auto-fire `scoreFit` once on open for estimated jobs
+
+**Files:**
+- Modify: `apps/web/src/components/job-analysis-actions.tsx`
+- Test: `apps/web/src/components/job-analysis-actions.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the body of `apps/web/src/components/job-analysis-actions.test.tsx` with:
+
+```tsx
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
+
+const { scoreFit } = vi.hoisted(() => ({
+  scoreFit: vi.fn(() => Promise.resolve({ fit_score: 80 })),
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock('@/lib/api', () => ({
+  scoreFit,
+  ApiRequestError: class ApiRequestError extends Error {},
+}));
+
+import { JobAnalysisActions } from './job-analysis-actions';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+it('offers a single "Score fit" action and no separate "Parse job" button', () => {
+  render(<JobAnalysisActions jobId="job-1" />);
+
+  expect(screen.getByRole('button', { name: /score fit/i })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /parse job/i })).not.toBeInTheDocument();
+});
+
+it('does not auto-score by default', () => {
+  render(<JobAnalysisActions jobId="job-1" />);
+  expect(scoreFit).not.toHaveBeenCalled();
+});
+
+it('auto-scores once on mount when the analysis is an estimate', async () => {
+  render(<JobAnalysisActions jobId="job-1" autoScore />);
+  await waitFor(() => expect(scoreFit).toHaveBeenCalledTimes(1));
+  expect(scoreFit).toHaveBeenCalledWith({ jobId: 'job-1' });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/components/job-analysis-actions.test.tsx`
+Expected: FAIL — `autoScore` prop has no effect; `scoreFit` not called.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `apps/web/src/components/job-analysis-actions.tsx` with:
+
+```tsx
+'use client';
+
+import { Target } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { ApiRequestError, scoreFit } from '@/lib/api';
+
+type JobAnalysisActionsProps = {
+  jobId: string;
+  /** True when the stored analysis is a free estimate (local-prerank): upgrade it
+   *  to a real LLM score once, silently, on open. */
+  autoScore?: boolean;
+};
+
+// "Score fit" is the single analysis action: it parses the job and scores the
+// fit in one step, then persists the scored analysis. (The old "Parse job"
+// button saved a fit-less heuristic that overwrote a good score — removed.)
+export function JobAnalysisActions({ jobId, autoScore = false }: JobAnalysisActionsProps) {
+  const router = useRouter();
+  const [isScoring, setIsScoring] = useState(false);
+  const autoFired = useRef(false);
+
+  async function handleScore({ silent = false }: { silent?: boolean } = {}) {
+    setIsScoring(true);
+    try {
+      const scored = await scoreFit({ jobId });
+      if (!silent) toast.success(`Fit score saved: ${scored.fit_score}/100`);
+      router.refresh();
+    } catch (error) {
+      // The automatic upgrade stays quiet on failure (e.g. daily budget reached):
+      // the estimate remains and the manual button is the fallback.
+      if (!silent) {
+        toast.error(error instanceof ApiRequestError ? error.message : 'Failed to score the fit.');
+      }
+    } finally {
+      setIsScoring(false);
+    }
+  }
+
+  useEffect(() => {
+    if (autoScore && !autoFired.current) {
+      autoFired.current = true;
+      void handleScore({ silent: true });
+    }
+    // Fire at most once per mount for an estimated job; jobId/autoScore are stable
+    // for the lifetime of the detail page.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoScore, jobId]);
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button onClick={() => void handleScore()} disabled={isScoring} className="gap-1.5">
+        <Target className="size-4" />
+        {isScoring ? 'Scoring…' : 'Score fit'}
+      </Button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && npx vitest run src/components/job-analysis-actions.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/job-analysis-actions.tsx apps/web/src/components/job-analysis-actions.test.tsx
+git commit -m "feat(web): auto-upgrade estimated fit to a real LLM score on open (#119)"
+```
+
+---
+
+## Task 7: Web — pass `autoScore` from the job-detail page + full verification
+
+**Files:**
+- Modify: `apps/web/src/app/(app)/jobs/[jobId]/page.tsx`
+
+- [ ] **Step 1: Pass the `autoScore` prop**
+
+In `apps/web/src/app/(app)/jobs/[jobId]/page.tsx`:
+
+Update the analysis-display import (line 16) to also import the pre-rank helper:
+
+```ts
+import { isHeuristicAnalysis, isPrerankAnalysis } from '@/lib/analysis-display';
+```
+
+After the `heuristic` line (line 36), add:
+
+```ts
+  const estimated = isPrerankAnalysis(job.analysis.modelUsed);
+```
+
+Update the `JobAnalysisActions` usage (line 64):
+
+```tsx
+          <JobAnalysisActions jobId={job.id} autoScore={estimated} />
+```
+
+- [ ] **Step 2: Typecheck, lint, and run the web test suite**
+
+Run: `cd apps/web && npm run typecheck`
+Expected: no errors.
+
+Run: `cd apps/web && npm run lint`
+Expected: no errors.
+
+Run: `cd apps/web && npm test`
+Expected: all suites PASS (including the new `analysis-display` + `job-analysis-actions` tests).
+
+- [ ] **Step 3: Run the full API test suite**
+
+Run: `cd apps/api && node scripts/run-tests.mjs`
+Expected: all PASS (110 prior + new local-fit + discovery pre-rank tests).
+
+- [ ] **Step 4: Build the web app**
+
+Run: `cd apps/web && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add "apps/web/src/app/(app)/jobs/[jobId]/page.tsx"
+git commit -m "feat(web): trigger score-on-open for estimated discovered jobs (#119)"
+git push -u origin feat/jobs-feed-prerank
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+gh pr create --title "feat: pre-rank discovered jobs + score-on-open (#118 → #119 · PR A)" \
+  --body "$(cat <<'BODY'
+Phase 2 PR A — the auto-score lifecycle for the Jobs feed.
+
+- New pure `local-fit.ts`: `computeLocalFit` (resume↔job keyword overlap) + `prerankAnalysis` (provisional analysis tagged `local-prerank`).
+- `runDiscoveryForUser` pre-ranks every newly inserted posting (free, $0) so the feed is ranked on ingest — applies to both `/api/discovery/run` and the `/api/n8n/discover` sweep.
+- Job-detail page auto-fires the existing `/api/ai/score-fit` once, client-side, to upgrade an estimate to a real LLM score (budget-guarded; silent on failure; manual "Score fit" remains the fallback).
+
+Spec: `docs/superpowers/specs/2026-06-24-jobs-feed-design.md`.
+
+Verification: API suite + web vitest + typecheck + lint + build all green.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** PR A rows of the spec table — `local-fit.ts` (Tasks 1–2), pre-rank wired into ingest (Tasks 3–4), score-on-open upgrade (Tasks 5–7). PRs B/C/D are intentionally out of scope.
+- **Type consistency:** `PRERANK_MODEL = 'local-prerank'` defined once per side (`local-fit.ts` API, `analysis-display.ts` web); `prerankAnalysis` returns `{ fitScore, analysis }`; `saveAnalysis` matches `saveJobAnalysis(userId, jobId, analysis, fitScore?)`; `DiscoveryDeps.getResume` returns `Promise<string>`.
+- **No placeholders:** every code step shows full code; commands include expected output.
+- **Cost guard:** the only paid call (`scoreFit`) is gated behind client mount + the existing `reserveAiBudget` in `/score-fit`; ingest is free.

--- a/docs/superpowers/specs/2026-06-24-jobs-feed-design.md
+++ b/docs/superpowers/specs/2026-06-24-jobs-feed-design.md
@@ -1,0 +1,157 @@
+# Phase 2 — JobRight-style Jobs feed (design)
+
+**Date:** 2026-06-24
+**Epic:** #124 · **Phase issue:** #119
+**Status:** Approved (brainstorm), pending implementation plan
+
+## Goal
+
+Turn Jobs from a manual CRM into a JobRight-style **feed**: tailored postings
+appear regularly, already ranked against the user's resume, filterable by
+recency — without manual per-job work. **No accuracy/cost regressions**: the
+expensive LLM scoring stays gated behind genuine user interest.
+
+## Locked decisions
+
+1. **Auto-score = free local pre-rank on ingest + full LLM score on first open.**
+   Every discovered posting gets an instant, $0 estimated fit at ingest. The
+   real 2-call LLM parse+score runs lazily the first time the user opens the
+   job, budget-guarded, and is cached. A 50-job sweep costs $0.
+2. **Background refresh = external GitHub Actions cron → existing
+   `POST /api/n8n/discover`.** No in-app scheduler (survives idle App Service,
+   no double-fire). Enabling it in prod requires the owner to set repo secrets.
+3. **Criteria capture = new onboarding step 2** (target roles + location +
+   remote) that creates the first saved search and runs an initial discovery,
+   plus an editable discovery panel inside Jobs.
+
+## Current state (verified)
+
+- Discovery works: `runDiscoveryForUser` (`apps/api/src/lib/discovery.ts`) pulls
+  Adzuna/Remotive from `saved_searches`, dedupes by URL **and**
+  `company|title|location` fingerprint, inserts via `createJob` with
+  `fitScore: null`. Postings already carry `datePosted` + `source`.
+- Two entry points: `POST /api/discovery/run` (user) and
+  `POST /api/n8n/discover` (n8n-secret-guarded sweep over all users with saved
+  searches) — both in `apps/api/src/routes/discovery.ts`, both call
+  `runDiscoveryForUser`.
+- Full scoring path (to reuse on open): `resolveParsedJob` →
+  `groundingFromParsed` → `resolveFitScore` → `saveJobAnalysis`, grounded on the
+  user's saved resume (`getUserProfile`), budget-guarded via `reserveAiBudget`
+  (`apps/api/src/routes/ai.ts`, the `/score-fit` handler).
+- UI: `jobs-table.tsx` has search + status/priority filters and a "via adzuna"
+  badge; **no** recency filter or posted date shown. Onboarding
+  (`apps/web/src/app/onboarding/page.tsx`) is a single resume step.
+- `saved_searches` already stores `query` / `location` / `remoteOnly` — reuse,
+  **no migration**.
+
+## Architecture
+
+### Auto-score lifecycle
+
+```
+Discover (manual "Discover now" OR cron sweep)
+   └─► runDiscoveryForUser(userId, { ..., getResume })
+          fetch resume ONCE per run (getUserProfile)
+          for each NEW posting:
+             computeLocalFit(descriptionText, resumeText)
+                └─► fitScore + analysis{ matchedSkills, modelUsed: 'local-prerank' }
+   ▼
+Feed shows estimated fit immediately (labeled "estimated")
+   │
+User opens job
+   └─► analysis.modelUsed === 'local-prerank' && reserveAiBudget(parse) ?
+          └─► full LLM parse + score (once) ─► saveJobAnalysis (real fit, cached)
+          else ─► stays estimated; manual "Score fit" button remains
+```
+
+The `local-prerank` sentinel in `analysis.modelUsed` is the single source of
+truth for "estimated vs. real" — no schema change.
+
+### New pure module — `apps/api/src/lib/local-fit.ts`
+
+```
+computeLocalFit(descriptionText: string, resumeText: string)
+  → { score: number; matchedSkills: string[] }
+```
+
+- Extract skill keywords from the description (reuse the existing keyword list /
+  parse helper), intersect with keywords present in the resume, scale overlap to
+  0–100. Deterministic, no LLM, no I/O. Fully unit-testable.
+- Edge cases: empty resume → `score 0`, `matchedSkills []`; no overlap → `0`;
+  full overlap → high but capped at 100.
+
+### Ingest wiring
+
+- Extend `DiscoveryDeps` with a `getResume(userId)` dependency (defaults to
+  `getUserProfile`). `runDiscoveryForUser` fetches the resume once, and for each
+  inserted posting computes local fit and persists `fitScore` + a provisional
+  `analysis` (matched skills + `modelUsed: 'local-prerank'`).
+- Because both `/api/discovery/run` and `/api/n8n/discover` route through
+  `runDiscoveryForUser`, pre-rank applies to manual and scheduled discovery
+  alike with no per-route code.
+- A posting with no resume on file still inserts (fit `0`/estimated); it upgrades
+  on open once a resume exists.
+
+### Score-on-open upgrade
+
+- The upgrade is triggered **client-side**, once, on the job detail component's
+  mount (a small effect), only when `analysis.modelUsed === 'local-prerank'` —
+  so SSR renders, link prefetches, and bots never spend budget. It calls the
+  existing `/score-fit` endpoint, which already reuses `reserveAiBudget`, so a
+  user at the daily cap simply keeps the estimate; the manual "Score fit" button
+  (Phase 1) is the fallback. Idempotent: a job already upgraded (real
+  `modelUsed`) never re-fires, and a concurrent manual click is harmless
+  (same endpoint, same cached result).
+
+### Frontend
+
+- **Onboarding step 2** — `onboarding/page.tsx` becomes two steps (resume →
+  target criteria). Step 2 captures roles/keywords + location + remote toggle →
+  `createSavedSearch` → `runDiscovery` → route to `/jobs`.
+- **Discovery panel in Jobs** — relocate `SavedSearchesManager` from Settings
+  into the Jobs page (collapsible panel above the table); remove the Settings
+  copy (redirect/point to Jobs). Manual search retained.
+- **Jobs table** (`jobs-table.tsx`) — add a recency `select`
+  (**All / 24h / 3d / 7d**) filtering on `datePosted` (fallback
+  `discoveredAt`); show posted date + source; add a matched-skills snippet and
+  an **"estimated"** tag when `modelUsed === 'local-prerank'`.
+
+### Background refresh
+
+- `.github/workflows/discover.yml`: cron every 6h →
+  `POST {API_BASE_URL}/api/n8n/discover` with the n8n webhook secret header.
+  Committed but inert until the owner sets repo secrets `API_BASE_URL` and
+  `N8N_WEBHOOK_SECRET`. Documented in the PR and `docs/`.
+
+## Data model
+
+No migrations. Reuse: `saved_searches` (query/location/remoteOnly),
+`jobs.fit_score`, `job_analysis` (with `model_used = 'local-prerank'` sentinel),
+`jobs.date_posted`, `jobs.source`. No per-user discovery timestamp (cron owns
+scheduling).
+
+## Build slices — 4 PRs off `main`, each independently green
+
+| PR | Scope | Layer |
+|----|-------|-------|
+| **A** | `local-fit.ts` + pre-rank wired into ingest + score-on-open upgrade. Carries this spec. | backend (TDD) |
+| **B** | Discovery panel → Jobs; onboarding step 2 + initial discovery | frontend |
+| **C** | Recency filter + posted date + matched-skills/"estimated" on rows | frontend |
+| **D** | GitHub Actions cron workflow + docs | ops |
+
+## Testing
+
+- `local-fit.test.ts` — pure: empty resume, zero overlap, full overlap, scaling/cap.
+- Discovery tests — ingest sets `fitScore` + `local-prerank` sentinel (manual + sweep).
+- Score-on-open — estimated → real upgrade; budget-exhausted stays estimated; no re-fire when already real.
+- Web (vitest) — onboarding step 2 flow, recency filter logic, discovery-panel render, "estimated" tag.
+
+## YAGNI (explicitly out of scope)
+
+No new DB tables, no in-app scheduler, no per-user discovery timestamps, no
+re-ranking of already-scored jobs, no change to the dedupe/source pipeline.
+
+## Workflow
+
+Branch each slice off `main`; one PR per slice; address Codex review before
+proceeding; owner does the final merge. Verify per `docs/TESTING.md`.


### PR DESCRIPTION
Phase 2 PR A — the auto-score lifecycle for the JobRight-style jobs feed. Every discovered posting gets a **free, instant estimated fit** at ingest, and the **real LLM fit** runs once when the user first opens the job. A 50-job sweep costs \$0.

Design spec: \`docs/superpowers/specs/2026-06-24-jobs-feed-design.md\` · Plan: \`docs/superpowers/plans/2026-06-24-jobs-feed-pr-a-prerank.md\`

## What's in this PR

**Backend (ingest pre-rank):**
- New pure module \`apps/api/src/lib/local-fit.ts\`:
  - \`computeLocalFit(description, resume)\` — resume↔job keyword-overlap score (no LLM, no I/O).
  - \`prerankAnalysis(...)\` — provisional \`JobAnalysis\` tagged with the \`local-prerank\` sentinel.
- \`runDiscoveryForUser\` pre-ranks each newly-inserted posting (fetches the resume once per run, applies fit after each insert). Applies to **both** \`/api/discovery/run\` and the \`/api/n8n/discover\` sweep. Pre-rank is **best-effort** — a transient analysis-save failure never aborts the sweep or downgrades an already-inserted job.
- Discovery route \`defaultDeps\` wire the real resume (\`getUserProfile().resumeText\`) + \`saveJobAnalysis\`.

**Frontend (score-on-open):**
- \`isPrerankAnalysis\` / \`PRERANK_MODEL\` helper to recognise the estimate sentinel.
- \`JobAnalysisActions\` gains an \`autoScore\` prop: on mount, for an estimated job, it fires the existing budget-guarded \`/api/ai/score-fit\` **once**, client-side, **silently** (no toast; unexpected errors logged to console). The manual "Score fit" button remains the fallback.
- The job-detail page passes \`autoScore\` when the analysis is still a \`local-prerank\` estimate.

## Verification
- API suite: **119 pass** · Web vitest: **35 pass** · typecheck + lint clean · web build succeeds.
- New tests: local-fit (overlap math + prerank sentinel), discovery pre-rank + best-effort-failure path, analysis-display helper, score-on-open (auto-fire once / not-by-default / no-refire-on-rerender).

## Notes
- Out of scope (later PRs): discovery panel in Jobs + onboarding step 2 (B), recency filters + cards (C), GitHub Actions cron (D).
- Includes two review-fix commits from the in-session spec/quality review gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)