### PR TITLE
feat: discovery in the Jobs tab + onboarding step 2 (#118 → #119 · PR B)

### DIFF
--- a/apps/web/src/app/(app)/jobs/page.test.tsx
+++ b/apps/web/src/app/(app)/jobs/page.test.tsx
@@ -14,6 +14,12 @@ vi.mock('@/components/jobs-table', () => ({
   ),
 }));
 
+// The discovery panel is an interactive client component (router + API calls);
+// stub it so this test stays focused on query-param normalization.
+vi.mock('@/components/saved-searches', () => ({
+  SavedSearchesManager: () => <div data-testid="saved-searches" />,
+}));
+
 it('normalizes a repeated q param (string[]) to its first value', async () => {
   const ui = await JobsPage({ searchParams: Promise.resolve({ q: ['backend', 'remote'] }) });
   render(ui);

--- a/apps/web/src/app/(app)/jobs/page.tsx
+++ b/apps/web/src/app/(app)/jobs/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Plus } from 'lucide-react';
 import Link from 'next/link';
 import { JobsTable } from '@/components/jobs-table';
+import { SavedSearchesManager } from '@/components/saved-searches';
 import { SectionCard } from '@/components/section-card';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -43,6 +44,13 @@ export default async function JobsPage({
           </p>
         </Card>
       ) : null}
+
+      <SectionCard
+        title="Find new jobs"
+        description="Save target searches, then pull real postings into your pipeline — already scored against your resume."
+      >
+        <SavedSearchesManager />
+      </SectionCard>
 
       <SectionCard
         title="Job pipeline"

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import { Database, FileText, Webhook } from 'lucide-react';
-import { SavedSearchesManager } from '@/components/saved-searches';
 import { SectionCard } from '@/components/section-card';
 import { DemoDataActions, ExportDataButton, ResumeReupload } from '@/components/settings-actions';
 import { Badge } from '@/components/ui/badge';
@@ -90,10 +89,6 @@ export default async function SettingsPage() {
           </div>
           <ResumeReupload />
         </div>
-      </SectionCard>
-
-      <SectionCard title="Job discovery" description="Save searches, then pull real postings into your CRM.">
-        <SavedSearchesManager />
       </SectionCard>
 
       <SectionCard title="AI provider" description="Configured on the server — shown here for transparency.">

--- a/apps/web/src/app/onboarding/onboarding-page.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-page.test.tsx
@@ -66,3 +66,18 @@ it('requires a role/keyword before discovering on step 2', async () => {
   expect(await screen.findByRole('alert')).toHaveTextContent(/add at least one role or keyword/i);
   expect(createSavedSearch).not.toHaveBeenCalled();
 });
+
+it('lets the user skip discovery and go to the dashboard', async () => {
+  const user = userEvent.setup();
+  render(<OnboardingPage />);
+
+  await user.click(screen.getByRole('tab', { name: /paste text/i }));
+  await user.type(screen.getByPlaceholderText(/paste your resume text/i), 'Engineer.');
+  await user.click(screen.getByRole('button', { name: /continue/i }));
+
+  await screen.findByLabelText(/role or keywords/i);
+  await user.click(screen.getByRole('button', { name: /skip for now/i }));
+
+  expect(createSavedSearch).not.toHaveBeenCalled();
+  await waitFor(() => expect(push).toHaveBeenCalledWith('/dashboard'));
+});

--- a/apps/web/src/app/onboarding/onboarding-page.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-page.test.tsx
@@ -1,12 +1,18 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, expect, it, vi } from 'vitest';
 
-const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
-vi.mock('sonner', () => ({ toast: { error: toastError, success: vi.fn() } }));
-vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }) }));
-vi.mock('@/lib/api', () => ({ saveResumeText: vi.fn(), uploadResumeFile: vi.fn() }));
+const { push, refresh } = vi.hoisted(() => ({ push: vi.fn(), refresh: vi.fn() }));
+const { saveResumeText, uploadResumeFile, createSavedSearch, runDiscovery } = vi.hoisted(() => ({
+  saveResumeText: vi.fn(() => Promise.resolve(null)),
+  uploadResumeFile: vi.fn(() => Promise.resolve(null)),
+  createSavedSearch: vi.fn(() => Promise.resolve({ id: 's1' })),
+  runDiscovery: vi.fn(() => Promise.resolve({ inserted: 3, skipped: 0, source: 'adzuna' })),
+}));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push, refresh }) }));
+vi.mock('@/lib/api', () => ({ saveResumeText, uploadResumeFile, createSavedSearch, runDiscovery }));
 
 import OnboardingPage from './page';
 
@@ -18,13 +24,45 @@ it('shows an inline alert (in addition to the toast) when continuing with no res
   const user = userEvent.setup();
   render(<OnboardingPage />);
 
-  // No alert before the user submits.
   expect(screen.queryByRole('alert')).toBeNull();
-
-  await user.click(screen.getByRole('button', { name: /continue to dashboard/i }));
+  await user.click(screen.getByRole('button', { name: /continue/i }));
 
   const alert = await screen.findByRole('alert');
   expect(alert).toHaveTextContent(/add your resume to continue/i);
-  // The toast still fires too — inline is "in addition to", not a replacement.
-  expect(toastError).toHaveBeenCalledOnce();
+});
+
+it('advances to the target-roles step after a resume is saved, then discovers and routes to jobs', async () => {
+  const user = userEvent.setup();
+  render(<OnboardingPage />);
+
+  await user.click(screen.getByRole('tab', { name: /paste text/i }));
+  await user.type(screen.getByPlaceholderText(/paste your resume text/i), 'Senior TypeScript engineer.');
+  await user.click(screen.getByRole('button', { name: /continue/i }));
+
+  const roleInput = await screen.findByLabelText(/role or keywords/i);
+  await user.type(roleInput, 'AI Engineer');
+  await user.click(screen.getByRole('button', { name: /find matching jobs/i }));
+
+  await waitFor(() => expect(createSavedSearch).toHaveBeenCalledWith({
+    query: 'AI Engineer',
+    location: undefined,
+    remoteOnly: false,
+  }));
+  expect(runDiscovery).toHaveBeenCalledOnce();
+  await waitFor(() => expect(push).toHaveBeenCalledWith('/jobs'));
+});
+
+it('requires a role/keyword before discovering on step 2', async () => {
+  const user = userEvent.setup();
+  render(<OnboardingPage />);
+
+  await user.click(screen.getByRole('tab', { name: /paste text/i }));
+  await user.type(screen.getByPlaceholderText(/paste your resume text/i), 'Engineer.');
+  await user.click(screen.getByRole('button', { name: /continue/i }));
+
+  await screen.findByLabelText(/role or keywords/i);
+  await user.click(screen.getByRole('button', { name: /find matching jobs/i }));
+
+  expect(await screen.findByRole('alert')).toHaveTextContent(/add at least one role or keyword/i);
+  expect(createSavedSearch).not.toHaveBeenCalled();
 });

--- a/apps/web/src/app/onboarding/onboarding-page.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-page.test.tsx
@@ -67,6 +67,27 @@ it('requires a role/keyword before discovering on step 2', async () => {
   expect(createSavedSearch).not.toHaveBeenCalled();
 });
 
+it('treats a "Remote" location as remote-only (the source ignores it as a place)', async () => {
+  const user = userEvent.setup();
+  render(<OnboardingPage />);
+
+  await user.click(screen.getByRole('tab', { name: /paste text/i }));
+  await user.type(screen.getByPlaceholderText(/paste your resume text/i), 'Engineer.');
+  await user.click(screen.getByRole('button', { name: /continue/i }));
+
+  await user.type(await screen.findByLabelText(/role or keywords/i), 'AI Engineer');
+  await user.type(screen.getByLabelText(/^location$/i), 'Remote');
+  await user.click(screen.getByRole('button', { name: /find matching jobs/i }));
+
+  await waitFor(() =>
+    expect(createSavedSearch).toHaveBeenCalledWith({
+      query: 'AI Engineer',
+      location: undefined,
+      remoteOnly: true,
+    }),
+  );
+});
+
 it('lets the user skip discovery and go to the dashboard', async () => {
   const user = userEvent.setup();
   render(<OnboardingPage />);

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -6,19 +6,29 @@ import { FileText, Loader2, Sparkles, Upload } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
-import { saveResumeText, uploadResumeFile } from '@/lib/api';
+import { saveResumeText, uploadResumeFile, createSavedSearch, runDiscovery } from '@/lib/api';
 
 export default function OnboardingPage() {
   const router = useRouter();
+
+  // Step 1 state
+  const [step, setStep] = useState<1 | 2>(1);
   const [resumeText, setResumeText] = useState('');
   const [fileName, setFileName] = useState<string | null>(null);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function finish() {
+  // Step 2 state
+  const [query, setQuery] = useState('');
+  const [location, setLocation] = useState('');
+  const [remoteOnly, setRemoteOnly] = useState(false);
+
+  async function saveResume() {
     setSaving(true);
     setError(null);
     try {
@@ -27,18 +37,49 @@ export default function OnboardingPage() {
       } else if (resumeText.trim()) {
         await saveResumeText(resumeText.trim());
       } else {
-        // Surface the validation failure inline (a toast alone is easy to miss and
-        // disappears) in addition to the toast.
         const message = 'Add your resume to continue — upload a PDF or paste the text.';
         setError(message);
         toast.error(message);
         return;
       }
-      toast.success('You’re all set. Welcome to JobOps Copilot.');
-      router.push('/dashboard');
-      router.refresh();
+      setStep(2);
     } catch {
       toast.error('Could not save your resume. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function discover() {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      const message = 'Add at least one role or keyword to find jobs.';
+      setError(message);
+      toast.error(message);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await createSavedSearch({
+        query: trimmed,
+        location: location.trim() || undefined,
+        remoteOnly,
+      });
+      try {
+        const result = await runDiscovery();
+        toast.success(
+          result.inserted > 0
+            ? `Found ${result.inserted} matching job${result.inserted === 1 ? '' : 's'}.`
+            : "Search saved — new jobs will appear as they're posted.",
+        );
+      } catch {
+        toast.success("Search saved — we'll pull matching jobs shortly.");
+      }
+      router.push('/jobs');
+      router.refresh();
+    } catch {
+      toast.error('Could not save your search. Please try again.');
     } finally {
       setSaving(false);
     }
@@ -51,80 +92,150 @@ export default function OnboardingPage() {
           <div className="bg-primary/10 text-primary mb-2 flex size-11 items-center justify-center rounded-xl">
             <Sparkles className="size-5" />
           </div>
-          <CardTitle className="font-heading text-2xl">Welcome to JobOps Copilot</CardTitle>
-          <CardDescription>
-            Add your resume so the AI can score job fit and draft outreach grounded in your real
-            experience. Nothing is sent anywhere without your review.
-          </CardDescription>
+          {step === 1 ? (
+            <>
+              <CardTitle className="font-heading text-2xl">Welcome to JobOps Copilot</CardTitle>
+              <CardDescription>
+                Add your resume so the AI can score job fit and draft outreach grounded in your real
+                experience. Nothing is sent anywhere without your review.
+              </CardDescription>
+            </>
+          ) : (
+            <>
+              <CardTitle className="font-heading text-2xl">What roles are you targeting?</CardTitle>
+              <CardDescription>
+                We&apos;ll pull matching postings into your feed, already scored against your resume.
+              </CardDescription>
+            </>
+          )}
         </CardHeader>
-        <CardContent className="space-y-5">
-          <Tabs defaultValue="upload">
-            <TabsList className="w-full">
-              <TabsTrigger value="upload" className="flex-1">
-                Upload PDF
-              </TabsTrigger>
-              <TabsTrigger value="paste" className="flex-1">
-                Paste text
-              </TabsTrigger>
-            </TabsList>
 
-            <TabsContent value="upload" className="pt-4">
-              <label
-                htmlFor="resume-file"
-                className="border-border hover:border-primary/50 hover:bg-accent/40 flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-dashed p-8 text-center transition-colors"
-              >
-                {fileName ? (
-                  <>
-                    <FileText className="text-primary size-6" />
-                    <span className="text-sm font-medium">{fileName}</span>
-                    <span className="text-muted-foreground text-xs">Click to choose a different file</span>
-                  </>
-                ) : (
-                  <>
-                    <Upload className="text-muted-foreground size-6" />
-                    <span className="text-sm font-medium">Drop or choose your resume PDF</span>
-                    <span className="text-muted-foreground text-xs">PDF, up to 5&nbsp;MB</span>
-                  </>
-                )}
-                <input
-                  id="resume-file"
-                  type="file"
-                  accept="application/pdf"
-                  className="sr-only"
+        {step === 1 ? (
+          <CardContent className="space-y-5">
+            <Tabs defaultValue="upload">
+              <TabsList className="w-full">
+                <TabsTrigger value="upload" className="flex-1">
+                  Upload PDF
+                </TabsTrigger>
+                <TabsTrigger value="paste" className="flex-1">
+                  Paste text
+                </TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="upload" className="pt-4">
+                <label
+                  htmlFor="resume-file"
+                  className="border-border hover:border-primary/50 hover:bg-accent/40 flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-dashed p-8 text-center transition-colors"
+                >
+                  {fileName ? (
+                    <>
+                      <FileText className="text-primary size-6" />
+                      <span className="text-sm font-medium">{fileName}</span>
+                      <span className="text-muted-foreground text-xs">Click to choose a different file</span>
+                    </>
+                  ) : (
+                    <>
+                      <Upload className="text-muted-foreground size-6" />
+                      <span className="text-sm font-medium">Drop or choose your resume PDF</span>
+                      <span className="text-muted-foreground text-xs">PDF, up to 5&nbsp;MB</span>
+                    </>
+                  )}
+                  <input
+                    id="resume-file"
+                    type="file"
+                    accept="application/pdf"
+                    className="sr-only"
+                    onChange={(event) => {
+                      const file = event.target.files?.[0] ?? null;
+                      setPendingFile(file);
+                      setFileName(file?.name ?? null);
+                      if (file) setError(null);
+                    }}
+                  />
+                </label>
+              </TabsContent>
+
+              <TabsContent value="paste" className="pt-4">
+                <Textarea
+                  value={resumeText}
                   onChange={(event) => {
-                    const file = event.target.files?.[0] ?? null;
-                    setPendingFile(file);
-                    setFileName(file?.name ?? null);
-                    if (file) setError(null);
+                    setResumeText(event.target.value);
+                    if (event.target.value.trim()) setError(null);
                   }}
+                  placeholder="Paste your resume text here…"
+                  className="min-h-48"
                 />
-              </label>
-            </TabsContent>
+              </TabsContent>
+            </Tabs>
 
-            <TabsContent value="paste" className="pt-4">
-              <Textarea
-                value={resumeText}
+            {error ? (
+              <p role="alert" className="text-destructive text-sm font-medium">
+                {error}
+              </p>
+            ) : null}
+
+            <Button onClick={saveResume} disabled={saving} className="w-full">
+              {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+              Continue
+            </Button>
+          </CardContent>
+        ) : (
+          <CardContent className="space-y-5">
+            <div className="space-y-1.5">
+              <Label htmlFor="role">Role or keywords</Label>
+              <Input
+                id="role"
+                value={query}
                 onChange={(event) => {
-                  setResumeText(event.target.value);
+                  setQuery(event.target.value);
                   if (event.target.value.trim()) setError(null);
                 }}
-                placeholder="Paste your resume text here…"
-                className="min-h-48"
+                placeholder="e.g. AI Engineer, automation"
               />
-            </TabsContent>
-          </Tabs>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="loc">Location</Label>
+              <Input
+                id="loc"
+                value={location}
+                onChange={(event) => setLocation(event.target.value)}
+                placeholder="Optional · e.g. Remote, San Francisco"
+              />
+            </div>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={remoteOnly}
+                onChange={(event) => setRemoteOnly(event.target.checked)}
+                className="size-4"
+              />
+              Remote roles only
+            </label>
 
-          {error ? (
-            <p role="alert" className="text-destructive text-sm font-medium">
-              {error}
-            </p>
-          ) : null}
+            {error ? (
+              <p role="alert" className="text-destructive text-sm font-medium">
+                {error}
+              </p>
+            ) : null}
 
-          <Button onClick={finish} disabled={saving} className="w-full">
-            {saving ? <Loader2 className="size-4 animate-spin" /> : null}
-            Continue to dashboard
-          </Button>
-        </CardContent>
+            <div className="flex items-center gap-3">
+              <Button onClick={discover} disabled={saving} className="flex-1">
+                {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+                Find matching jobs
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  router.push('/dashboard');
+                  router.refresh();
+                }}
+                disabled={saving}
+              >
+                Skip for now
+              </Button>
+            </div>
+          </CardContent>
+        )}
       </Card>
     </main>
   );

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { saveResumeText, uploadResumeFile, createSavedSearch, runDiscovery } from '@/lib/api';
@@ -202,15 +203,12 @@ export default function OnboardingPage() {
                 placeholder="Optional · e.g. Remote, San Francisco"
               />
             </div>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={remoteOnly}
-                onChange={(event) => setRemoteOnly(event.target.checked)}
-                className="size-4"
-              />
-              Remote roles only
-            </label>
+            <div className="flex items-center gap-2">
+              <Switch id="remote" checked={remoteOnly} onCheckedChange={setRemoteOnly} />
+              <Label htmlFor="remote" className="text-sm font-normal">
+                Remote roles only
+              </Label>
+            </div>
 
             {error ? (
               <p role="alert" className="text-destructive text-sm font-medium">

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -13,6 +13,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { saveResumeText, uploadResumeFile, createSavedSearch, runDiscovery } from '@/lib/api';
 
+// Mirrors the Adzuna source: these "locations" aren't geographic, so they're
+// ignored as a `where` filter — we treat them as a remote-only signal instead.
+const NON_GEOGRAPHIC_LOCATIONS = new Set(['remote', 'anywhere', 'worldwide', 'global']);
+
 export default function OnboardingPage() {
   const router = useRouter();
 
@@ -62,10 +66,15 @@ export default function OnboardingPage() {
     setSaving(true);
     setError(null);
     try {
+      // A non-geographic "location" (e.g. "Remote") is dropped by the Adzuna
+      // source and does nothing; it's the remoteOnly flag that biases toward
+      // remote roles. Normalize so a user who types one still gets a remote feed.
+      const trimmedLocation = location.trim();
+      const isRemoteLocation = NON_GEOGRAPHIC_LOCATIONS.has(trimmedLocation.toLowerCase());
       await createSavedSearch({
         query: trimmed,
-        location: location.trim() || undefined,
-        remoteOnly,
+        location: isRemoteLocation ? undefined : trimmedLocation || undefined,
+        remoteOnly: remoteOnly || isRemoteLocation,
       });
       try {
         const result = await runDiscovery();
@@ -200,7 +209,7 @@ export default function OnboardingPage() {
                 id="loc"
                 value={location}
                 onChange={(event) => setLocation(event.target.value)}
-                placeholder="Optional · e.g. Remote, San Francisco"
+                placeholder="Optional · e.g. San Francisco (use the toggle for remote)"
               />
             </div>
             <div className="flex items-center gap-2">

--- a/docs/superpowers/plans/2026-06-24-jobs-feed-pr-b-discovery-ux.md
+++ b/docs/superpowers/plans/2026-06-24-jobs-feed-pr-b-discovery-ux.md
@@ -1,0 +1,327 @@
+# Jobs Feed — PR B (discovery in Jobs + onboarding step 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Put job discovery where users look for jobs (the Jobs tab) and capture target roles/location during onboarding so a new user lands on a populated feed.
+
+**Architecture:** The `SavedSearchesManager` client component (add/list/delete saved searches + "Discover now") already exists and is rendered in Settings. PR B relocates it into the Jobs page and removes the Settings copy, then turns the single-step onboarding into a two-step wizard whose second step captures target criteria, creates the first saved search, runs an initial discovery, and routes to `/jobs`.
+
+**Tech Stack:** Next.js App Router (server + client components), React, Vitest + Testing Library. Spec: `docs/superpowers/specs/2026-06-24-jobs-feed-design.md` (tasks 2.1, 2.2).
+
+**Branch:** `feat/jobs-feed-pr-b` (already created).
+
+**Scope:** PR B of 4. Out of scope: recency filters + cards (PR C), cron (PR D).
+
+---
+
+## Existing API helpers (web, `@/lib/api`) — reuse, do not change
+- `createSavedSearch({ query, location?, remoteOnly? }): Promise<SavedSearchItem>`
+- `runDiscovery(): Promise<{ inserted; skipped; source }>`
+- `fetchSavedSearches()`, `deleteSavedSearch(id)` (used inside `SavedSearchesManager`)
+- `saveResumeText(text)`, `uploadResumeFile(file)` (onboarding step 1, existing)
+
+---
+
+## Task 1: Onboarding step 2 — capture target roles/location
+
+**Files:**
+- Modify: `apps/web/src/app/onboarding/page.tsx`
+- Test: `apps/web/src/app/onboarding/onboarding-page.test.tsx`
+
+The page becomes a two-step wizard via a `step` state (`1 | 2`). Step 1 keeps the resume UI but its button advances to step 2 instead of routing to the dashboard. Step 2 captures a role/keywords query (required), location (optional), and a remote-only toggle, then creates a saved search, runs discovery, and routes to `/jobs`. A "Skip for now" link routes to `/dashboard`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace `apps/web/src/app/onboarding/onboarding-page.test.tsx` with:
+
+```tsx
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, expect, it, vi } from 'vitest';
+
+const { push, refresh } = vi.hoisted(() => ({ push: vi.fn(), refresh: vi.fn() }));
+const { saveResumeText, uploadResumeFile, createSavedSearch, runDiscovery } = vi.hoisted(() => ({
+  saveResumeText: vi.fn(() => Promise.resolve(null)),
+  uploadResumeFile: vi.fn(() => Promise.resolve(null)),
+  createSavedSearch: vi.fn(() => Promise.resolve({ id: 's1' })),
+  runDiscovery: vi.fn(() => Promise.resolve({ inserted: 3, skipped: 0, source: 'adzuna' })),
+}));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push, refresh }) }));
+vi.mock('@/lib/api', () => ({ saveResumeText, uploadResumeFile, createSavedSearch, runDiscovery }));
+
+import OnboardingPage from './page';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+it('shows an inline alert (in addition to the toast) when continuing with no resume', async () => {
+  const user = userEvent.setup();
+  render(<OnboardingPage />);
+
+  expect(screen.queryByRole('alert')).toBeNull();
+  await user.click(screen.getByRole('button', { name: /continue/i }));
+
+  const alert = await screen.findByRole('alert');
+  expect(alert).toHaveTextContent(/add your resume to continue/i);
+});
+
+it('advances to the target-roles step after a resume is saved, then discovers and routes to jobs', async () => {
+  const user = userEvent.setup();
+  render(<OnboardingPage />);
+
+  // Step 1: paste a resume and continue.
+  await user.click(screen.getByRole('tab', { name: /paste text/i }));
+  await user.type(screen.getByPlaceholderText(/paste your resume text/i), 'Senior TypeScript engineer.');
+  await user.click(screen.getByRole('button', { name: /continue/i }));
+
+  // Step 2 appears: enter target role + discover.
+  const roleInput = await screen.findByLabelText(/role or keywords/i);
+  await user.type(roleInput, 'AI Engineer');
+  await user.click(screen.getByRole('button', { name: /find matching jobs/i }));
+
+  await waitFor(() => expect(createSavedSearch).toHaveBeenCalledWith({
+    query: 'AI Engineer',
+    location: undefined,
+    remoteOnly: false,
+  }));
+  expect(runDiscovery).toHaveBeenCalledOnce();
+  await waitFor(() => expect(push).toHaveBeenCalledWith('/jobs'));
+});
+
+it('requires a role/keyword before discovering on step 2', async () => {
+  const user = userEvent.setup();
+  render(<OnboardingPage />);
+
+  await user.click(screen.getByRole('tab', { name: /paste text/i }));
+  await user.type(screen.getByPlaceholderText(/paste your resume text/i), 'Engineer.');
+  await user.click(screen.getByRole('button', { name: /continue/i }));
+
+  await screen.findByLabelText(/role or keywords/i);
+  await user.click(screen.getByRole('button', { name: /find matching jobs/i }));
+
+  expect(await screen.findByRole('alert')).toHaveTextContent(/add at least one role or keyword/i);
+  expect(createSavedSearch).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/web" && npx vitest run src/app/onboarding/onboarding-page.test.tsx`
+Expected: FAIL — there is no step 2, no "Find matching jobs" button, and the button currently reads "Continue to dashboard".
+
+- [ ] **Step 3: Implement the two-step wizard**
+
+Rewrite `apps/web/src/app/onboarding/page.tsx`. Keep all existing step-1 resume markup (tabs, file input, paste textarea, inline error). Apply these changes:
+
+1. Add imports: `createSavedSearch`, `runDiscovery` to the existing `@/lib/api` import; add `Input`, `Label` from `@/components/ui/input` / `@/components/ui/label`.
+2. Add state: `const [step, setStep] = useState<1 | 2>(1);`, `const [query, setQuery] = useState('')`, `const [location, setLocation] = useState('')`, `const [remoteOnly, setRemoteOnly] = useState(false)`.
+3. Rename `finish` to `saveResume`. On success (resume saved), call `setStep(2)` instead of `router.push('/dashboard')`. Keep the no-resume inline-alert validation. Its button label becomes `Continue`.
+4. Add `discover()`:
+
+```tsx
+  async function discover() {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      const message = 'Add at least one role or keyword to find jobs.';
+      setError(message);
+      toast.error(message);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await createSavedSearch({
+        query: trimmed,
+        location: location.trim() || undefined,
+        remoteOnly,
+      });
+      try {
+        const result = await runDiscovery();
+        toast.success(
+          result.inserted > 0
+            ? `Found ${result.inserted} matching job${result.inserted === 1 ? '' : 's'}.`
+            : 'Search saved — new jobs will appear as they’re posted.',
+        );
+      } catch {
+        // The search is saved; discovery can run later (manual button or cron).
+        toast.success('Search saved — we’ll pull matching jobs shortly.');
+      }
+      router.push('/jobs');
+      router.refresh();
+    } catch {
+      toast.error('Could not save your search. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  }
+```
+
+5. Render step 2 when `step === 2` (replace the resume `CardContent` body). Use this block for the step-2 content (header text + form):
+
+```tsx
+        <CardContent className="space-y-5">
+          <div className="space-y-1.5">
+            <Label htmlFor="role">Role or keywords</Label>
+            <Input
+              id="role"
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                if (event.target.value.trim()) setError(null);
+              }}
+              placeholder="e.g. AI Engineer, automation"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="loc">Location</Label>
+            <Input
+              id="loc"
+              value={location}
+              onChange={(event) => setLocation(event.target.value)}
+              placeholder="Optional · e.g. Remote, San Francisco"
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={remoteOnly}
+              onChange={(event) => setRemoteOnly(event.target.checked)}
+              className="size-4"
+            />
+            Remote roles only
+          </label>
+
+          {error ? (
+            <p role="alert" className="text-destructive text-sm font-medium">
+              {error}
+            </p>
+          ) : null}
+
+          <div className="flex items-center gap-3">
+            <Button onClick={discover} disabled={saving} className="flex-1">
+              {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+              Find matching jobs
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                router.push('/dashboard');
+                router.refresh();
+              }}
+              disabled={saving}
+            >
+              Skip for now
+            </Button>
+          </div>
+        </CardContent>
+```
+
+6. Update the `CardHeader` title/description to reflect the step: step 1 keeps the resume copy; step 2 shows title `What roles are you targeting?` and description `We’ll pull matching postings into your feed, already scored against your resume.` Wrap the resume `CardContent` so it only renders when `step === 1`, and the step-2 `CardContent` only when `step === 2`. Keep the `Sparkles` icon block.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/web" && npx vitest run src/app/onboarding/onboarding-page.test.tsx`
+Expected: PASS (3 tests).
+
+Then: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/web" && npm run lint && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot" && git add apps/web/src/app/onboarding/page.tsx apps/web/src/app/onboarding/onboarding-page.test.tsx && git commit -F - <<'EOF'
+feat(web): onboarding step 2 captures target roles → first discovery (#119)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01YY7NVS3QLuFeTqkmBaidAB
+EOF
+```
+
+---
+
+## Task 2: Move the discovery panel from Settings into Jobs
+
+**Files:**
+- Modify: `apps/web/src/app/(app)/jobs/page.tsx`
+- Modify: `apps/web/src/app/(app)/settings/page.tsx`
+
+- [ ] **Step 1: Add the discovery panel to the Jobs page**
+
+In `apps/web/src/app/(app)/jobs/page.tsx`:
+
+Add the import:
+```ts
+import { SavedSearchesManager } from '@/components/saved-searches';
+```
+
+Insert a discovery `SectionCard` directly above the existing "Job pipeline" `SectionCard`:
+```tsx
+      <SectionCard
+        title="Find new jobs"
+        description="Save target searches, then pull real postings into your pipeline — already scored against your resume."
+      >
+        <SavedSearchesManager />
+      </SectionCard>
+```
+
+- [ ] **Step 2: Remove the discovery panel from Settings**
+
+In `apps/web/src/app/(app)/settings/page.tsx`:
+
+Remove the import `import { SavedSearchesManager } from '@/components/saved-searches';` (line 3).
+
+Remove the entire "Job discovery" `SectionCard` block:
+```tsx
+      <SectionCard title="Job discovery" description="Save searches, then pull real postings into your CRM.">
+        <SavedSearchesManager />
+      </SectionCard>
+```
+
+- [ ] **Step 3: Typecheck, lint, build**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/web" && npm run typecheck && npm run lint`
+Expected: no errors (verifies no dangling `SavedSearchesManager` reference in Settings).
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/web" && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot" && git add "apps/web/src/app/(app)/jobs/page.tsx" "apps/web/src/app/(app)/settings/page.tsx" && git commit -F - <<'EOF'
+feat(web): move job discovery from Settings into the Jobs tab (#119)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01YY7NVS3QLuFeTqkmBaidAB
+EOF
+```
+
+---
+
+## Task 3: Full verification + open PR
+
+- [ ] **Step 1: Run the full web suite + API suite**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/web" && npm test`
+Expected: all PASS.
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && node scripts/run-tests.mjs`
+Expected: all PASS (unchanged — PR B is web-only).
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot" && git push -u origin feat/jobs-feed-pr-b
+```
+
+Then open the PR with `gh pr create` (base `main`), title `feat: discovery in the Jobs tab + onboarding step 2 (#118 → #119 · PR B)`, body summarising the relocation + onboarding wizard, ending with the Generated-with line.
+
+---
+
+## Self-review notes
+- **Spec coverage:** 2.1 (relocate discovery → Jobs, remove Settings copy) = Task 2; 2.2 (onboarding criteria capture → first saved search + discovery) = Task 1.
+- **Type consistency:** `createSavedSearch({ query, location?, remoteOnly? })` and `runDiscovery()` match `@/lib/api`. `step` is `1 | 2`. The no-resume validation message (`add your resume to continue`) and step-2 message (`add at least one role or keyword`) match the tests.
+- **No placeholders:** all code shown in full; commands include expected output.


### PR DESCRIPTION
Phase 2 PR B — put job discovery where users look for jobs, and capture target criteria during onboarding so a new account lands on a populated feed.

Design spec: \`docs/superpowers/specs/2026-06-24-jobs-feed-design.md\` (tasks 2.1, 2.2) · Plan: \`docs/superpowers/plans/2026-06-24-jobs-feed-pr-b-discovery-ux.md\`

## What's in this PR

**Discovery moved into Jobs (2.1):**
- The \`SavedSearchesManager\` panel (saved searches + "Discover now") now renders in a "Find new jobs" card above the pipeline on the Jobs page, and is removed from Settings.

**Onboarding step 2 (2.2):**
- Onboarding is now a two-step wizard. Step 1 (resume) advances to step 2 instead of routing to the dashboard.
- Step 2 captures role/keywords (required) + location (optional) + a remote-only \`Switch\`, then creates the first saved search, runs an initial discovery, and routes to \`/jobs\`. A "Skip for now" link goes to the dashboard.
- A failed discovery is non-fatal (the saved search is still created); a failed save keeps the user on step 2 with a toast.

## Verification
- Web vitest: **42 pass** (onboarding wizard happy-path / validation / skip; jobs-page query normalization with the panel stubbed). API suite **119 pass** (unchanged — web-only PR). typecheck + lint + build clean.

## Notes
- Out of scope (later PRs): recency filters + matched-skills/"estimated" on cards (C), GitHub Actions cron (D).
- Includes one in-session code-review pass (swapped the native checkbox for the shadcn \`Switch\`; added the skip-path test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)