### PR TITLE
feat: scheduled jobs-feed discovery cron (#118 → #119 · PR D)

### DIFF
--- a/.github/workflows/discover.yml
+++ b/.github/workflows/discover.yml
@@ -1,0 +1,67 @@
+# Scheduled jobs-feed discovery sweep.
+#
+# Drives the "background auto-refresh" half of the Jobs feed (Phase 2): every few
+# hours it POSTs the service-to-service sweep endpoint, which runs every user's
+# saved searches against the job sources, inserts new postings, and pre-ranks
+# them against each user's resume. The endpoint itself lives in the API
+# (`POST /api/n8n/discover`, guarded by the n8n webhook secret); this workflow is
+# just the clock.
+#
+# Inert until configured: it skips cleanly unless BOTH the `NEXT_PUBLIC_API_BASE_URL`
+# repo variable (the API origin — already set for the web deploy) and the
+# `N8N_WEBHOOK_SECRET` repo secret (matching the API's env) are present.
+name: Discover jobs (scheduled sweep)
+
+on:
+  schedule:
+    - cron: '0 */6 * * *' # every 6 hours
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: discover-sweep
+  # Let an in-flight sweep finish rather than cancelling it mid-insert.
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    name: Sweep saved searches for new postings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger the discovery sweep
+        env:
+          API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_BASE_URL }}
+          N8N_WEBHOOK_SECRET: ${{ secrets.N8N_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${API_BASE_URL:-}" ] || [ -z "${N8N_WEBHOOK_SECRET:-}" ]; then
+            echo "::notice::Skipping — set the NEXT_PUBLIC_API_BASE_URL variable and the N8N_WEBHOOK_SECRET secret to activate the scheduled jobs feed."
+            exit 0
+          fi
+
+          url="${API_BASE_URL%/}/api/n8n/discover"
+          echo "POST ${url}"
+
+          # -w appends the status code on its own line; split body vs code below.
+          # The secret only travels in a request header (never echoed); Actions
+          # also masks registered secrets in logs.
+          response="$(curl -sS -X POST "${url}" \
+            -H 'Content-Type: application/json' \
+            -H "X-N8N-Webhook-Secret: ${N8N_WEBHOOK_SECRET}" \
+            --retry 3 --retry-delay 5 --max-time 120 \
+            -w '\n%{http_code}' \
+            -d '{}')"
+
+          body="$(printf '%s' "${response}" | sed '$d')"
+          code="$(printf '%s' "${response}" | tail -n1)"
+
+          echo "HTTP ${code}"
+          echo "${body}"
+
+          if [ "${code}" -lt 200 ] || [ "${code}" -ge 300 ]; then
+            echo "::error::Discovery sweep failed (HTTP ${code})." >&2
+            exit 1
+          fi

--- a/docs/AUTOMATION_WORKFLOWS.md
+++ b/docs/AUTOMATION_WORKFLOWS.md
@@ -14,8 +14,29 @@ The workflows build on the endpoints that already exist:
 - `POST /api/ai/generate-weekly-report` for weekly summaries
 - `GET /api/reports` and `GET /api/reports/latest` for saved weekly report history
 - `POST /api/n8n/job-intake` for webhook-driven job creation, parsing, and optional fit scoring
+- `POST /api/n8n/discover` to sweep every saved-search user, pull new postings, and pre-rank them against each resume
 - `POST /api/n8n/follow-up-reminders` for scheduled reminder queues
 - `POST /api/n8n/weekly-report` for weekly digest drafts
+
+## Scheduled discovery (built-in)
+
+The Jobs feed's background auto-refresh ships in-repo as a GitHub Actions cron —
+no external orchestrator required. `.github/workflows/discover.yml` runs every 6
+hours (and on manual `workflow_dispatch`) and POSTs `/api/n8n/discover`, which
+runs each user's saved searches, inserts new postings, and pre-ranks them
+against their resume (the real LLM fit score then runs when a job is opened).
+
+It's **inert until configured** — the job skips cleanly unless both are set in
+the repo's Actions settings:
+
+- Variable `NEXT_PUBLIC_API_BASE_URL` — the API origin (already set for the web
+  deploy), e.g. `https://jobops-api.azurewebsites.net`.
+- Secret `N8N_WEBHOOK_SECRET` — must match the API's `N8N_WEBHOOK_SECRET` env so
+  the `X-N8N-Webhook-Secret` header is accepted.
+
+Swap to an external scheduler (n8n, Make, Azure scheduled task) any time by
+pointing it at the same endpoint with the same header; the workflow is just the
+clock.
 
 ## n8n
 


### PR DESCRIPTION
Phase 2 PR D (final slice) — the background auto-refresh that keeps the Jobs feed fresh.

Design spec: \`docs/superpowers/specs/2026-06-24-jobs-feed-design.md\` (task 2.4).

## What's in this PR
- **\`.github/workflows/discover.yml\`** — a GitHub Actions cron (every 6h + manual \`workflow_dispatch\`) that POSTs the existing \`/api/n8n/discover\` sweep with the \`X-N8N-Webhook-Secret\` header. The sweep runs every saved-search user's searches, inserts new postings, and pre-ranks them against each resume (the real LLM fit then runs on job open, per PR A).
- **Docs** — \`AUTOMATION_WORKFLOWS.md\` gains the \`/api/n8n/discover\` hook + a "Scheduled discovery (built-in)" section.

## Activation (owner action — the workflow is inert until then)
It **skips cleanly** unless both are set in the repo's Actions settings:
- Variable \`NEXT_PUBLIC_API_BASE_URL\` — the API origin (already set for the web deploy).
- Secret \`N8N_WEBHOOK_SECRET\` — must match the API's env so the header is accepted.

Swap to an external scheduler (n8n / Make / Azure task) any time by pointing it at the same endpoint + header.

## Verification
- Workflow YAML mirrors the existing \`agent-drift-check.yml\` structure; embedded bash validated (\`bash -n\`) and the unconfigured skip-path exits 0. No app code changed.

## Notes
This completes Phase 2 (#119): pre-rank + score-on-open (A), discovery-in-Jobs + onboarding (B), recency/cards (C), and this scheduler (D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)