### PR TITLE
feat: server-side job-URL extract endpoint (#118 → #120 · PR A)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,7 +23,8 @@
     "multer": "^2.0.1",
     "node-html-parser": "^7.1.0",
     "pdf-parse": "^1.1.1",
-    "pg": "^8.20.0"
+    "pg": "^8.20.0",
+    "undici": "^7.28.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "express-rate-limit": "^8.5.2",
     "helmet": "^8.2.0",
     "multer": "^2.0.1",
+    "node-html-parser": "^7.1.0",
     "pdf-parse": "^1.1.1",
     "pg": "^8.20.0"
   },

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -10,6 +10,7 @@ import { aiRouter } from '@/routes/ai';
 import { assistantStreamRouter } from '@/routes/assistant';
 import { demoRouter } from '@/routes/demo';
 import { healthRouter } from '@/routes/health';
+import { jobExtractRouter } from '@/routes/job-extract';
 import { jobsRouter } from '@/routes/jobs';
 import { n8nRouter } from '@/routes/n8n';
 import { profileRouter } from '@/routes/profile';
@@ -74,6 +75,7 @@ export function createApp() {
   app.use(globalLimiter);
 
   app.use('/api', healthRouter);
+  app.use('/api/jobs', jobExtractRouter);
   app.use('/api/jobs', jobsRouter);
   // SSE assistant stream: mounted at the exact path (before the AI router) so it pipes
   // unbuffered and doesn't double-apply the AI guards to /assistant/run|resume.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -75,7 +75,9 @@ export function createApp() {
   app.use(globalLimiter);
 
   app.use('/api', healthRouter);
-  app.use('/api/jobs', jobExtractRouter);
+  // The extract endpoint makes an outbound fetch per call, so it gets the strict
+  // limiter (like AI/discovery) — scoped to /extract only, not the jobs CRUD.
+  app.use('/api/jobs/extract', strictLimiter, jobExtractRouter);
   app.use('/api/jobs', jobsRouter);
   // SSE assistant stream: mounted at the exact path (before the AI router) so it pipes
   // unbuffered and doesn't double-apply the AI guards to /assistant/run|resume.

--- a/apps/api/src/lib/job-url-extract.test.ts
+++ b/apps/api/src/lib/job-url-extract.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { extractJobFromHtml } from './job-url-extract';
+
+const JSONLD = `<!doctype html><html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting","title":"AI Engineer",
+ "description":"<p>Build <b>agents</b> with TypeScript.</p>",
+ "hiringOrganization":{"@type":"Organization","name":"Pebble"},
+ "jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"San Francisco","addressRegion":"CA","addressCountry":"US"}},
+ "jobLocationType":"TELECOMMUTE"}
+</script></head><body><h1>Ignored</h1></body></html>`;
+
+test('extracts a JSON-LD JobPosting', () => {
+  const result = extractJobFromHtml(JSONLD);
+  assert.equal(result.source, 'jsonld');
+  assert.equal(result.title, 'AI Engineer');
+  assert.equal(result.company, 'Pebble');
+  assert.equal(result.location, 'San Francisco, CA, US');
+  assert.equal(result.workplaceType, 'remote');
+  assert.match(result.descriptionText ?? '', /Build agents with TypeScript/);
+});
+
+test('falls back to OpenGraph / meta tags', () => {
+  const html = `<html><head>
+    <meta property="og:title" content="Backend Engineer">
+    <meta property="og:site_name" content="Acme">
+    <meta property="og:description" content="Go and Postgres.">
+    <title>Backend Engineer — Acme</title></head><body></body></html>`;
+  const result = extractJobFromHtml(html);
+  assert.equal(result.source, 'opengraph');
+  assert.equal(result.title, 'Backend Engineer');
+  assert.equal(result.company, 'Acme');
+  assert.equal(result.descriptionText, 'Go and Postgres.');
+});
+
+test('uses a heuristic when there is no structured data', () => {
+  const html = `<html><head><title>x</title></head><body>
+    <script>var a=1;</script><h1>Data Scientist</h1>
+    <article>We need pandas and SQL skills for this role.</article></body></html>`;
+  const result = extractJobFromHtml(html);
+  assert.equal(result.title, 'Data Scientist');
+  assert.match(result.descriptionText ?? '', /pandas and SQL/);
+  assert.ok(result.source === 'heuristic' || result.source === 'opengraph');
+});
+
+test('skips malformed JSON-LD without throwing', () => {
+  const html = `<html><head>
+    <script type="application/ld+json">{ not json }</script>
+    <meta property="og:title" content="Still Works"></head><body></body></html>`;
+  const result = extractJobFromHtml(html);
+  assert.equal(result.title, 'Still Works');
+});
+
+test('returns source "none" for an empty page', () => {
+  const result = extractJobFromHtml('<html><head></head><body></body></html>');
+  assert.equal(result.source, 'none');
+  assert.equal(result.title, undefined);
+});

--- a/apps/api/src/lib/job-url-extract.test.ts
+++ b/apps/api/src/lib/job-url-extract.test.ts
@@ -41,7 +41,38 @@ test('uses a heuristic when there is no structured data', () => {
   const result = extractJobFromHtml(html);
   assert.equal(result.title, 'Data Scientist');
   assert.match(result.descriptionText ?? '', /pandas and SQL/);
-  assert.ok(result.source === 'heuristic' || result.source === 'opengraph');
+  assert.equal(result.source, 'heuristic');
+});
+
+test('reads a JobPosting nested in an @graph with an array @type', () => {
+  const html = `<html><head><script type="application/ld+json">
+    {"@context":"https://schema.org","@graph":[
+      {"@type":"Organization","name":"Ignored"},
+      {"@type":["JobPosting","Thing"],"title":"Graph Role","hiringOrganization":"StringCo"}
+    ]}</script></head><body></body></html>`;
+  const result = extractJobFromHtml(html);
+  assert.equal(result.source, 'jsonld');
+  assert.equal(result.title, 'Graph Role');
+  // hiringOrganization given as a bare string maps to company.
+  assert.equal(result.company, 'StringCo');
+});
+
+test('joins the first jobLocation when it is given as an array', () => {
+  const html = `<html><head><script type="application/ld+json">
+    {"@type":"JobPosting","title":"Multi","jobLocation":[
+      {"@type":"Place","address":{"addressLocality":"Austin","addressRegion":"TX"}},
+      {"@type":"Place","address":{"addressLocality":"Denver"}}
+    ]}</script></head><body></body></html>`;
+  const result = extractJobFromHtml(html);
+  assert.equal(result.location, 'Austin, TX');
+});
+
+test('falls back to <title> in the heuristic tier when there is no h1', () => {
+  const html = `<html><head><title>Lone Title Role</title></head><body>
+    <p>Some role description text here.</p></body></html>`;
+  const result = extractJobFromHtml(html);
+  assert.equal(result.title, 'Lone Title Role');
+  assert.equal(result.source, 'heuristic');
 });
 
 test('skips malformed JSON-LD without throwing', () => {

--- a/apps/api/src/lib/job-url-extract.test.ts
+++ b/apps/api/src/lib/job-url-extract.test.ts
@@ -57,7 +57,7 @@ test('reads a JobPosting nested in an @graph with an array @type', () => {
   assert.equal(result.company, 'StringCo');
 });
 
-test('joins the first jobLocation when it is given as an array', () => {
+test('uses the first jobLocation when it is given as an array', () => {
   const html = `<html><head><script type="application/ld+json">
     {"@type":"JobPosting","title":"Multi","jobLocation":[
       {"@type":"Place","address":{"addressLocality":"Austin","addressRegion":"TX"}},

--- a/apps/api/src/lib/job-url-extract.ts
+++ b/apps/api/src/lib/job-url-extract.ts
@@ -108,6 +108,10 @@ function fromHeuristic(root: HTMLElement): Partial<ExtractedJob> {
 
 export function extractJobFromHtml(html: string): ExtractedJob {
   const root = parse(html);
+  // Evaluated eagerly left-to-right: fromJsonLd/fromMeta must read the tree
+  // BEFORE fromHeuristic mutates it (it strips script/style/etc.). Keep this
+  // order and don't wrap a tier in a lazy thunk, or the heuristic's mutation
+  // would race the earlier readers.
   const tiers: Array<[ExtractedJob['source'], Partial<ExtractedJob>]> = [
     ['jsonld', fromJsonLd(root)],
     ['opengraph', fromMeta(root)],

--- a/apps/api/src/lib/job-url-extract.ts
+++ b/apps/api/src/lib/job-url-extract.ts
@@ -1,0 +1,134 @@
+import { parse, type HTMLElement } from 'node-html-parser';
+
+export type WorkplaceType = 'remote' | 'hybrid' | 'onsite' | 'flexible';
+
+export interface ExtractedJob {
+  title?: string;
+  company?: string;
+  location?: string;
+  descriptionText?: string;
+  workplaceType?: WorkplaceType;
+  source: 'jsonld' | 'opengraph' | 'heuristic' | 'none';
+}
+
+function clean(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** JSON-LD descriptions are usually HTML; flatten to readable text. */
+function htmlToText(html: string): string | undefined {
+  const text = parse(html).structuredText.trim();
+  return text.length > 0 ? text : undefined;
+}
+
+function collectJsonLd(root: HTMLElement): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [];
+  for (const node of root.querySelectorAll('script[type="application/ld+json"]')) {
+    let data: unknown;
+    try {
+      data = JSON.parse(node.text);
+    } catch {
+      continue;
+    }
+    const items = Array.isArray(data) ? data : [data];
+    for (const item of items) {
+      if (item && typeof item === 'object') {
+        out.push(item as Record<string, unknown>);
+        const graph = (item as { '@graph'?: unknown })['@graph'];
+        if (Array.isArray(graph)) {
+          for (const g of graph) if (g && typeof g === 'object') out.push(g as Record<string, unknown>);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function hasJobPostingType(obj: Record<string, unknown>): boolean {
+  const t = obj['@type'];
+  return t === 'JobPosting' || (Array.isArray(t) && t.includes('JobPosting'));
+}
+
+function companyFrom(org: unknown): string | undefined {
+  if (typeof org === 'string') return clean(org);
+  if (org && typeof org === 'object') return clean((org as { name?: unknown }).name);
+  return undefined;
+}
+
+function locationFrom(loc: unknown): string | undefined {
+  const first = Array.isArray(loc) ? loc[0] : loc;
+  if (!first || typeof first !== 'object') return undefined;
+  const address = (first as { address?: unknown }).address;
+  if (typeof address === 'string') return clean(address);
+  if (!address || typeof address !== 'object') return undefined;
+  const a = address as Record<string, unknown>;
+  const parts = [a.addressLocality, a.addressRegion, a.addressCountry]
+    .map(clean)
+    .filter((p): p is string => p !== undefined);
+  return parts.length > 0 ? parts.join(', ') : undefined;
+}
+
+function fromJsonLd(root: HTMLElement): Partial<ExtractedJob> {
+  const job = collectJsonLd(root).find(hasJobPostingType);
+  if (!job) return {};
+  const desc = clean(job.description);
+  const locationType = typeof job.jobLocationType === 'string' ? job.jobLocationType.toUpperCase() : '';
+  return {
+    title: clean(job.title),
+    company: companyFrom(job.hiringOrganization),
+    location: locationFrom(job.jobLocation),
+    descriptionText: desc ? (htmlToText(desc) ?? desc) : undefined,
+    workplaceType: locationType === 'TELECOMMUTE' ? 'remote' : undefined,
+  };
+}
+
+function metaContent(root: HTMLElement, selector: string): string | undefined {
+  return clean(root.querySelector(selector)?.getAttribute('content'));
+}
+
+function fromMeta(root: HTMLElement): Partial<ExtractedJob> {
+  return {
+    title: metaContent(root, 'meta[property="og:title"]'),
+    company: metaContent(root, 'meta[property="og:site_name"]'),
+    descriptionText:
+      metaContent(root, 'meta[property="og:description"]') ?? metaContent(root, 'meta[name="description"]'),
+  };
+}
+
+function fromHeuristic(root: HTMLElement): Partial<ExtractedJob> {
+  const title =
+    clean(root.querySelector('h1')?.text) ?? clean(root.querySelector('title')?.text);
+  for (const node of root.querySelectorAll('script, style, nav, header, footer')) node.remove();
+  const body = root.querySelector('body') ?? root;
+  const text = body.structuredText.trim();
+  return { title, descriptionText: text.length > 0 ? text.slice(0, 20_000) : undefined };
+}
+
+export function extractJobFromHtml(html: string): ExtractedJob {
+  const root = parse(html);
+  const tiers: Array<[ExtractedJob['source'], Partial<ExtractedJob>]> = [
+    ['jsonld', fromJsonLd(root)],
+    ['opengraph', fromMeta(root)],
+    ['heuristic', fromHeuristic(root)],
+  ];
+
+  const result: ExtractedJob = { source: 'none' };
+  for (const [tier, data] of tiers) {
+    let used = false;
+    if (result.title === undefined && data.title !== undefined) { result.title = data.title; used = true; }
+    if (result.company === undefined && data.company !== undefined) { result.company = data.company; used = true; }
+    if (result.location === undefined && data.location !== undefined) { result.location = data.location; used = true; }
+    if (result.descriptionText === undefined && data.descriptionText !== undefined) {
+      result.descriptionText = data.descriptionText;
+      used = true;
+    }
+    if (result.workplaceType === undefined && data.workplaceType !== undefined) {
+      result.workplaceType = data.workplaceType;
+      used = true;
+    }
+    if (used && result.source === 'none') result.source = tier;
+  }
+  return result;
+}

--- a/apps/api/src/lib/job-url-extract.ts
+++ b/apps/api/src/lib/job-url-extract.ts
@@ -8,6 +8,11 @@ export interface ExtractedJob {
   location?: string;
   descriptionText?: string;
   workplaceType?: WorkplaceType;
+  /**
+   * Highest-priority tier that contributed at least one field (jsonld >
+   * opengraph > heuristic), or 'none'. Individual fields may come from lower
+   * tiers — `source` reflects the best signal seen, not every field's origin.
+   */
   source: 'jsonld' | 'opengraph' | 'heuristic' | 'none';
 }
 
@@ -36,6 +41,8 @@ function collectJsonLd(root: HTMLElement): Record<string, unknown>[] {
     for (const item of items) {
       if (item && typeof item === 'object') {
         out.push(item as Record<string, unknown>);
+        // One @graph level is expanded; nested graphs are vanishingly rare in
+        // job postings and not worth the recursion.
         const graph = (item as { '@graph'?: unknown })['@graph'];
         if (Array.isArray(graph)) {
           for (const g of graph) if (g && typeof g === 'object') out.push(g as Record<string, unknown>);
@@ -73,7 +80,9 @@ function locationFrom(loc: unknown): string | undefined {
 function fromJsonLd(root: HTMLElement): Partial<ExtractedJob> {
   const job = collectJsonLd(root).find(hasJobPostingType);
   if (!job) return {};
-  const desc = clean(job.description);
+  // Cap before the second parse() in htmlToText: a hostile page can embed a huge
+  // description string inside the (already 2 MB-capped) HTML.
+  const desc = clean(job.description)?.slice(0, 20_000);
   const locationType = typeof job.jobLocationType === 'string' ? job.jobLocationType.toUpperCase() : '';
   return {
     title: clean(job.title),

--- a/apps/api/src/lib/job-url-fetch.test.ts
+++ b/apps/api/src/lib/job-url-fetch.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { extractJobFromUrl, fetchJobPage } from './job-url-fetch';
+
+const okSafe = async (raw: string) => ({ ok: true as const, url: new URL(raw) });
+
+function htmlResponse(body: string, contentType = 'text/html; charset=utf-8', status = 200): Response {
+  return new Response(body, { status, headers: { 'content-type': contentType } });
+}
+
+test('fetchJobPage returns html for a safe, html, 200 page', async () => {
+  const page = await fetchJobPage('https://example.com/job', {
+    assertSafe: okSafe,
+    fetchImpl: async () => htmlResponse('<html><body>hi</body></html>'),
+  });
+  assert.equal(page.blocked, undefined);
+  assert.match(page.html ?? '', /hi/);
+});
+
+test('fetchJobPage blocks a non-html response', async () => {
+  const page = await fetchJobPage('https://example.com/x.pdf', {
+    assertSafe: okSafe,
+    fetchImpl: async () => htmlResponse('%PDF', 'application/pdf'),
+  });
+  assert.notEqual(page.blocked, undefined);
+  assert.equal(page.html, undefined);
+});
+
+test('fetchJobPage surfaces an SSRF rejection', async () => {
+  const page = await fetchJobPage('http://169.254.169.254/', {
+    assertSafe: async () => ({ ok: false as const, reason: 'blocked range' }),
+    fetchImpl: async () => htmlResponse('should not be reached'),
+  });
+  assert.equal(page.blocked, 'blocked range');
+});
+
+test('fetchJobPage re-validates a redirect target', async () => {
+  let calls = 0;
+  const page = await fetchJobPage('https://example.com/start', {
+    assertSafe: async (raw) =>
+      raw.includes('internal')
+        ? { ok: false as const, reason: 'redirect blocked' }
+        : { ok: true as const, url: new URL(raw) },
+    fetchImpl: async () => {
+      calls += 1;
+      return new Response(null, { status: 302, headers: { location: 'http://internal.local/' } });
+    },
+  });
+  assert.equal(page.blocked, 'redirect blocked');
+  assert.equal(calls, 1);
+});
+
+test('extractJobFromUrl maps a fetched page', async () => {
+  const result = await extractJobFromUrl('https://example.com/job', {
+    fetchPage: async () => ({
+      html: '<html><head><meta property="og:title" content="Mapped Role"></head><body></body></html>',
+    }),
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.data.title, 'Mapped Role');
+});
+
+test('extractJobFromUrl returns the block reason as an error', async () => {
+  const result = await extractJobFromUrl('http://10.0.0.1/', {
+    fetchPage: async () => ({ blocked: 'private address' }),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.ok === false && result.error, 'private address');
+});

--- a/apps/api/src/lib/job-url-fetch.test.ts
+++ b/apps/api/src/lib/job-url-fetch.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { extractJobFromUrl, fetchJobPage } from './job-url-fetch';
+import { anyAddressBlocked, extractJobFromUrl, fetchJobPage } from './job-url-fetch';
 
 const okSafe = async (raw: string) => ({ ok: true as const, url: new URL(raw) });
 
@@ -92,6 +92,27 @@ test('fetchJobPage stops after too many redirects', async () => {
     },
   });
   assert.equal(page.blocked, 'Too many redirects.');
+});
+
+test('anyAddressBlocked guards the connect-time resolution', () => {
+  // The connect-time SSRF check: block if no address, or any resolved address is private.
+  assert.equal(anyAddressBlocked([]), true);
+  assert.equal(anyAddressBlocked([{ address: '93.184.216.34' }]), false);
+  assert.equal(anyAddressBlocked([{ address: '93.184.216.34' }, { address: '169.254.169.254' }]), true);
+});
+
+test('fetchJobPage blocks (does not throw) when the body stream errors mid-read', async () => {
+  const erroring = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      controller.error(new Error('socket reset'));
+    },
+  });
+  const page = await fetchJobPage('https://example.com/job', {
+    assertSafe: okSafe,
+    fetchImpl: async () => new Response(erroring, { status: 200, headers: { 'content-type': 'text/html' } }),
+  });
+  assert.equal(page.blocked, 'Could not finish reading that page.');
+  assert.equal(page.html, undefined);
 });
 
 test('extractJobFromUrl maps a fetched page', async () => {

--- a/apps/api/src/lib/job-url-fetch.test.ts
+++ b/apps/api/src/lib/job-url-fetch.test.ts
@@ -50,6 +50,38 @@ test('fetchJobPage re-validates a redirect target', async () => {
   assert.equal(calls, 1);
 });
 
+test('fetchJobPage blocks a body over the 2 MB cap', async () => {
+  const big = 'x'.repeat(2_000_001);
+  const page = await fetchJobPage('https://example.com/big', {
+    assertSafe: okSafe,
+    fetchImpl: async () => htmlResponse(big),
+  });
+  assert.equal(page.blocked, 'That page is too large to read.');
+  assert.equal(page.html, undefined);
+});
+
+test('fetchJobPage blocks when the fetch throws (timeout/network)', async () => {
+  const page = await fetchJobPage('https://example.com/slow', {
+    assertSafe: okSafe,
+    fetchImpl: async () => {
+      throw new DOMException('timed out', 'TimeoutError');
+    },
+  });
+  assert.equal(page.blocked, 'Could not reach that page.');
+});
+
+test('fetchJobPage stops after too many redirects', async () => {
+  let n = 0;
+  const page = await fetchJobPage('https://example.com/r', {
+    assertSafe: okSafe,
+    fetchImpl: async () => {
+      n += 1;
+      return new Response(null, { status: 302, headers: { location: `https://example.com/r${n}` } });
+    },
+  });
+  assert.equal(page.blocked, 'Too many redirects.');
+});
+
 test('extractJobFromUrl maps a fetched page', async () => {
   const result = await extractJobFromUrl('https://example.com/job', {
     fetchPage: async () => ({

--- a/apps/api/src/lib/job-url-fetch.test.ts
+++ b/apps/api/src/lib/job-url-fetch.test.ts
@@ -115,6 +115,15 @@ test('fetchJobPage blocks (does not throw) when the body stream errors mid-read'
   assert.equal(page.html, undefined);
 });
 
+test('fetchJobPage blocks (does not throw) on a malformed redirect location', async () => {
+  const page = await fetchJobPage('https://example.com/start', {
+    assertSafe: okSafe,
+    fetchImpl: async () => new Response(null, { status: 302, headers: { location: 'http://[' } }),
+  });
+  assert.equal(page.blocked, 'That page redirected to an invalid URL.');
+  assert.equal(page.html, undefined);
+});
+
 test('extractJobFromUrl maps a fetched page', async () => {
   const result = await extractJobFromUrl('https://example.com/job', {
     fetchPage: async () => ({

--- a/apps/api/src/lib/job-url-fetch.test.ts
+++ b/apps/api/src/lib/job-url-fetch.test.ts
@@ -17,6 +17,18 @@ test('fetchJobPage returns html for a safe, html, 200 page', async () => {
   assert.match(page.html ?? '', /hi/);
 });
 
+test('fetchJobPage allows a response with no content-type header', async () => {
+  // A Uint8Array body does not get an auto content-type (unlike a string body),
+  // so this exercises the missing-header path.
+  const page = await fetchJobPage('https://example.com/job', {
+    assertSafe: okSafe,
+    fetchImpl: async () =>
+      new Response(new TextEncoder().encode('<html><body>ok</body></html>'), { status: 200 }),
+  });
+  assert.equal(page.blocked, undefined);
+  assert.match(page.html ?? '', /ok/);
+});
+
 test('fetchJobPage blocks a non-html response', async () => {
   const page = await fetchJobPage('https://example.com/x.pdf', {
     assertSafe: okSafe,

--- a/apps/api/src/lib/job-url-fetch.ts
+++ b/apps/api/src/lib/job-url-fetch.ts
@@ -1,0 +1,90 @@
+import { assertUrlSafe } from '@/lib/url-safety';
+import { extractJobFromHtml, type ExtractedJob } from '@/lib/job-url-extract';
+
+const MAX_BYTES = 2_000_000;
+const TIMEOUT_MS = 8_000;
+const MAX_REDIRECTS = 3;
+
+export interface FetchedPage {
+  html?: string;
+  blocked?: string;
+}
+
+export interface FetchDeps {
+  assertSafe?: typeof assertUrlSafe;
+  fetchImpl?: typeof fetch;
+}
+
+async function readCapped(response: Response, maxBytes: number): Promise<string | null> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const text = await response.text();
+    return Buffer.byteLength(text) > maxBytes ? null : text;
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/** Fetch a user URL behind the SSRF guard; never throws — returns `{ blocked }` on any failure. */
+export async function fetchJobPage(rawUrl: string, deps: FetchDeps = {}): Promise<FetchedPage> {
+  const assertSafe = deps.assertSafe ?? assertUrlSafe;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+
+  let target = rawUrl;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+    const safe = await assertSafe(target);
+    if (!safe.ok) return { blocked: safe.reason };
+
+    let response: Response;
+    try {
+      response = await fetchImpl(safe.url, {
+        redirect: 'manual',
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+        headers: { 'User-Agent': 'JobOpsCopilot/1.0 (+job-autofill)', Accept: 'text/html' },
+      });
+    } catch {
+      return { blocked: 'Could not reach that page.' };
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) return { blocked: 'Redirect without a destination.' };
+      target = new URL(location, safe.url).toString();
+      continue;
+    }
+    if (!response.ok) return { blocked: `The page returned HTTP ${response.status}.` };
+    if (!(response.headers.get('content-type') ?? '').includes('text/html')) {
+      return { blocked: 'That URL is not an HTML page.' };
+    }
+
+    const html = await readCapped(response, MAX_BYTES);
+    if (html === null) return { blocked: 'That page is too large to read.' };
+    return { html };
+  }
+  return { blocked: 'Too many redirects.' };
+}
+
+export type ExtractResult = { ok: true; data: ExtractedJob } | { ok: false; error: string };
+
+export interface ExtractDeps {
+  fetchPage?: typeof fetchJobPage;
+}
+
+export async function extractJobFromUrl(url: string, deps: ExtractDeps = {}): Promise<ExtractResult> {
+  const page = await (deps.fetchPage ?? fetchJobPage)(url);
+  if (page.blocked !== undefined || page.html === undefined) {
+    return { ok: false, error: page.blocked ?? 'Could not read that page.' };
+  }
+  return { ok: true, data: extractJobFromHtml(page.html) };
+}

--- a/apps/api/src/lib/job-url-fetch.ts
+++ b/apps/api/src/lib/job-url-fetch.ts
@@ -18,6 +18,8 @@ export interface FetchDeps {
 async function readCapped(response: Response, maxBytes: number): Promise<string | null> {
   const reader = response.body?.getReader();
   if (!reader) {
+    // Body-less Response — only test doubles hit this; Node's fetch always
+    // streams, so the streamed path below is what bounds memory in production.
     const text = await response.text();
     return Buffer.byteLength(text) > maxBytes ? null : text;
   }
@@ -64,7 +66,8 @@ export async function fetchJobPage(rawUrl: string, deps: FetchDeps = {}): Promis
       continue;
     }
     if (!response.ok) return { blocked: `The page returned HTTP ${response.status}.` };
-    if (!(response.headers.get('content-type') ?? '').includes('text/html')) {
+    const contentType = (response.headers.get('content-type') ?? '').split(';')[0]?.trim().toLowerCase();
+    if (contentType !== 'text/html') {
       return { blocked: 'That URL is not an HTML page.' };
     }
 

--- a/apps/api/src/lib/job-url-fetch.ts
+++ b/apps/api/src/lib/job-url-fetch.ts
@@ -1,9 +1,40 @@
-import { assertUrlSafe } from '@/lib/url-safety';
+import { lookup as dnsLookup, type LookupAddress } from 'node:dns';
+import type { LookupFunction } from 'node:net';
+import { Agent } from 'undici';
+import { assertUrlSafe, isBlockedAddress } from '@/lib/url-safety';
 import { extractJobFromHtml, type ExtractedJob } from '@/lib/job-url-extract';
 
 const MAX_BYTES = 2_000_000;
 const TIMEOUT_MS = 8_000;
 const MAX_REDIRECTS = 3;
+
+/** A pre-fetch SSRF check is point-in-time; the OS re-resolves the host when
+ *  `fetch` connects, so a hostile host can rebind DNS to a private IP between
+ *  the two. This connect-time guard re-checks the address actually being
+ *  connected to (and undici connects to exactly that address), closing the gap. */
+export function anyAddressBlocked(addresses: ReadonlyArray<{ address: string }>): boolean {
+  return addresses.length === 0 || addresses.some((a) => isBlockedAddress(a.address));
+}
+
+const safeLookup = (
+  hostname: string,
+  options: { all?: boolean } & Record<string, unknown>,
+  callback: (err: NodeJS.ErrnoException | null, address: string | LookupAddress[], family?: number) => void,
+): void => {
+  dnsLookup(hostname, { ...options, all: true }, (err, addresses) => {
+    if (err) return callback(err, []);
+    const list = addresses as LookupAddress[];
+    if (anyAddressBlocked(list)) {
+      return callback(Object.assign(new Error('Blocked address'), { code: 'EAI_FAIL' }), []);
+    }
+    if (options.all) return callback(null, list);
+    return callback(null, list[0]!.address, list[0]!.family);
+  });
+};
+
+// Reused dispatcher: every connection it makes is vetted at connect time.
+// (Cast bridges Node's overloaded LookupFunction signature to our handler.)
+const safeDispatcher = new Agent({ connect: { lookup: safeLookup as unknown as LookupFunction } });
 
 export interface FetchedPage {
   html?: string;
@@ -54,7 +85,11 @@ export async function fetchJobPage(rawUrl: string, deps: FetchDeps = {}): Promis
         redirect: 'manual',
         signal: AbortSignal.timeout(TIMEOUT_MS),
         headers: { 'User-Agent': 'JobOpsCopilot/1.0 (+job-autofill)', Accept: 'text/html' },
-      });
+        // undici reads `dispatcher`; the connect-time guard pins a vetted IP.
+        // Cast via unknown: `dispatcher` isn't in the DOM RequestInit type, and
+        // undici/undici-types versions differ structurally.
+        dispatcher: safeDispatcher,
+      } as unknown as RequestInit);
     } catch {
       return { blocked: 'Could not reach that page.' };
     }
@@ -73,7 +108,14 @@ export async function fetchJobPage(rawUrl: string, deps: FetchDeps = {}): Promis
       return { blocked: 'That URL is not an HTML page.' };
     }
 
-    const html = await readCapped(response, MAX_BYTES);
+    // Body read can still fail after headers arrive (timeout mid-stream, socket
+    // reset); keep the "never throws" contract by turning it into a block.
+    let html: string | null;
+    try {
+      html = await readCapped(response, MAX_BYTES);
+    } catch {
+      return { blocked: 'Could not finish reading that page.' };
+    }
     if (html === null) return { blocked: 'That page is too large to read.' };
     return { html };
   }

--- a/apps/api/src/lib/job-url-fetch.ts
+++ b/apps/api/src/lib/job-url-fetch.ts
@@ -1,6 +1,6 @@
 import { lookup as dnsLookup, type LookupAddress } from 'node:dns';
 import type { LookupFunction } from 'node:net';
-import { Agent } from 'undici';
+import { Agent, fetch as undiciFetch } from 'undici';
 import { assertUrlSafe, isBlockedAddress } from '@/lib/url-safety';
 import { extractJobFromHtml, type ExtractedJob } from '@/lib/job-url-extract';
 
@@ -72,7 +72,9 @@ async function readCapped(response: Response, maxBytes: number): Promise<string 
 /** Fetch a user URL behind the SSRF guard; never throws — returns `{ blocked }` on any failure. */
 export async function fetchJobPage(rawUrl: string, deps: FetchDeps = {}): Promise<FetchedPage> {
   const assertSafe = deps.assertSafe ?? assertUrlSafe;
-  const fetchImpl = deps.fetchImpl ?? fetch;
+  // Default to undici's own fetch (same package as the Agent above) so the
+  // `dispatcher` is honored — a global-fetch dispatcher is a cross-instance type.
+  const fetchImpl = deps.fetchImpl ?? (undiciFetch as unknown as typeof fetch);
 
   let target = rawUrl;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
@@ -97,7 +99,11 @@ export async function fetchJobPage(rawUrl: string, deps: FetchDeps = {}): Promis
     if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get('location');
       if (!location) return { blocked: 'Redirect without a destination.' };
-      target = new URL(location, safe.url).toString();
+      try {
+        target = new URL(location, safe.url).toString();
+      } catch {
+        return { blocked: 'That page redirected to an invalid URL.' };
+      }
       continue;
     }
     if (!response.ok) return { blocked: `The page returned HTTP ${response.status}.` };

--- a/apps/api/src/lib/job-url-fetch.ts
+++ b/apps/api/src/lib/job-url-fetch.ts
@@ -66,8 +66,10 @@ export async function fetchJobPage(rawUrl: string, deps: FetchDeps = {}): Promis
       continue;
     }
     if (!response.ok) return { blocked: `The page returned HTTP ${response.status}.` };
+    // Reject an explicit non-HTML type, but allow a missing content-type: some
+    // job boards omit it, and the extractor degrades to source:'none' on junk.
     const contentType = (response.headers.get('content-type') ?? '').split(';')[0]?.trim().toLowerCase();
-    if (contentType !== 'text/html') {
+    if (contentType && contentType !== 'text/html') {
       return { blocked: 'That URL is not an HTML page.' };
     }
 

--- a/apps/api/src/lib/url-safety.test.ts
+++ b/apps/api/src/lib/url-safety.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { assertUrlSafe, isBlockedAddress } from './url-safety';
+
+test('isBlockedAddress flags private / loopback / link-local ranges', () => {
+  for (const ip of ['127.0.0.1', '10.1.2.3', '192.168.0.5', '172.16.0.1', '169.254.169.254', '0.0.0.0', '::1', 'fe80::1', 'fd00::1']) {
+    assert.equal(isBlockedAddress(ip), true, `${ip} should be blocked`);
+  }
+});
+
+test('isBlockedAddress allows public addresses', () => {
+  for (const ip of ['93.184.216.34', '1.1.1.1', '2606:2800:220:1:248:1893:25c8:1946']) {
+    assert.equal(isBlockedAddress(ip), false, `${ip} should be allowed`);
+  }
+});
+
+test('assertUrlSafe rejects non-http(s) schemes without resolving', async () => {
+  for (const url of ['file:///etc/passwd', 'ftp://example.com', 'gopher://x']) {
+    const result = await assertUrlSafe(url, async () => [{ address: '93.184.216.34' }]);
+    assert.equal(result.ok, false);
+  }
+});
+
+test('assertUrlSafe rejects hosts that resolve to a blocked address', async () => {
+  const result = await assertUrlSafe('http://localhost/job', async () => [{ address: '127.0.0.1' }]);
+  assert.equal(result.ok, false);
+});
+
+test('assertUrlSafe accepts a public host', async () => {
+  const result = await assertUrlSafe('https://boards.greenhouse.io/x', async () => [{ address: '93.184.216.34' }]);
+  assert.equal(result.ok, true);
+});
+
+test('assertUrlSafe rejects an unparseable URL', async () => {
+  const result = await assertUrlSafe('not a url', async () => []);
+  assert.equal(result.ok, false);
+});

--- a/apps/api/src/lib/url-safety.test.ts
+++ b/apps/api/src/lib/url-safety.test.ts
@@ -14,6 +14,30 @@ test('isBlockedAddress allows public addresses', () => {
   }
 });
 
+test('isBlockedAddress closes IPv6 SSRF bypasses', () => {
+  for (const ip of [
+    'fe81::1', // fe80::/10 — a string-prefix "fe80" check would miss this
+    'febf::1',
+    'fc00::1', // unique-local fc half
+    '::ffff:169.254.169.254', // IPv4-mapped metadata (most common vector)
+    '::ffff:7f00:1', // IPv4-mapped loopback, hex-word form
+    '::169.254.169.254', // deprecated IPv4-compatible
+    '2002:a9fe:a9fe::1', // 6to4 embedding 169.254.169.254
+    '2001:0:1234::1', // Teredo
+    '100.64.0.1', // CGNAT
+    '100.127.255.255',
+  ]) {
+    assert.equal(isBlockedAddress(ip), true, `${ip} should be blocked`);
+  }
+});
+
+test('assertUrlSafe blocks a decimal-encoded IPv4 host (WHATWG normalizes it)', async () => {
+  // http://2130706433/ === 127.0.0.1; the URL parser normalizes the hostname,
+  // so the injected resolver receives the dotted form and isBlockedAddress catches it.
+  const result = await assertUrlSafe('http://2130706433/', async (host) => [{ address: host }]);
+  assert.equal(result.ok, false);
+});
+
 test('assertUrlSafe rejects non-http(s) schemes without resolving', async () => {
   for (const url of ['file:///etc/passwd', 'ftp://example.com', 'gopher://x']) {
     const result = await assertUrlSafe(url, async () => [{ address: '93.184.216.34' }]);

--- a/apps/api/src/lib/url-safety.ts
+++ b/apps/api/src/lib/url-safety.ts
@@ -20,13 +20,30 @@ function isBlockedV4(ip: string): boolean {
   return false;
 }
 
+function v4FromGroups(hi: number, lo: number): string {
+  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+}
+
 function isBlockedV6(ip: string): boolean {
   const addr = (ip.toLowerCase().split('%')[0]) as string; // drop any zone id
-  if (addr === '::1' || addr === '::') return true;
+  if (addr === '::1' || addr === '::') return true; // loopback / unspecified
+  // IPv4-mapped ::ffff:a.b.c.d (dotted) and ::ffff:HHHH:HHHH (hex-word) forms.
   const mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
   if (mapped) return isBlockedV4(mapped[1] as string);
-  if (addr.startsWith('fe80')) return true; // link-local fe80::/10
-  if (addr.startsWith('fc') || addr.startsWith('fd')) return true; // unique-local fc00::/7
+  const mappedHex = addr.match(/^::ffff:([\da-f]{1,4}):([\da-f]{1,4})$/);
+  if (mappedHex) {
+    return isBlockedV4(v4FromGroups(parseInt(mappedHex[1] as string, 16), parseInt(mappedHex[2] as string, 16)));
+  }
+  // IPv4-compatible (deprecated) ::a.b.c.d — e.g. ::169.254.169.254.
+  const compat = addr.match(/^::(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (compat) return isBlockedV4(compat[1] as string);
+  // 6to4 (2002::/16) and Teredo (2001:0::/32) embed/relay IPv4 — deprecated; block wholesale.
+  if (addr.startsWith('2002:') || addr.startsWith('2001:0:')) return true;
+  // Numeric range checks on the first 16-bit group (string prefixes miss
+  // fe81–febf and fc/fd written non-canonically).
+  const head = parseInt(addr.split(':')[0] as string, 16);
+  if (head >= 0xfe80 && head <= 0xfebf) return true; // link-local fe80::/10
+  if (head >= 0xfc00 && head <= 0xfdff) return true; // unique-local fc00::/7
   return false;
 }
 
@@ -38,7 +55,15 @@ export function isBlockedAddress(ip: string): boolean {
   return true; // not a valid IP literal — block defensively
 }
 
-/** Validate a user-supplied URL for server-side fetching (scheme + resolved IP). */
+/**
+ * Validate a user-supplied URL for server-side fetching (scheme + resolved IP).
+ *
+ * IMPORTANT: this check is point-in-time. The returned `url` is re-resolved by
+ * the OS when handed to `fetch`, leaving a DNS-rebinding (TOCTOU) window. The
+ * caller mitigates by following redirects manually and re-validating every hop
+ * (see `job-url-fetch.ts`); do not treat the returned `url` as unconditionally
+ * safe to fetch.
+ */
 export async function assertUrlSafe(
   rawUrl: string,
   lookup: LookupFn = defaultLookup,

--- a/apps/api/src/lib/url-safety.ts
+++ b/apps/api/src/lib/url-safety.ts
@@ -1,0 +1,65 @@
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+export type LookupFn = (hostname: string) => Promise<Array<{ address: string }>>;
+
+const defaultLookup: LookupFn = (hostname) => dnsLookup(hostname, { all: true });
+
+function isBlockedV4(ip: string): boolean {
+  const parts = ip.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return true;
+  const a = parts[0] as number;
+  const b = parts[1] as number;
+  if (a === 0) return true; // 0.0.0.0/8
+  if (a === 10) return true; // 10/8
+  if (a === 127) return true; // loopback
+  if (a === 169 && b === 254) return true; // link-local incl. 169.254.169.254 metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12
+  if (a === 192 && b === 168) return true; // 192.168/16
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT
+  return false;
+}
+
+function isBlockedV6(ip: string): boolean {
+  const addr = (ip.toLowerCase().split('%')[0]) as string; // drop any zone id
+  if (addr === '::1' || addr === '::') return true;
+  const mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (mapped) return isBlockedV4(mapped[1] as string);
+  if (addr.startsWith('fe80')) return true; // link-local fe80::/10
+  if (addr.startsWith('fc') || addr.startsWith('fd')) return true; // unique-local fc00::/7
+  return false;
+}
+
+/** True when an IP literal is in a private/loopback/link-local/metadata range. */
+export function isBlockedAddress(ip: string): boolean {
+  const kind = isIP(ip);
+  if (kind === 4) return isBlockedV4(ip);
+  if (kind === 6) return isBlockedV6(ip);
+  return true; // not a valid IP literal — block defensively
+}
+
+/** Validate a user-supplied URL for server-side fetching (scheme + resolved IP). */
+export async function assertUrlSafe(
+  rawUrl: string,
+  lookup: LookupFn = defaultLookup,
+): Promise<{ ok: true; url: URL } | { ok: false; reason: string }> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: 'Enter a valid URL.' };
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return { ok: false, reason: 'Only http and https URLs are supported.' };
+  }
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await lookup(url.hostname);
+  } catch {
+    return { ok: false, reason: 'Could not resolve that host.' };
+  }
+  if (addresses.length === 0 || addresses.some((a) => isBlockedAddress(a.address))) {
+    return { ok: false, reason: 'That URL points to a private or disallowed address.' };
+  }
+  return { ok: true, url };
+}

--- a/apps/api/src/routes/job-extract.test.ts
+++ b/apps/api/src/routes/job-extract.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+import express from 'express';
+import { createJobExtractRouter } from './job-extract';
+import type { ExtractResult } from '@/lib/job-url-fetch';
+
+async function withServer(
+  mount: (app: express.Express) => void,
+  run: (baseUrl: string) => Promise<void>,
+) {
+  const app = express();
+  app.use(express.json());
+  app.use((request, _response, next) => {
+    const header = request.header('X-User-Id');
+    if (header) request.userId = header.trim();
+    next();
+  });
+  mount(app);
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('no server address');
+  }
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+function mountExtract(extract: (url: string) => Promise<ExtractResult>) {
+  return (app: express.Express) => app.use('/api/jobs', createJobExtractRouter({ extract }));
+}
+
+test('POST /api/jobs/extract requires a signed-in user', async () => {
+  await withServer(mountExtract(async () => ({ ok: true, data: { source: 'none' } })), async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs/extract`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url: 'https://x/y' }),
+    });
+    assert.equal(response.status, 401);
+  });
+});
+
+test('POST /api/jobs/extract returns extracted fields', async () => {
+  await withServer(
+    mountExtract(async () => ({ ok: true, data: { title: 'AI Engineer', source: 'jsonld' } })),
+    async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/jobs/extract`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'X-User-Id': 'u1' },
+        body: JSON.stringify({ url: 'https://x/y' }),
+      });
+      assert.equal(response.status, 200);
+      const body = (await response.json()) as { title: string; source: string };
+      assert.equal(body.title, 'AI Engineer');
+      assert.equal(body.source, 'jsonld');
+    },
+  );
+});
+
+test('POST /api/jobs/extract returns 400 for a blocked URL', async () => {
+  await withServer(
+    mountExtract(async () => ({ ok: false, error: 'private address' })),
+    async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/jobs/extract`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'X-User-Id': 'u1' },
+        body: JSON.stringify({ url: 'http://10.0.0.1/' }),
+      });
+      assert.equal(response.status, 400);
+      const body = (await response.json()) as { error: string };
+      assert.equal(body.error, 'private address');
+    },
+  );
+});
+
+test('POST /api/jobs/extract returns 400 when url is missing', async () => {
+  await withServer(mountExtract(async () => ({ ok: true, data: { source: 'none' } })), async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs/extract`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'X-User-Id': 'u1' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(response.status, 400);
+  });
+});

--- a/apps/api/src/routes/job-extract.test.ts
+++ b/apps/api/src/routes/job-extract.test.ts
@@ -32,7 +32,7 @@ async function withServer(
 }
 
 function mountExtract(extract: (url: string) => Promise<ExtractResult>) {
-  return (app: express.Express) => app.use('/api/jobs', createJobExtractRouter({ extract }));
+  return (app: express.Express) => app.use('/api/jobs/extract', createJobExtractRouter({ extract }));
 }
 
 test('POST /api/jobs/extract requires a signed-in user', async () => {

--- a/apps/api/src/routes/job-extract.ts
+++ b/apps/api/src/routes/job-extract.ts
@@ -8,11 +8,13 @@ export interface JobExtractDeps {
 
 const defaultDeps: JobExtractDeps = { extract: (url) => extractJobFromUrl(url) };
 
-/** `POST /api/jobs/extract` — fetch a job URL and return autofill fields. */
+/** `POST /api/jobs/extract` — fetch a job URL and return autofill fields.
+ *  Mounted at `/api/jobs/extract` (with the strict rate limiter), so the route
+ *  path registered here is `/`. */
 export function createJobExtractRouter(deps: JobExtractDeps = defaultDeps) {
   const router = Router();
 
-  router.post('/extract', async (request, response, next) => {
+  router.post('/', async (request, response, next) => {
     const userId = requireUser(request, response);
     if (!userId) return;
 

--- a/apps/api/src/routes/job-extract.ts
+++ b/apps/api/src/routes/job-extract.ts
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import { requireUser } from '@/lib/auth';
+import { extractJobFromUrl, type ExtractResult } from '@/lib/job-url-fetch';
+
+export interface JobExtractDeps {
+  extract: (url: string) => Promise<ExtractResult>;
+}
+
+const defaultDeps: JobExtractDeps = { extract: (url) => extractJobFromUrl(url) };
+
+/** `POST /api/jobs/extract` — fetch a job URL and return autofill fields. */
+export function createJobExtractRouter(deps: JobExtractDeps = defaultDeps) {
+  const router = Router();
+
+  router.post('/extract', async (request, response, next) => {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
+    const url = typeof request.body?.url === 'string' ? request.body.url.trim() : '';
+    if (!url) {
+      response.status(400).json({ error: 'A job URL is required.' });
+      return;
+    }
+
+    try {
+      const result = await deps.extract(url);
+      if (!result.ok) {
+        response.status(400).json({ error: result.error });
+        return;
+      }
+      response.json(result.data);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+export const jobExtractRouter = createJobExtractRouter();

--- a/docs/superpowers/plans/2026-06-24-job-url-autofill-pr-a-extract.md
+++ b/docs/superpowers/plans/2026-06-24-job-url-autofill-pr-a-extract.md
@@ -1,0 +1,828 @@
+# Job-URL Autofill — PR A (extract endpoint) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A server-side `POST /api/jobs/extract` that fetches a pasted job URL (behind an SSRF guard) and returns title/company/location/description/workplace extracted from JSON-LD, OpenGraph, or page text.
+
+**Architecture:** Four focused units — a pure HTML extractor (`job-url-extract.ts`), an SSRF guard (`url-safety.ts`), a guarded fetch + composition (`job-url-fetch.ts`), and a thin injectable router (`routes/job-extract.ts`) mounted at `/api/jobs`. Pure pieces are unit-tested against fixtures; I/O is isolated and injected in tests so nothing hits the network.
+
+**Tech Stack:** Express, Node 20 global `fetch`, `node-html-parser` (new dep), `node:dns/promises`, `node:net`; node:test + tsx. Spec: `docs/superpowers/specs/2026-06-24-job-url-autofill-design.md`.
+
+**Branch:** `feat/job-url-extract` (already created; carries the spec). **Scope:** PR A of 2 (B = frontend autofill UX).
+
+---
+
+## File structure
+
+- **Create** `apps/api/src/lib/job-url-extract.ts` — pure: `extractJobFromHtml(html) → ExtractedJob` (JSON-LD → OG → heuristic). + types.
+- **Create** `apps/api/src/lib/url-safety.ts` — pure-ish SSRF guard: `isBlockedAddress(ip)`, `assertUrlSafe(url, lookup)`.
+- **Create** `apps/api/src/lib/job-url-fetch.ts` — I/O: `fetchJobPage(url, deps)` + `extractJobFromUrl(url, deps)` composition.
+- **Create** `apps/api/src/routes/job-extract.ts` — `createJobExtractRouter(deps)` + default `jobExtractRouter`.
+- **Modify** `apps/api/src/app.ts` — mount `jobExtractRouter` at `/api/jobs`.
+- Test files mirror each lib/route.
+
+---
+
+## Task 1: Pure HTML extractor + `node-html-parser`
+
+**Files:**
+- Create: `apps/api/src/lib/job-url-extract.ts`
+- Test: `apps/api/src/lib/job-url-extract.test.ts`
+
+- [ ] **Step 1: Add the dependency**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && npm install node-html-parser@^7`
+Expected: adds `node-html-parser` to `apps/api/package.json` dependencies.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/api/src/lib/job-url-extract.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { extractJobFromHtml } from './job-url-extract';
+
+const JSONLD = `<!doctype html><html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting","title":"AI Engineer",
+ "description":"<p>Build <b>agents</b> with TypeScript.</p>",
+ "hiringOrganization":{"@type":"Organization","name":"Pebble"},
+ "jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"San Francisco","addressRegion":"CA","addressCountry":"US"}},
+ "jobLocationType":"TELECOMMUTE"}
+</script></head><body><h1>Ignored</h1></body></html>`;
+
+test('extracts a JSON-LD JobPosting', () => {
+  const result = extractJobFromHtml(JSONLD);
+  assert.equal(result.source, 'jsonld');
+  assert.equal(result.title, 'AI Engineer');
+  assert.equal(result.company, 'Pebble');
+  assert.equal(result.location, 'San Francisco, CA, US');
+  assert.equal(result.workplaceType, 'remote');
+  assert.match(result.descriptionText ?? '', /Build agents with TypeScript/);
+});
+
+test('falls back to OpenGraph / meta tags', () => {
+  const html = `<html><head>
+    <meta property="og:title" content="Backend Engineer">
+    <meta property="og:site_name" content="Acme">
+    <meta property="og:description" content="Go and Postgres.">
+    <title>Backend Engineer — Acme</title></head><body></body></html>`;
+  const result = extractJobFromHtml(html);
+  assert.equal(result.source, 'opengraph');
+  assert.equal(result.title, 'Backend Engineer');
+  assert.equal(result.company, 'Acme');
+  assert.equal(result.descriptionText, 'Go and Postgres.');
+});
+
+test('uses a heuristic when there is no structured data', () => {
+  const html = `<html><head><title>x</title></head><body>
+    <script>var a=1;</script><h1>Data Scientist</h1>
+    <article>We need pandas and SQL skills for this role.</article></body></html>`;
+  const result = extractJobFromHtml(html);
+  assert.equal(result.title, 'Data Scientist');
+  assert.match(result.descriptionText ?? '', /pandas and SQL/);
+  assert.ok(result.source === 'heuristic' || result.source === 'opengraph');
+});
+
+test('skips malformed JSON-LD without throwing', () => {
+  const html = `<html><head>
+    <script type="application/ld+json">{ not json }</script>
+    <meta property="og:title" content="Still Works"></head><body></body></html>`;
+  const result = extractJobFromHtml(html);
+  assert.equal(result.title, 'Still Works');
+});
+
+test('returns source "none" for an empty page', () => {
+  const result = extractJobFromHtml('<html><head></head><body></body></html>');
+  assert.equal(result.source, 'none');
+  assert.equal(result.title, undefined);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && node --import tsx --test --test-concurrency=1 src/lib/job-url-extract.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement**
+
+Create `apps/api/src/lib/job-url-extract.ts`:
+
+```ts
+import { parse, type HTMLElement } from 'node-html-parser';
+
+export type WorkplaceType = 'remote' | 'hybrid' | 'onsite' | 'flexible';
+
+export interface ExtractedJob {
+  title?: string;
+  company?: string;
+  location?: string;
+  descriptionText?: string;
+  workplaceType?: WorkplaceType;
+  source: 'jsonld' | 'opengraph' | 'heuristic' | 'none';
+}
+
+function clean(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** JSON-LD descriptions are usually HTML; flatten to readable text. */
+function htmlToText(html: string): string | undefined {
+  const text = parse(html).structuredText.trim();
+  return text.length > 0 ? text : undefined;
+}
+
+// ---- JSON-LD tier ----
+function collectJsonLd(root: HTMLElement): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [];
+  for (const node of root.querySelectorAll('script[type="application/ld+json"]')) {
+    let data: unknown;
+    try {
+      data = JSON.parse(node.text);
+    } catch {
+      continue; // malformed block — skip it
+    }
+    const items = Array.isArray(data) ? data : [data];
+    for (const item of items) {
+      if (item && typeof item === 'object') {
+        out.push(item as Record<string, unknown>);
+        const graph = (item as { '@graph'?: unknown })['@graph'];
+        if (Array.isArray(graph)) {
+          for (const g of graph) if (g && typeof g === 'object') out.push(g as Record<string, unknown>);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function hasJobPostingType(obj: Record<string, unknown>): boolean {
+  const t = obj['@type'];
+  return t === 'JobPosting' || (Array.isArray(t) && t.includes('JobPosting'));
+}
+
+function companyFrom(org: unknown): string | undefined {
+  if (typeof org === 'string') return clean(org);
+  if (org && typeof org === 'object') return clean((org as { name?: unknown }).name);
+  return undefined;
+}
+
+function locationFrom(loc: unknown): string | undefined {
+  const first = Array.isArray(loc) ? loc[0] : loc;
+  if (!first || typeof first !== 'object') return undefined;
+  const address = (first as { address?: unknown }).address;
+  if (typeof address === 'string') return clean(address);
+  if (!address || typeof address !== 'object') return undefined;
+  const a = address as Record<string, unknown>;
+  const parts = [a.addressLocality, a.addressRegion, a.addressCountry]
+    .map(clean)
+    .filter((p): p is string => p !== undefined);
+  return parts.length > 0 ? parts.join(', ') : undefined;
+}
+
+function fromJsonLd(root: HTMLElement): Partial<ExtractedJob> {
+  const job = collectJsonLd(root).find(hasJobPostingType);
+  if (!job) return {};
+  const desc = clean(job.description);
+  const locationType = typeof job.jobLocationType === 'string' ? job.jobLocationType.toUpperCase() : '';
+  return {
+    title: clean(job.title),
+    company: companyFrom(job.hiringOrganization),
+    location: locationFrom(job.jobLocation),
+    descriptionText: desc ? (htmlToText(desc) ?? desc) : undefined,
+    workplaceType: locationType === 'TELECOMMUTE' ? 'remote' : undefined,
+  };
+}
+
+// ---- OpenGraph / meta tier ----
+function metaContent(root: HTMLElement, selector: string): string | undefined {
+  return clean(root.querySelector(selector)?.getAttribute('content'));
+}
+
+function fromMeta(root: HTMLElement): Partial<ExtractedJob> {
+  return {
+    title: metaContent(root, 'meta[property="og:title"]') ?? clean(root.querySelector('title')?.text),
+    company: metaContent(root, 'meta[property="og:site_name"]'),
+    descriptionText:
+      metaContent(root, 'meta[property="og:description"]') ?? metaContent(root, 'meta[name="description"]'),
+  };
+}
+
+// ---- heuristic tier (runs last; may mutate the tree) ----
+function fromHeuristic(root: HTMLElement): Partial<ExtractedJob> {
+  const title = clean(root.querySelector('h1')?.text);
+  for (const node of root.querySelectorAll('script, style, nav, header, footer')) node.remove();
+  const body = root.querySelector('body') ?? root;
+  const text = body.structuredText.trim();
+  return { title, descriptionText: text.length > 0 ? text.slice(0, 20_000) : undefined };
+}
+
+export function extractJobFromHtml(html: string): ExtractedJob {
+  const root = parse(html);
+  // Order matters: jsonld + meta read scripts/head before the heuristic strips them.
+  const tiers: Array<[ExtractedJob['source'], Partial<ExtractedJob>]> = [
+    ['jsonld', fromJsonLd(root)],
+    ['opengraph', fromMeta(root)],
+    ['heuristic', fromHeuristic(root)],
+  ];
+
+  const result: ExtractedJob = { source: 'none' };
+  for (const [tier, data] of tiers) {
+    let used = false;
+    if (result.title === undefined && data.title !== undefined) { result.title = data.title; used = true; }
+    if (result.company === undefined && data.company !== undefined) { result.company = data.company; used = true; }
+    if (result.location === undefined && data.location !== undefined) { result.location = data.location; used = true; }
+    if (result.descriptionText === undefined && data.descriptionText !== undefined) {
+      result.descriptionText = data.descriptionText;
+      used = true;
+    }
+    if (result.workplaceType === undefined && data.workplaceType !== undefined) {
+      result.workplaceType = data.workplaceType;
+      used = true;
+    }
+    if (used && result.source === 'none') result.source = tier;
+  }
+  return result;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && node --import tsx --test --test-concurrency=1 src/lib/job-url-extract.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot" && git add apps/api/package.json apps/api/package-lock.json apps/api/src/lib/job-url-extract.ts apps/api/src/lib/job-url-extract.test.ts && git commit -F - <<'EOF'
+feat(api): tiered HTML job extractor (JSON-LD/OG/heuristic) (#120)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01YY7NVS3QLuFeTqkmBaidAB
+EOF
+```
+
+(If the repo uses a root lockfile instead of `apps/api/package-lock.json`, add whichever lockfile changed.)
+
+---
+
+## Task 2: SSRF guard
+
+**Files:**
+- Create: `apps/api/src/lib/url-safety.ts`
+- Test: `apps/api/src/lib/url-safety.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/lib/url-safety.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { assertUrlSafe, isBlockedAddress } from './url-safety';
+
+test('isBlockedAddress flags private / loopback / link-local ranges', () => {
+  for (const ip of ['127.0.0.1', '10.1.2.3', '192.168.0.5', '172.16.0.1', '169.254.169.254', '0.0.0.0', '::1', 'fe80::1', 'fd00::1']) {
+    assert.equal(isBlockedAddress(ip), true, `${ip} should be blocked`);
+  }
+});
+
+test('isBlockedAddress allows public addresses', () => {
+  for (const ip of ['93.184.216.34', '1.1.1.1', '2606:2800:220:1:248:1893:25c8:1946']) {
+    assert.equal(isBlockedAddress(ip), false, `${ip} should be allowed`);
+  }
+});
+
+test('assertUrlSafe rejects non-http(s) schemes without resolving', async () => {
+  for (const url of ['file:///etc/passwd', 'ftp://example.com', 'gopher://x']) {
+    const result = await assertUrlSafe(url, async () => [{ address: '93.184.216.34' }]);
+    assert.equal(result.ok, false);
+  }
+});
+
+test('assertUrlSafe rejects hosts that resolve to a blocked address', async () => {
+  const result = await assertUrlSafe('http://localhost/job', async () => [{ address: '127.0.0.1' }]);
+  assert.equal(result.ok, false);
+});
+
+test('assertUrlSafe accepts a public host', async () => {
+  const result = await assertUrlSafe('https://boards.greenhouse.io/x', async () => [{ address: '93.184.216.34' }]);
+  assert.equal(result.ok, true);
+});
+
+test('assertUrlSafe rejects an unparseable URL', async () => {
+  const result = await assertUrlSafe('not a url', async () => []);
+  assert.equal(result.ok, false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && node --import tsx --test --test-concurrency=1 src/lib/url-safety.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/api/src/lib/url-safety.ts`:
+
+```ts
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+export type LookupFn = (hostname: string) => Promise<Array<{ address: string }>>;
+
+const defaultLookup: LookupFn = (hostname) => dnsLookup(hostname, { all: true });
+
+function isBlockedV4(ip: string): boolean {
+  const parts = ip.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return true;
+  const [a, b] = parts;
+  if (a === 0) return true; // 0.0.0.0/8
+  if (a === 10) return true; // 10/8
+  if (a === 127) return true; // loopback
+  if (a === 169 && b === 254) return true; // link-local incl. 169.254.169.254 metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12
+  if (a === 192 && b === 168) return true; // 192.168/16
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT
+  return false;
+}
+
+function isBlockedV6(ip: string): boolean {
+  const addr = ip.toLowerCase().split('%')[0]; // drop any zone id
+  if (addr === '::1' || addr === '::') return true;
+  const mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (mapped) return isBlockedV4(mapped[1]);
+  if (addr.startsWith('fe80')) return true; // link-local fe80::/10
+  if (addr.startsWith('fc') || addr.startsWith('fd')) return true; // unique-local fc00::/7
+  return false;
+}
+
+/** True when an IP literal is in a private/loopback/link-local/metadata range. */
+export function isBlockedAddress(ip: string): boolean {
+  const kind = isIP(ip);
+  if (kind === 4) return isBlockedV4(ip);
+  if (kind === 6) return isBlockedV6(ip);
+  return true; // not a valid IP literal — block defensively
+}
+
+/** Validate a user-supplied URL for server-side fetching (scheme + resolved IP). */
+export async function assertUrlSafe(
+  rawUrl: string,
+  lookup: LookupFn = defaultLookup,
+): Promise<{ ok: true; url: URL } | { ok: false; reason: string }> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: 'Enter a valid URL.' };
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return { ok: false, reason: 'Only http and https URLs are supported.' };
+  }
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await lookup(url.hostname);
+  } catch {
+    return { ok: false, reason: 'Could not resolve that host.' };
+  }
+  if (addresses.length === 0 || addresses.some((a) => isBlockedAddress(a.address))) {
+    return { ok: false, reason: 'That URL points to a private or disallowed address.' };
+  }
+  return { ok: true, url };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && node --import tsx --test --test-concurrency=1 src/lib/url-safety.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot" && git add apps/api/src/lib/url-safety.ts apps/api/src/lib/url-safety.test.ts && git commit -F - <<'EOF'
+feat(api): SSRF guard for user-supplied fetch URLs (#120)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01YY7NVS3QLuFeTqkmBaidAB
+EOF
+```
+
+---
+
+## Task 3: Guarded fetch + composition
+
+**Files:**
+- Create: `apps/api/src/lib/job-url-fetch.ts`
+- Test: `apps/api/src/lib/job-url-fetch.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/lib/job-url-fetch.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { extractJobFromUrl, fetchJobPage } from './job-url-fetch';
+
+const okSafe = async (raw: string) => ({ ok: true as const, url: new URL(raw) });
+
+function htmlResponse(body: string, contentType = 'text/html; charset=utf-8', status = 200): Response {
+  return new Response(body, { status, headers: { 'content-type': contentType } });
+}
+
+test('fetchJobPage returns html for a safe, html, 200 page', async () => {
+  const page = await fetchJobPage('https://example.com/job', {
+    assertSafe: okSafe,
+    fetchImpl: async () => htmlResponse('<html><body>hi</body></html>'),
+  });
+  assert.equal(page.blocked, undefined);
+  assert.match(page.html ?? '', /hi/);
+});
+
+test('fetchJobPage blocks a non-html response', async () => {
+  const page = await fetchJobPage('https://example.com/x.pdf', {
+    assertSafe: okSafe,
+    fetchImpl: async () => htmlResponse('%PDF', 'application/pdf'),
+  });
+  assert.notEqual(page.blocked, undefined);
+  assert.equal(page.html, undefined);
+});
+
+test('fetchJobPage surfaces an SSRF rejection', async () => {
+  const page = await fetchJobPage('http://169.254.169.254/', {
+    assertSafe: async () => ({ ok: false as const, reason: 'blocked range' }),
+    fetchImpl: async () => htmlResponse('should not be reached'),
+  });
+  assert.equal(page.blocked, 'blocked range');
+});
+
+test('fetchJobPage re-validates a redirect target', async () => {
+  let calls = 0;
+  const page = await fetchJobPage('https://example.com/start', {
+    // First host is safe; the redirect target is rejected.
+    assertSafe: async (raw) =>
+      raw.includes('internal')
+        ? { ok: false as const, reason: 'redirect blocked' }
+        : { ok: true as const, url: new URL(raw) },
+    fetchImpl: async () => {
+      calls += 1;
+      return new Response(null, { status: 302, headers: { location: 'http://internal.local/' } });
+    },
+  });
+  assert.equal(page.blocked, 'redirect blocked');
+  assert.equal(calls, 1);
+});
+
+test('extractJobFromUrl maps a fetched page', async () => {
+  const result = await extractJobFromUrl('https://example.com/job', {
+    fetchPage: async () => ({
+      html: '<html><head><meta property="og:title" content="Mapped Role"></head><body></body></html>',
+    }),
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.data.title, 'Mapped Role');
+});
+
+test('extractJobFromUrl returns the block reason as an error', async () => {
+  const result = await extractJobFromUrl('http://10.0.0.1/', {
+    fetchPage: async () => ({ blocked: 'private address' }),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.ok === false && result.error, 'private address');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && node --import tsx --test --test-concurrency=1 src/lib/job-url-fetch.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/api/src/lib/job-url-fetch.ts`:
+
+```ts
+import { assertUrlSafe } from '@/lib/url-safety';
+import { extractJobFromHtml, type ExtractedJob } from '@/lib/job-url-extract';
+
+const MAX_BYTES = 2_000_000;
+const TIMEOUT_MS = 8_000;
+const MAX_REDIRECTS = 3;
+
+export interface FetchedPage {
+  html?: string;
+  blocked?: string;
+}
+
+export interface FetchDeps {
+  assertSafe?: typeof assertUrlSafe;
+  fetchImpl?: typeof fetch;
+}
+
+async function readCapped(response: Response, maxBytes: number): Promise<string | null> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const text = await response.text();
+    return Buffer.byteLength(text) > maxBytes ? null : text;
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/** Fetch a user URL behind the SSRF guard; never throws — returns `{ blocked }` on any failure. */
+export async function fetchJobPage(rawUrl: string, deps: FetchDeps = {}): Promise<FetchedPage> {
+  const assertSafe = deps.assertSafe ?? assertUrlSafe;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+
+  let target = rawUrl;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+    const safe = await assertSafe(target);
+    if (!safe.ok) return { blocked: safe.reason };
+
+    let response: Response;
+    try {
+      response = await fetchImpl(safe.url, {
+        redirect: 'manual', // follow manually so each hop is re-validated
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+        headers: { 'User-Agent': 'JobOpsCopilot/1.0 (+job-autofill)', Accept: 'text/html' },
+      });
+    } catch {
+      return { blocked: 'Could not reach that page.' };
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) return { blocked: 'Redirect without a destination.' };
+      target = new URL(location, safe.url).toString();
+      continue;
+    }
+    if (!response.ok) return { blocked: `The page returned HTTP ${response.status}.` };
+    if (!(response.headers.get('content-type') ?? '').includes('text/html')) {
+      return { blocked: 'That URL is not an HTML page.' };
+    }
+
+    const html = await readCapped(response, MAX_BYTES);
+    if (html === null) return { blocked: 'That page is too large to read.' };
+    return { html };
+  }
+  return { blocked: 'Too many redirects.' };
+}
+
+export type ExtractResult = { ok: true; data: ExtractedJob } | { ok: false; error: string };
+
+export interface ExtractDeps {
+  fetchPage?: typeof fetchJobPage;
+}
+
+export async function extractJobFromUrl(url: string, deps: ExtractDeps = {}): Promise<ExtractResult> {
+  const page = await (deps.fetchPage ?? fetchJobPage)(url);
+  if (page.blocked !== undefined || page.html === undefined) {
+    return { ok: false, error: page.blocked ?? 'Could not read that page.' };
+  }
+  return { ok: true, data: extractJobFromHtml(page.html) };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && node --import tsx --test --test-concurrency=1 src/lib/job-url-fetch.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot" && git add apps/api/src/lib/job-url-fetch.ts apps/api/src/lib/job-url-fetch.test.ts && git commit -F - <<'EOF'
+feat(api): SSRF-guarded page fetch + URL→job composition (#120)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01YY7NVS3QLuFeTqkmBaidAB
+EOF
+```
+
+---
+
+## Task 4: Route + mount + verification + PR
+
+**Files:**
+- Create: `apps/api/src/routes/job-extract.ts`
+- Create: `apps/api/src/routes/job-extract.test.ts`
+- Modify: `apps/api/src/app.ts`
+
+- [ ] **Step 1: Write the failing route test**
+
+Create `apps/api/src/routes/job-extract.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+import express from 'express';
+import { createJobExtractRouter } from './job-extract';
+import type { ExtractResult } from '@/lib/job-url-fetch';
+
+async function withServer(
+  mount: (app: express.Express) => void,
+  run: (baseUrl: string) => Promise<void>,
+) {
+  const app = express();
+  app.use(express.json());
+  app.use((request, _response, next) => {
+    const header = request.header('X-User-Id');
+    if (header) request.userId = header.trim();
+    next();
+  });
+  mount(app);
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('no server address');
+  }
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+function mountExtract(extract: (url: string) => Promise<ExtractResult>) {
+  return (app: express.Express) => app.use('/api/jobs', createJobExtractRouter({ extract }));
+}
+
+test('POST /api/jobs/extract requires a signed-in user', async () => {
+  await withServer(mountExtract(async () => ({ ok: true, data: { source: 'none' } })), async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs/extract`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url: 'https://x/y' }),
+    });
+    assert.equal(response.status, 401);
+  });
+});
+
+test('POST /api/jobs/extract returns extracted fields', async () => {
+  await withServer(
+    mountExtract(async () => ({ ok: true, data: { title: 'AI Engineer', source: 'jsonld' } })),
+    async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/jobs/extract`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'X-User-Id': 'u1' },
+        body: JSON.stringify({ url: 'https://x/y' }),
+      });
+      assert.equal(response.status, 200);
+      const body = await response.json();
+      assert.equal(body.title, 'AI Engineer');
+      assert.equal(body.source, 'jsonld');
+    },
+  );
+});
+
+test('POST /api/jobs/extract returns 400 for a blocked URL', async () => {
+  await withServer(
+    mountExtract(async () => ({ ok: false, error: 'private address' })),
+    async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/jobs/extract`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'X-User-Id': 'u1' },
+        body: JSON.stringify({ url: 'http://10.0.0.1/' }),
+      });
+      assert.equal(response.status, 400);
+      const body = await response.json();
+      assert.equal(body.error, 'private address');
+    },
+  );
+});
+
+test('POST /api/jobs/extract returns 400 when url is missing', async () => {
+  await withServer(mountExtract(async () => ({ ok: true, data: { source: 'none' } })), async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs/extract`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'X-User-Id': 'u1' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(response.status, 400);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && node --import tsx --test --test-concurrency=1 src/routes/job-extract.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the router**
+
+Create `apps/api/src/routes/job-extract.ts`:
+
+```ts
+import { Router } from 'express';
+import { requireUser } from '@/lib/auth';
+import { extractJobFromUrl, type ExtractResult } from '@/lib/job-url-fetch';
+
+export interface JobExtractDeps {
+  extract: (url: string) => Promise<ExtractResult>;
+}
+
+const defaultDeps: JobExtractDeps = { extract: (url) => extractJobFromUrl(url) };
+
+/** `POST /api/jobs/extract` — fetch a job URL and return autofill fields. */
+export function createJobExtractRouter(deps: JobExtractDeps = defaultDeps) {
+  const router = Router();
+
+  router.post('/extract', async (request, response, next) => {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+
+    const url = typeof request.body?.url === 'string' ? request.body.url.trim() : '';
+    if (!url) {
+      response.status(400).json({ error: 'A job URL is required.' });
+      return;
+    }
+
+    try {
+      const result = await deps.extract(url);
+      if (!result.ok) {
+        response.status(400).json({ error: result.error });
+        return;
+      }
+      response.json(result.data);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+export const jobExtractRouter = createJobExtractRouter();
+```
+
+- [ ] **Step 4: Run the route test to verify it passes**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && node --import tsx --test --test-concurrency=1 src/routes/job-extract.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Mount the router in `app.ts`**
+
+In `apps/api/src/app.ts`, add the import next to the other route imports (match the existing import style):
+
+```ts
+import { jobExtractRouter } from '@/routes/job-extract';
+```
+
+Then mount it immediately BEFORE the existing `app.use('/api/jobs', jobsRouter);` line so `/extract` is matched here and all other `/api/jobs/*` paths fall through to `jobsRouter`:
+
+```ts
+  app.use('/api/jobs', jobExtractRouter);
+  app.use('/api/jobs', jobsRouter);
+```
+
+- [ ] **Step 6: Full verification**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && npm run typecheck`
+Expected: no errors.
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && npm run lint`
+Expected: no errors.
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/api" && node scripts/run-tests.mjs`
+Expected: all PASS (prior suite + the 4 new test files).
+
+- [ ] **Step 7: Commit, push, open PR**
+
+```bash
+cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot" && git add apps/api/src/routes/job-extract.ts apps/api/src/routes/job-extract.test.ts apps/api/src/app.ts && git commit -F - <<'EOF'
+feat(api): POST /api/jobs/extract autofill endpoint (#120)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01YY7NVS3QLuFeTqkmBaidAB
+EOF
+git push -u origin feat/job-url-extract
+```
+
+Then open the PR (base `main`), title `feat: server-side job-URL extract endpoint (#118 → #120 · PR A)`, body summarising the endpoint + SSRF guard + tiered extraction, ending with the Generated-with line.
+
+---
+
+## Self-review notes
+- **Spec coverage:** task 3.1 (server fetch + extraction + SSRF + timeouts/non-HTML) = Tasks 1–4; the field mapping (title/company/location/description/workplace) = Task 1. PR B covers 3.2 (form mapping/UX).
+- **Type consistency:** `ExtractedJob` (with `source`) defined in `job-url-extract.ts` and re-used in `job-url-fetch.ts` + route; `ExtractResult` discriminated union (`ok`) defined once in `job-url-fetch.ts` and consumed by the route + its test; `assertUrlSafe` returns `{ ok, url }|{ ok, reason }`; `fetchJobPage` returns `{ html }|{ blocked }`.
+- **No placeholders:** every step has full code + exact commands.
+- **Offline tests:** all I/O is injected (`assertSafe`/`fetchImpl`/`fetchPage`/`extract`); no test hits the network or DNS.
+- **Security:** SSRF guard re-validates every redirect hop (`redirect: 'manual'`), blocks non-http(s) schemes, private/loopback/link-local/metadata ranges (incl. `169.254.169.254`), caps size (2 MB) + time (8 s), and requires `text/html`.

--- a/docs/superpowers/specs/2026-06-24-job-url-autofill-design.md
+++ b/docs/superpowers/specs/2026-06-24-job-url-autofill-design.md
@@ -1,0 +1,146 @@
+# Phase 3 — Add-a-job autofill from URL (design)
+
+**Date:** 2026-06-24
+**Epic:** #124 · **Phase issue:** #120
+**Status:** Approved (brainstorm), pending implementation plan
+
+## Goal
+
+Paste a job URL in `/jobs/new` → the app fetches the page server-side and
+**autofills** title, company, location, description, and workplace type, instead
+of manual paste. **Best-effort and always editable** — unsupported pages fall
+back to manual entry with a clear message.
+
+## Locked decisions
+
+1. **Extraction = lightweight parser (`node-html-parser`), tiered: JSON-LD
+   `JobPosting` → OpenGraph/meta → main-text heuristic.** Covers the high-value
+   structured-data case (Greenhouse / Lever / Ashby) with broad fallback at
+   minimal dependency weight. No headless browser, no per-ATS scrapers, no LLM.
+2. **Server-side fetch with a hard SSRF guard** (arbitrary user URLs are
+   fetched, so this is a security requirement, not a nice-to-have).
+3. **UX = explicit "Autofill" button** next to the URL field; overwrites the
+   mapped fields on click; graceful inline fallback when extraction is thin.
+
+## Current state (verified)
+
+- `apps/web/src/components/job-create-form.tsx` stores the URL as plain text;
+  the description must be pasted manually. No fetching/scraping exists.
+- The API has **no HTML parser** (deps: express, pg, pdf-parse, multer, helmet,
+  …). Node 20+ global `fetch` is available. Job sources (Adzuna/Remotive) fetch
+  JSON APIs, not HTML — no reusable HTML extraction.
+- Routes are mounted in `apps/api/src/app.ts`; `/api/jobs` → `jobsRouter`.
+
+## Architecture
+
+### New endpoint — `POST /api/jobs/extract`
+
+Mounted on the existing `jobsRouter` (auth-required like the rest of `/api/jobs`).
+
+- **Request:** `{ url: string }`.
+- **Response:** `ExtractedJob` —
+  ```ts
+  interface ExtractedJob {
+    title?: string;
+    company?: string;
+    location?: string;
+    descriptionText?: string;
+    workplaceType?: 'remote' | 'hybrid' | 'onsite' | 'flexible';
+    source: 'jsonld' | 'opengraph' | 'heuristic' | 'none';
+  }
+  ```
+  Every content field is optional; the client autofills whatever is present.
+  `source` reports which tier produced the result (for an honest UI message).
+- **Errors:** invalid/blocked/oversized/non-HTML URL → `400` with a clear
+  message (or a `200` with `source: 'none'` and no fields — see Error handling).
+
+### New module — `apps/api/src/lib/job-url-extract.ts`
+
+Two units with clear boundaries:
+
+**1. `extractJobFromHtml(html: string, pageUrl: string): ExtractedJob`** — pure,
+no I/O, fully unit-testable against fixture HTML. Tiered, first hit wins per
+field (later tiers only fill gaps):
+- **JSON-LD** — parse every `<script type="application/ld+json">` block; find an
+  object (or `@graph` member) with `@type` `JobPosting`. Map: `title`;
+  `hiringOrganization.name` → company; `jobLocation.address` (locality/region/
+  country, joined) → location; `description` → descriptionText (HTML stripped to
+  text); `jobLocationType === 'TELECOMMUTE'` → workplaceType `remote`. Malformed
+  JSON in a block is skipped, never thrown.
+- **OpenGraph / meta** (fills any field JSON-LD missed) — `og:title` / `<title>`
+  → title; `og:site_name` → company; `og:description` / `<meta name=description>`
+  → descriptionText.
+- **Heuristic** (last resort for descriptionText/title) — strip `<script>` and
+  `<style>`, take the `<h1>` as title and the largest visible text block as
+  descriptionText.
+- `source` = the highest tier that produced any field (`jsonld` > `opengraph` >
+  `heuristic`), or `none` when nothing usable was found.
+
+**2. `fetchJobPage(url: string): Promise<{ html: string } | { blocked: string }>`**
+— the guarded I/O:
+- Allow only `http`/`https` schemes; reject anything else.
+- **SSRF guard:** resolve the hostname and reject private / loopback /
+  link-local / metadata ranges — `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`,
+  `192.168.0.0/16`, `169.254.0.0/16` (incl. `169.254.169.254`), `::1`, `fc00::/7`,
+  `fe80::/10`, and `0.0.0.0`. Re-check after each redirect; cap redirects (≤3).
+- `AbortSignal.timeout(8000)`; a `User-Agent` header; read the body with a
+  **2 MB cap** (abort if exceeded); require a `text/html` content-type.
+- Any failure (DNS, timeout, blocked range, non-HTML, oversize, non-2xx) returns
+  `{ blocked: <reason> }` rather than throwing.
+
+The route composes them: `fetchJobPage` → on `{ html }` call `extractJobFromHtml`;
+on `{ blocked }` return the clean error.
+
+### Frontend
+
+- **`apps/web/src/lib/api.ts`** — add `extractJobFromUrl(url: string):
+  Promise<ExtractedJob>` hitting `POST /api/jobs/extract`.
+- **`apps/web/src/components/job-create-form.tsx`** — an **"Autofill"** button
+  beside the Job URL field, disabled until the URL parses as `http(s)`. On
+  click: loading state ("Reading posting…") → on success populate `title`,
+  `company`, `location`, `descriptionText`, `workplaceType` from the returned
+  fields (overwrite; the user edits before saving) and toast *"Autofilled from
+  {source} — review before saving."* On `source: 'none'` / no usable fields:
+  inline message *"Couldn't read that posting automatically — paste the
+  description below."* The form stays fully manual; the URL is still saved.
+
+## Error handling
+
+- Blocked/invalid URL (SSRF, bad scheme, non-HTML, oversize, timeout, non-2xx):
+  route returns `400 { error }`; the form shows the inline fallback message.
+- Thin extraction (page fetched but nothing useful): `200 { source: 'none' }`;
+  same inline fallback. (We distinguish "couldn't fetch" from "fetched but
+  empty" but the user message is the same — both mean "type it yourself".)
+- Malformed JSON-LD: skipped silently; extraction continues with lower tiers.
+
+## Testing
+
+- `job-url-extract.test.ts` (pure) — fixtures: full JSON-LD `JobPosting`
+  (all fields + `source:'jsonld'`); OG-only page (`source:'opengraph'`); bare
+  HTML (heuristic title/desc or `none`); malformed JSON-LD block (no throw,
+  falls through); `TELECOMMUTE` → `remote`.
+- SSRF unit tests — `http://169.254.169.254`, `http://localhost`,
+  `http://10.0.0.1`, `file:///etc/passwd`, `ftp://…` all return `{ blocked }`.
+- Route test — `POST /api/jobs/extract` with a mocked `fetchJobPage`/fetch:
+  maps fields on success; returns a clean `400` for a blocked URL.
+- Web (vitest) — Autofill populates the form fields on a successful response;
+  shows the fallback message on `source: 'none'`; button disabled for a
+  non-URL value.
+
+## Build slices — 2 PRs off `main`
+
+| PR | Scope | Layer |
+|----|-------|-------|
+| **A** | `job-url-extract.ts` (extract + SSRF-guarded fetch) + `POST /api/jobs/extract` + tests; add `node-html-parser` dep | backend (TDD) |
+| **B** | `extractJobFromUrl` client + Autofill button/UX in the create form + tests | frontend |
+
+## YAGNI (out of scope)
+
+No headless browser / JS rendering, no per-ATS custom scrapers, no caching, no
+screenshots, no LLM cleanup of extracted text, no auto-trigger on paste (explicit
+button only), no bulk/multi-URL import.
+
+## Workflow
+
+Branch each slice off `main`; one PR per slice; address Codex review before
+proceeding; owner merges. Verify per `docs/TESTING.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "multer": "^2.0.1",
         "node-html-parser": "^7.1.0",
         "pdf-parse": "^1.1.1",
-        "pg": "^8.20.0"
+        "pg": "^8.20.0",
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
@@ -15473,7 +15474,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "express-rate-limit": "^8.5.2",
         "helmet": "^8.2.0",
         "multer": "^2.0.1",
+        "node-html-parser": "^7.1.0",
         "pdf-parse": "^1.1.1",
         "pg": "^8.20.0"
       },
@@ -7722,6 +7723,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -8232,6 +8239,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -8244,6 +8267,18 @@
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/css.escape": {
@@ -8701,6 +8736,73 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -10419,6 +10521,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/headers-polyfill": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
@@ -11321,7 +11432,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -12463,6 +12573,16 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-html-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
+      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.44",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
@@ -12505,6 +12625,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-assign": {


### PR DESCRIPTION
Phase 3 PR A — the backend for "autofill from a job URL". `POST /api/jobs/extract` fetches a pasted URL server-side (behind an SSRF guard) and returns title/company/location/description/workplace.

Design: \`docs/superpowers/specs/2026-06-24-job-url-autofill-design.md\` · Plan: \`docs/superpowers/plans/2026-06-24-job-url-autofill-pr-a-extract.md\`

## What's in this PR (4 focused modules)
- **\`lib/job-url-extract.ts\`** — pure tiered extractor: JSON-LD \`JobPosting\` (incl. @graph, array @type, string/object org, array/object location, HTML→text description, capped) → OpenGraph/meta → h1/\`<title>\`+body heuristic. `source` reports the best tier.
- **\`lib/url-safety.ts\`** — **SSRF guard**: http(s)-only; rejects private/loopback/link-local/metadata ranges incl. the IPv6 bypasses (fe80::/10 full range, IPv4-mapped \`::ffff:\` dotted+hex, IPv4-compatible \`::a.b.c.d\`, 6to4, Teredo, CGNAT). DNS-resolves the host and checks every redirect hop.
- **\`lib/job-url-fetch.ts\`** — guarded fetch: manual redirect following with per-hop re-validation, 8s timeout, **2 MB streamed cap**, content-type check (lenient on missing); never throws. Plus the URL→job composition.
- **\`routes/job-extract.ts\`** — injectable router, mounted at \`/api/jobs/extract\` behind \`strictLimiter\` (it makes an outbound fetch per call) and the same auth as all \`/api/jobs\`.

## Security
Adversarial review of the SSRF guard caught and closed **3 IPv6 bypasses** (a string-prefix \`fe80\` check missing fe81–febf, unhandled IPv4-compatible/hex-mapped forms, and 6to4) — now covered by regression tests. The DNS-rebinding (TOCTOU) residual is documented and mitigated by per-hop redirect re-validation.

## Verification
- API suite **149 pass** (extractor, SSRF guard incl. bypass tests, fetch incl. size-cap/timeout/redirect-limit, route incl. auth/200/400). typecheck + lint clean. No network/DNS in tests (all I/O injected).

## Notes
- PR B (separate) adds the frontend Autofill button + form mapping.
- Built subagent-driven with per-task spec + quality reviews and a final holistic review; this PR folds in their fixes (description cap, IPv6 hardening, untested-safeguard coverage, rate limit, content-type leniency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)