### PR TITLE
feat: add-job autofill from URL — frontend (#118 → #120 · PR B)

### DIFF
--- a/apps/web/src/components/job-create-form.test.tsx
+++ b/apps/web/src/components/job-create-form.test.tsx
@@ -67,6 +67,25 @@ it('shows a manual-entry fallback when nothing could be extracted', async () => 
   expect(screen.getByLabelText(/job title/i)).toHaveValue('');
 });
 
+it('locks the URL input while extraction is in flight (no stale apply)', async () => {
+  let resolveExtract: (value: { source: string }) => void = () => {};
+  extractJobFromUrl.mockReturnValue(
+    new Promise((resolve) => {
+      resolveExtract = resolve;
+    }),
+  );
+  const user = userEvent.setup();
+  render(<JobCreateForm />);
+
+  const urlInput = screen.getByLabelText(/job url/i);
+  await user.type(urlInput, 'https://x/y');
+  await user.click(screen.getByRole('button', { name: /autofill/i }));
+
+  expect(urlInput).toBeDisabled();
+  resolveExtract({ source: 'none' });
+  await waitFor(() => expect(urlInput).toBeEnabled());
+});
+
 it('toasts an error when the extraction request fails', async () => {
   extractJobFromUrl.mockRejectedValue(new Error('network down'));
   const user = userEvent.setup();

--- a/apps/web/src/components/job-create-form.test.tsx
+++ b/apps/web/src/components/job-create-form.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@/lib/api', () => ({
   ApiRequestError: class ApiRequestError extends Error {},
 }));
 
+import { toast } from 'sonner';
 import { JobCreateForm } from './job-create-form';
 
 afterEach(() => {
@@ -50,6 +51,8 @@ it('populates the form from a successful extraction', async () => {
   await waitFor(() => expect(screen.getByLabelText(/company/i)).toHaveValue('Pebble'));
   expect(screen.getByLabelText(/job title/i)).toHaveValue('AI Engineer');
   expect(screen.getByLabelText(/job description/i)).toHaveValue('Build agents.');
+  // The success toast names the source (jsonld → structured data).
+  expect(vi.mocked(toast.success)).toHaveBeenCalledWith(expect.stringMatching(/structured data/i));
 });
 
 it('shows a manual-entry fallback when nothing could be extracted', async () => {
@@ -61,5 +64,19 @@ it('shows a manual-entry fallback when nothing could be extracted', async () => 
   await user.click(screen.getByRole('button', { name: /autofill/i }));
 
   expect(await screen.findByText(/couldn.t read that posting/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/job title/i)).toHaveValue('');
+});
+
+it('toasts an error when the extraction request fails', async () => {
+  extractJobFromUrl.mockRejectedValue(new Error('network down'));
+  const user = userEvent.setup();
+  render(<JobCreateForm />);
+
+  await user.type(screen.getByLabelText(/job url/i), 'https://x/y');
+  await user.click(screen.getByRole('button', { name: /autofill/i }));
+
+  await waitFor(() =>
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Could not read that job posting.'),
+  );
   expect(screen.getByLabelText(/job title/i)).toHaveValue('');
 });

--- a/apps/web/src/components/job-create-form.test.tsx
+++ b/apps/web/src/components/job-create-form.test.tsx
@@ -81,9 +81,13 @@ it('locks the URL input while extraction is in flight (no stale apply)', async (
   await user.type(urlInput, 'https://x/y');
   await user.click(screen.getByRole('button', { name: /autofill/i }));
 
+  // Both the URL and the mapped fields lock so in-flight edits can't be clobbered.
   expect(urlInput).toBeDisabled();
+  expect(screen.getByLabelText(/job description/i)).toBeDisabled();
+  expect(screen.getByLabelText(/company/i)).toBeDisabled();
   resolveExtract({ source: 'none' });
   await waitFor(() => expect(urlInput).toBeEnabled());
+  expect(screen.getByLabelText(/job description/i)).toBeEnabled();
 });
 
 it('toasts an error when the extraction request fails', async () => {

--- a/apps/web/src/components/job-create-form.test.tsx
+++ b/apps/web/src/components/job-create-form.test.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, expect, it, vi } from 'vitest';
+
+const { extractJobFromUrl, createJob } = vi.hoisted(() => ({
+  extractJobFromUrl: vi.fn(),
+  createJob: vi.fn(),
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }) }));
+vi.mock('@/lib/api', () => ({
+  extractJobFromUrl,
+  createJob,
+  ApiRequestError: class ApiRequestError extends Error {},
+}));
+
+import { JobCreateForm } from './job-create-form';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+it('disables Autofill until the URL is a valid http(s) URL', async () => {
+  const user = userEvent.setup();
+  render(<JobCreateForm />);
+
+  const autofill = screen.getByRole('button', { name: /autofill/i });
+  expect(autofill).toBeDisabled();
+
+  await user.type(screen.getByLabelText(/job url/i), 'https://boards.greenhouse.io/x/jobs/1');
+  expect(autofill).toBeEnabled();
+});
+
+it('populates the form from a successful extraction', async () => {
+  extractJobFromUrl.mockResolvedValue({
+    title: 'AI Engineer',
+    company: 'Pebble',
+    location: 'Remote',
+    descriptionText: 'Build agents.',
+    workplaceType: 'remote',
+    source: 'jsonld',
+  });
+  const user = userEvent.setup();
+  render(<JobCreateForm />);
+
+  await user.type(screen.getByLabelText(/job url/i), 'https://x/y');
+  await user.click(screen.getByRole('button', { name: /autofill/i }));
+
+  await waitFor(() => expect(screen.getByLabelText(/company/i)).toHaveValue('Pebble'));
+  expect(screen.getByLabelText(/job title/i)).toHaveValue('AI Engineer');
+  expect(screen.getByLabelText(/job description/i)).toHaveValue('Build agents.');
+});
+
+it('shows a manual-entry fallback when nothing could be extracted', async () => {
+  extractJobFromUrl.mockResolvedValue({ source: 'none' });
+  const user = userEvent.setup();
+  render(<JobCreateForm />);
+
+  await user.type(screen.getByLabelText(/job url/i), 'https://x/y');
+  await user.click(screen.getByRole('button', { name: /autofill/i }));
+
+  expect(await screen.findByText(/couldn.t read that posting/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/job title/i)).toHaveValue('');
+});

--- a/apps/web/src/components/job-create-form.tsx
+++ b/apps/web/src/components/job-create-form.tsx
@@ -205,6 +205,9 @@ export function JobCreateForm() {
               onChange={(event) => updateField('jobUrl', event.target.value)}
               placeholder="https://…"
               className="flex-1"
+              // Locked during extraction so an in-flight response can't be applied
+              // to a URL the user changed meanwhile (stale-autofill mismatch).
+              disabled={isExtracting}
             />
             <Button
               type="button"

--- a/apps/web/src/components/job-create-form.tsx
+++ b/apps/web/src/components/job-create-form.tsx
@@ -166,6 +166,9 @@ export function JobCreateForm() {
           onChange={(event) => updateField('descriptionText', event.target.value)}
           placeholder="Paste the full job posting here…"
           className="max-h-80 min-h-40 overflow-y-auto"
+          // Locked during autofill so in-flight edits aren't clobbered when the
+          // extracted response resolves (it overwrites the autofilled fields).
+          disabled={isExtracting}
           required
         />
         {errors.descriptionText ? (
@@ -181,6 +184,7 @@ export function JobCreateForm() {
             value={form.company}
             onChange={(event) => updateField('company', event.target.value)}
             placeholder="Pebble"
+            disabled={isExtracting}
             required
           />
           {errors.company ? <p className="text-destructive text-xs">{errors.company}</p> : null}
@@ -192,6 +196,7 @@ export function JobCreateForm() {
             value={form.title}
             onChange={(event) => updateField('title', event.target.value)}
             placeholder="AI Software Engineer"
+            disabled={isExtracting}
             required
           />
           {errors.title ? <p className="text-destructive text-xs">{errors.title}</p> : null}
@@ -237,6 +242,7 @@ export function JobCreateForm() {
             value={form.location}
             onChange={(event) => updateField('location', event.target.value)}
             placeholder="Remote · San Francisco"
+            disabled={isExtracting}
           />
         </div>
         <div className="space-y-1.5">
@@ -248,6 +254,7 @@ export function JobCreateForm() {
             onChange={(event) =>
               updateField('workplaceType', event.target.value as Job['workplaceType'])
             }
+            disabled={isExtracting}
           >
             {workplaceTypeOptions.map((option) => (
               <option key={option} value={option}>

--- a/apps/web/src/components/job-create-form.tsx
+++ b/apps/web/src/components/job-create-form.tsx
@@ -18,6 +18,15 @@ const priorityOptions: Array<Job['priority']> = ['high', 'medium', 'low'];
 const selectClass =
   'border-input bg-card h-9 w-full rounded-md border px-2.5 text-sm capitalize shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none';
 
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 type FormState = {
   company: string;
   title: string;
@@ -54,15 +63,6 @@ export function JobCreateForm() {
 
   function updateField<K extends keyof FormState>(field: K, value: FormState[K]) {
     setForm((current) => ({ ...current, [field]: value }));
-  }
-
-  function isHttpUrl(value: string): boolean {
-    try {
-      const url = new URL(value.trim());
-      return url.protocol === 'http:' || url.protocol === 'https:';
-    } catch {
-      return false;
-    }
   }
 
   async function handleAutofill() {
@@ -213,12 +213,19 @@ export function JobCreateForm() {
               disabled={!isHttpUrl(form.jobUrl) || isExtracting}
               className="shrink-0 gap-1.5"
             >
-              {isExtracting ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
+              {isExtracting ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <Download className="size-4" aria-hidden="true" />
+              )}
               Autofill
             </Button>
           </div>
           {errors.jobUrl ? <p className="text-destructive text-xs">{errors.jobUrl}</p> : null}
-          {autofillNote ? <p className="text-muted-foreground text-xs">{autofillNote}</p> : null}
+          {/* Always-present live region so a screen reader announces a failed autofill. */}
+          <p role="status" className="text-muted-foreground text-xs empty:hidden">
+            {autofillNote ?? ''}
+          </p>
         </div>
         <div className="space-y-1.5">
           <Label htmlFor="location">Location</Label>

--- a/apps/web/src/components/job-create-form.tsx
+++ b/apps/web/src/components/job-create-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Sparkles } from 'lucide-react';
+import { Download, Loader2, Sparkles } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import type { FormEvent } from 'react';
 import { useState } from 'react';
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { ApiRequestError, createJob } from '@/lib/api';
+import { ApiRequestError, createJob, extractJobFromUrl } from '@/lib/api';
 import type { Job } from '@/types/job';
 
 const workplaceTypeOptions: Array<Job['workplaceType']> = ['remote', 'hybrid', 'onsite', 'flexible'];
@@ -49,9 +49,54 @@ export function JobCreateForm() {
   const [form, setForm] = useState<FormState>(initialState);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isExtracting, setIsExtracting] = useState(false);
+  const [autofillNote, setAutofillNote] = useState<string | null>(null);
 
   function updateField<K extends keyof FormState>(field: K, value: FormState[K]) {
     setForm((current) => ({ ...current, [field]: value }));
+  }
+
+  function isHttpUrl(value: string): boolean {
+    try {
+      const url = new URL(value.trim());
+      return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  async function handleAutofill() {
+    const url = form.jobUrl.trim();
+    if (!isHttpUrl(url)) return;
+    setIsExtracting(true);
+    setAutofillNote(null);
+    try {
+      const data = await extractJobFromUrl(url);
+      const hasAny = Boolean(
+        data.title || data.company || data.location || data.descriptionText || data.workplaceType,
+      );
+      if (!hasAny) {
+        setAutofillNote('Couldn’t read that posting automatically — paste the description below.');
+        return;
+      }
+      setForm((current) => ({
+        ...current,
+        title: data.title ?? current.title,
+        company: data.company ?? current.company,
+        location: data.location ?? current.location,
+        descriptionText: data.descriptionText ?? current.descriptionText,
+        workplaceType: data.workplaceType ?? current.workplaceType,
+      }));
+      setErrors({});
+      const label = data.source === 'jsonld' ? 'the posting’s structured data' : 'page metadata';
+      toast.success(`Autofilled from ${label} — review before saving.`);
+    } catch (error) {
+      toast.error(
+        error instanceof ApiRequestError ? error.message : 'Could not read that job posting.',
+      );
+    } finally {
+      setIsExtracting(false);
+    }
   }
 
   function validate(values: FormState) {
@@ -153,13 +198,27 @@ export function JobCreateForm() {
         </div>
         <div className="space-y-1.5">
           <Label htmlFor="jobUrl">Job URL</Label>
-          <Input
-            id="jobUrl"
-            value={form.jobUrl}
-            onChange={(event) => updateField('jobUrl', event.target.value)}
-            placeholder="https://…"
-          />
+          <div className="flex gap-2">
+            <Input
+              id="jobUrl"
+              value={form.jobUrl}
+              onChange={(event) => updateField('jobUrl', event.target.value)}
+              placeholder="https://…"
+              className="flex-1"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleAutofill}
+              disabled={!isHttpUrl(form.jobUrl) || isExtracting}
+              className="shrink-0 gap-1.5"
+            >
+              {isExtracting ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
+              Autofill
+            </Button>
+          </div>
           {errors.jobUrl ? <p className="text-destructive text-xs">{errors.jobUrl}</p> : null}
+          {autofillNote ? <p className="text-muted-foreground text-xs">{autofillNote}</p> : null}
         </div>
         <div className="space-y-1.5">
           <Label htmlFor="location">Location</Label>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -411,6 +411,22 @@ export async function runDiscovery(): Promise<DiscoveryRunResult> {
   return requestJson<DiscoveryRunResult>('/api/discovery/run', { method: 'POST', body: '{}' });
 }
 
+export interface ExtractedJobResponse {
+  title?: string;
+  company?: string;
+  location?: string;
+  descriptionText?: string;
+  workplaceType?: 'remote' | 'hybrid' | 'onsite' | 'flexible';
+  source: 'jsonld' | 'opengraph' | 'heuristic' | 'none';
+}
+
+export async function extractJobFromUrl(url: string): Promise<ExtractedJobResponse> {
+  return requestJson<ExtractedJobResponse>('/api/jobs/extract', {
+    method: 'POST',
+    body: JSON.stringify({ url }),
+  });
+}
+
 async function apiFetch(path: string, init: RequestInit): Promise<Response> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',

--- a/docs/superpowers/plans/2026-06-24-job-url-autofill-pr-b-ui.md
+++ b/docs/superpowers/plans/2026-06-24-job-url-autofill-pr-b-ui.md
@@ -1,0 +1,255 @@
+# Job-URL Autofill — PR B (frontend) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** An "Autofill" button on `/jobs/new` that fetches the pasted job URL via the PR-A endpoint and populates title/company/location/description/workplace — best-effort, always editable.
+
+**Architecture:** A thin web API client (`extractJobFromUrl`) calls `POST /api/jobs/extract`; the create form gains an Autofill button beside the Job URL field that fills whatever fields the response returns, with a clear inline fallback when extraction is thin.
+
+**Tech Stack:** Next.js client component, React, Vitest + Testing Library. Spec: `docs/superpowers/specs/2026-06-24-job-url-autofill-design.md` (task 3.2). Backend (`POST /api/jobs/extract`) returns camelCase `{ title?, company?, location?, descriptionText?, workplaceType?, source }`.
+
+**Branch:** `feat/job-url-autofill-ui` (already created). **Scope:** PR B of 2 (PR A shipped the endpoint).
+
+---
+
+## Task 1: Web API client + Autofill UX
+
+**Files:**
+- Modify: `apps/web/src/lib/api.ts` (add `ExtractedJobResponse` + `extractJobFromUrl`)
+- Modify: `apps/web/src/components/job-create-form.tsx`
+- Test: `apps/web/src/components/job-create-form.test.tsx` (create)
+
+- [ ] **Step 1: Add the web API client**
+
+In `apps/web/src/lib/api.ts`, add (near the other helpers; `requestJson` is the existing helper):
+
+```ts
+export interface ExtractedJobResponse {
+  title?: string;
+  company?: string;
+  location?: string;
+  descriptionText?: string;
+  workplaceType?: 'remote' | 'hybrid' | 'onsite' | 'flexible';
+  source: 'jsonld' | 'opengraph' | 'heuristic' | 'none';
+}
+
+export async function extractJobFromUrl(url: string): Promise<ExtractedJobResponse> {
+  return requestJson<ExtractedJobResponse>('/api/jobs/extract', {
+    method: 'POST',
+    body: JSON.stringify({ url }),
+  });
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/web/src/components/job-create-form.test.tsx`:
+
+```tsx
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, expect, it, vi } from 'vitest';
+
+const { extractJobFromUrl, createJob } = vi.hoisted(() => ({
+  extractJobFromUrl: vi.fn(),
+  createJob: vi.fn(),
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }) }));
+vi.mock('@/lib/api', () => ({
+  extractJobFromUrl,
+  createJob,
+  ApiRequestError: class ApiRequestError extends Error {},
+}));
+
+import { JobCreateForm } from './job-create-form';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+it('disables Autofill until the URL is a valid http(s) URL', async () => {
+  const user = userEvent.setup();
+  render(<JobCreateForm />);
+
+  const autofill = screen.getByRole('button', { name: /autofill/i });
+  expect(autofill).toBeDisabled();
+
+  await user.type(screen.getByLabelText(/job url/i), 'https://boards.greenhouse.io/x/jobs/1');
+  expect(autofill).toBeEnabled();
+});
+
+it('populates the form from a successful extraction', async () => {
+  extractJobFromUrl.mockResolvedValue({
+    title: 'AI Engineer',
+    company: 'Pebble',
+    location: 'Remote',
+    descriptionText: 'Build agents.',
+    workplaceType: 'remote',
+    source: 'jsonld',
+  });
+  const user = userEvent.setup();
+  render(<JobCreateForm />);
+
+  await user.type(screen.getByLabelText(/job url/i), 'https://x/y');
+  await user.click(screen.getByRole('button', { name: /autofill/i }));
+
+  await waitFor(() => expect(screen.getByLabelText(/company/i)).toHaveValue('Pebble'));
+  expect(screen.getByLabelText(/job title/i)).toHaveValue('AI Engineer');
+  expect(screen.getByLabelText(/job description/i)).toHaveValue('Build agents.');
+});
+
+it('shows a manual-entry fallback when nothing could be extracted', async () => {
+  extractJobFromUrl.mockResolvedValue({ source: 'none' });
+  const user = userEvent.setup();
+  render(<JobCreateForm />);
+
+  await user.type(screen.getByLabelText(/job url/i), 'https://x/y');
+  await user.click(screen.getByRole('button', { name: /autofill/i }));
+
+  expect(await screen.findByText(/couldn.t read that posting/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/job title/i)).toHaveValue('');
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/web" && npx vitest run src/components/job-create-form.test.tsx`
+Expected: FAIL — no Autofill button.
+
+- [ ] **Step 4: Implement the form changes**
+
+In `apps/web/src/components/job-create-form.tsx`:
+
+1. Update imports — add `extractJobFromUrl` and a `Download` icon:
+```ts
+import { Download, Loader2, Sparkles } from 'lucide-react';
+import { ApiRequestError, createJob, extractJobFromUrl } from '@/lib/api';
+```
+
+2. Add state below `isSubmitting`:
+```ts
+  const [isExtracting, setIsExtracting] = useState(false);
+  const [autofillNote, setAutofillNote] = useState<string | null>(null);
+```
+
+3. Add a URL check + the autofill handler (after `updateField`):
+```ts
+  function isHttpUrl(value: string): boolean {
+    try {
+      const url = new URL(value.trim());
+      return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  async function handleAutofill() {
+    const url = form.jobUrl.trim();
+    if (!isHttpUrl(url)) return;
+    setIsExtracting(true);
+    setAutofillNote(null);
+    try {
+      const data = await extractJobFromUrl(url);
+      const hasAny = Boolean(
+        data.title || data.company || data.location || data.descriptionText || data.workplaceType,
+      );
+      if (!hasAny) {
+        setAutofillNote('Couldn’t read that posting automatically — paste the description below.');
+        return;
+      }
+      setForm((current) => ({
+        ...current,
+        title: data.title ?? current.title,
+        company: data.company ?? current.company,
+        location: data.location ?? current.location,
+        descriptionText: data.descriptionText ?? current.descriptionText,
+        workplaceType: data.workplaceType ?? current.workplaceType,
+      }));
+      setErrors({});
+      const label = data.source === 'jsonld' ? 'the posting’s structured data' : 'page metadata';
+      toast.success(`Autofilled from ${label} — review before saving.`);
+    } catch (error) {
+      toast.error(
+        error instanceof ApiRequestError ? error.message : 'Could not read that job posting.',
+      );
+    } finally {
+      setIsExtracting(false);
+    }
+  }
+```
+
+5. Replace the Job URL field block (the `<div className="space-y-1.5">` containing the `jobUrl` Label + Input + error) with one that adds the Autofill button and note:
+```tsx
+        <div className="space-y-1.5">
+          <Label htmlFor="jobUrl">Job URL</Label>
+          <div className="flex gap-2">
+            <Input
+              id="jobUrl"
+              value={form.jobUrl}
+              onChange={(event) => updateField('jobUrl', event.target.value)}
+              placeholder="https://…"
+              className="flex-1"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleAutofill}
+              disabled={!isHttpUrl(form.jobUrl) || isExtracting}
+              className="shrink-0 gap-1.5"
+            >
+              {isExtracting ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
+              Autofill
+            </Button>
+          </div>
+          {errors.jobUrl ? <p className="text-destructive text-xs">{errors.jobUrl}</p> : null}
+          {autofillNote ? <p className="text-muted-foreground text-xs">{autofillNote}</p> : null}
+        </div>
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/web" && npx vitest run src/components/job-create-form.test.tsx`
+Expected: PASS (3 tests).
+
+Then: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/web" && npm run lint && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot" && git add apps/web/src/lib/api.ts apps/web/src/components/job-create-form.tsx apps/web/src/components/job-create-form.test.tsx && git commit -F - <<'EOF'
+feat(web): autofill the add-job form from a pasted URL (#120)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01YY7NVS3QLuFeTqkmBaidAB
+EOF
+```
+
+---
+
+## Task 2: Full verification + open PR
+
+- [ ] **Step 1: Full web suite + build**
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/web" && npm test`
+Expected: all PASS.
+
+Run: `cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot/apps/web" && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 2: Push + open PR**
+
+```bash
+cd "C:/Users/talee/OneDrive - Higher Education Commission/projects/JobOps Copilot" && git push -u origin feat/job-url-autofill-ui
+```
+Open the PR (base `main`), title `feat: add-job autofill from URL — frontend (#118 → #120 · PR B)`, body summarising the Autofill button + mapping + fallback, ending with the Generated-with line.
+
+---
+
+## Self-review notes
+- **Spec coverage:** 3.2 (map → form fields, editable, clear fallback) = Task 1.
+- **Type consistency:** `ExtractedJobResponse` (camelCase, matching the backend `ExtractedJob`); `extractJobFromUrl(url)` hits `POST /api/jobs/extract`. `workplaceType` union matches `Job['workplaceType']`.
+- **Behavior:** overwrite-on-autofill (user clicked intentionally), button gated on a valid http(s) URL, inline fallback on `source: 'none'`/no fields, toast on API error (e.g. blocked URL). The URL is still saved on manual submit regardless.
+- **No placeholders:** full code + exact commands.


### PR DESCRIPTION
Phase 3 PR B (final slice) — the frontend for autofill-from-URL, on top of PR A's \`POST /api/jobs/extract\`.

Design: \`docs/superpowers/specs/2026-06-24-job-url-autofill-design.md\` (task 3.2) · Plan: \`docs/superpowers/plans/2026-06-24-job-url-autofill-pr-b-ui.md\`

## What's in this PR
- **Web client** — \`extractJobFromUrl(url)\` → \`POST /api/jobs/extract\`, returning the camelCase \`{ title?, company?, location?, descriptionText?, workplaceType?, source }\`.
- **Autofill button** on \`/jobs/new\`, beside the Job URL field — disabled until the URL is a valid http(s) URL (and while extracting). On click it fills whatever fields the response returns (overwrite-when-present, since the user clicked intentionally) and toasts the source ("structured data" vs "page metadata").
- **Graceful fallback** — when nothing could be extracted (\`source: 'none'\`), an inline note ("Couldn't read that posting automatically — paste the description below.") in an aria-live region; the form stays fully manual and the URL is still saved on submit. API errors (e.g. a blocked URL from the SSRF guard) are toasted.

## Verification
- Web vitest **54 pass** (Autofill: disabled→enabled gating, populate-on-success + toast wording, empty-result fallback, API-error toast). typecheck + lint + build clean. (API unchanged.)

## Notes
- This completes **Phase 3 (#120)**: server-side extract endpoint (PR A #133) + this autofill UI.
- Built subagent-driven with spec + quality review gates; folds in their a11y fixes (live region, aria-hidden icons) and added error-path coverage.
- Product follow-up (flagged, matches the agreed plan): autofill silently overwrites already-typed fields — fine for "paste URL first", could later surface which fields changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)