### PR TITLE
feat: persist AI agent outputs — frontend (#118 → #121 · PR B)

### DIFF
--- a/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
+++ b/apps/web/src/app/(app)/jobs/[jobId]/page.tsx
@@ -13,7 +13,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { fetchProfile } from '@/lib/api';
+import { fetchAgentOutputs, fetchProfile } from '@/lib/api';
 import { isHeuristicAnalysis, isPrerankAnalysis } from '@/lib/analysis-display';
 import { formatDate } from '@/lib/format';
 import { loadJob } from '@/lib/job-data';
@@ -30,11 +30,12 @@ export async function generateMetadata({ params }: JobDetailParams): Promise<Met
 
 export default async function JobDetailPage({ params }: JobDetailParams) {
   const { jobId } = await params;
-  // Fetch the profile alongside the job so we can decide whether auto-scoring is
-  // even possible; a profile failure must not break the page.
-  const [{ job, source }, profile] = await Promise.all([
+  // Fetch the profile + persisted agent outputs alongside the job. Neither is
+  // load-bearing for the page, so a failure of either must not break it.
+  const [{ job, source }, profile, agentOutputs] = await Promise.all([
     loadJob(jobId),
     fetchProfile().catch(() => null),
+    fetchAgentOutputs(jobId).catch(() => []),
   ]);
   if (!job) notFound();
 
@@ -155,7 +156,7 @@ export default async function JobDetailPage({ params }: JobDetailParams) {
 
             <TabsContent value="agents">
               <Card className="p-5">
-                <JobAgentsPanel jobId={job.id} />
+                <JobAgentsPanel jobId={job.id} initialOutputs={agentOutputs} />
               </Card>
             </TabsContent>
 

--- a/apps/web/src/components/job-agents-panel.test.tsx
+++ b/apps/web/src/components/job-agents-panel.test.tsx
@@ -1,0 +1,82 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, expect, it, vi } from 'vitest';
+import type { AgentOutputItem } from '@/lib/api';
+
+const { runInterviewPrep, runResearch, runSkillGap } = vi.hoisted(() => ({
+  runInterviewPrep: vi.fn(),
+  runResearch: vi.fn(),
+  runSkillGap: vi.fn(),
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@/lib/api', () => ({
+  runInterviewPrep,
+  runResearch,
+  runSkillGap,
+  ApiRequestError: class ApiRequestError extends Error {},
+}));
+
+import { JobAgentsPanel } from './job-agents-panel';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const interviewOutput: AgentOutputItem = {
+  jobId: 'job-1',
+  kind: 'interview_prep',
+  modelUsed: 'gpt-test',
+  createdAt: '2026-06-20T10:00:00.000Z',
+  payload: {
+    likely_questions: ['Tell me about a hard bug'],
+    talking_points: ['Shipped the overhaul'],
+    gaps_to_address: [],
+    questions_to_ask: ['What does success look like?'],
+  },
+};
+
+it('renders a persisted output immediately on mount', () => {
+  render(<JobAgentsPanel jobId="job-1" initialOutputs={[interviewOutput]} />);
+
+  expect(screen.getByText('Tell me about a hard bug')).toBeInTheDocument();
+  expect(screen.queryByText(/run the interview prep agent/i)).not.toBeInTheDocument();
+});
+
+it('labels the action "Regenerate" when a persisted output is present', () => {
+  render(<JobAgentsPanel jobId="job-1" initialOutputs={[interviewOutput]} />);
+
+  expect(screen.getByRole('button', { name: /regenerate/i })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /^run agent$/i })).not.toBeInTheDocument();
+});
+
+it('labels the action "Run agent" with no persisted output', () => {
+  render(<JobAgentsPanel jobId="job-1" />);
+
+  expect(screen.getByRole('button', { name: /run agent/i })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /regenerate/i })).not.toBeInTheDocument();
+});
+
+it('shows a "Generated … · model" line for a persisted output', () => {
+  render(<JobAgentsPanel jobId="job-1" initialOutputs={[interviewOutput]} />);
+
+  const line = screen.getByText(/^Generated /);
+  expect(line).toHaveTextContent('gpt-test');
+});
+
+it('regenerate calls the agent API and replaces the shown result', async () => {
+  runInterviewPrep.mockResolvedValue({
+    likely_questions: ['A fresh question'],
+    talking_points: [],
+    gaps_to_address: [],
+    questions_to_ask: [],
+    model_used: 'gpt-fresh',
+  });
+
+  render(<JobAgentsPanel jobId="job-1" initialOutputs={[interviewOutput]} />);
+  await userEvent.click(screen.getByRole('button', { name: /regenerate/i }));
+
+  await waitFor(() => expect(runInterviewPrep).toHaveBeenCalledWith({ jobId: 'job-1' }));
+  expect(await screen.findByText('A fresh question')).toBeInTheDocument();
+  expect(screen.queryByText('Tell me about a hard bug')).not.toBeInTheDocument();
+});

--- a/apps/web/src/components/job-agents-panel.tsx
+++ b/apps/web/src/components/job-agents-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Bot, GraduationCap, Loader2, Search } from 'lucide-react';
-import { useState } from 'react';
+import { useState, useSyncExternalStore } from 'react';
 import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -85,11 +85,27 @@ function RunPrompt({
   );
 }
 
+// `false` during SSR + the initial client render, `true` once hydrated — the
+// React-recommended, mismatch-free way to gate client-only rendering.
+const noopSubscribe = () => () => {};
+function useHydrated() {
+  return useSyncExternalStore(
+    noopSubscribe,
+    () => true,
+    () => false,
+  );
+}
+
 function GeneratedLine({ meta }: { meta: OutputMeta }) {
+  // formatCompactDateTime renders in the runtime's local timezone, so the SSR
+  // (server TZ) and hydration (browser TZ) outputs can disagree. Defer the
+  // local-time string until after hydration to avoid a hydration mismatch.
+  const hydrated = useHydrated();
+
   if (!meta.createdAt) return null;
   return (
     <p className="text-muted-foreground text-xs">
-      Generated {formatCompactDateTime(meta.createdAt)}
+      Generated {hydrated ? formatCompactDateTime(meta.createdAt) : '…'}
       {meta.modelUsed ? ` · ${meta.modelUsed}` : ''}
     </p>
   );

--- a/apps/web/src/components/job-agents-panel.tsx
+++ b/apps/web/src/components/job-agents-panel.tsx
@@ -7,17 +7,41 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { formatCompactDateTime } from '@/lib/format';
 import {
   ApiRequestError,
   runInterviewPrep,
   runResearch,
   runSkillGap,
+  type AgentOutputItem,
+  type AgentOutputKind,
   type InterviewPrepResponse,
   type ResearchBriefResponse,
   type SkillGapPlanResponse,
 } from '@/lib/api';
 
 type AgentKind = 'interview' | 'research' | 'skillGap';
+
+/** Persisted store kinds ↔ the panel's tab keys. */
+const STORE_KIND: Record<AgentKind, AgentOutputKind> = {
+  interview: 'interview_prep',
+  research: 'research',
+  skillGap: 'skill_gap',
+};
+
+interface OutputMeta {
+  createdAt?: string;
+  modelUsed?: string;
+}
+
+/** A persisted run may carry the model on its payload even though the run types omit it. */
+function modelFrom(payload: unknown): string | undefined {
+  if (payload && typeof payload === 'object' && 'model_used' in payload) {
+    const value = (payload as { model_used?: unknown }).model_used;
+    return typeof value === 'string' ? value : undefined;
+  }
+  return undefined;
+}
 
 const AGENTS = [
   { kind: 'interview' as const, icon: GraduationCap, label: 'Interview prep', desc: 'Likely questions, talking points & gaps' },
@@ -55,9 +79,19 @@ function RunPrompt({
       </div>
       <Button size="sm" variant={hasResult ? 'outline' : 'secondary'} disabled={running} onClick={onRun}>
         {running ? <Loader2 className="size-4 animate-spin" /> : null}
-        {running ? 'Running…' : hasResult ? 'Re-run' : 'Run agent'}
+        {running ? 'Running…' : hasResult ? 'Regenerate' : 'Run agent'}
       </Button>
     </div>
+  );
+}
+
+function GeneratedLine({ meta }: { meta: OutputMeta }) {
+  if (!meta.createdAt) return null;
+  return (
+    <p className="text-muted-foreground text-xs">
+      Generated {formatCompactDateTime(meta.createdAt)}
+      {meta.modelUsed ? ` · ${meta.modelUsed}` : ''}
+    </p>
   );
 }
 
@@ -80,16 +114,50 @@ function ListBlock({ title, items }: { title: string; items: string[] }) {
   );
 }
 
-export function JobAgentsPanel({ jobId }: { jobId: string }) {
+function seed<T>(outputs: AgentOutputItem[] | undefined, kind: AgentKind): T | null {
+  const record = outputs?.find((output) => output.kind === STORE_KIND[kind]);
+  return record ? (record.payload as T) : null;
+}
+
+function seedMeta(outputs: AgentOutputItem[] | undefined, kind: AgentKind): OutputMeta {
+  const record = outputs?.find((output) => output.kind === STORE_KIND[kind]);
+  if (!record) return {};
+  return { createdAt: record.createdAt, modelUsed: record.modelUsed ?? modelFrom(record.payload) };
+}
+
+export function JobAgentsPanel({
+  jobId,
+  initialOutputs,
+}: {
+  jobId: string;
+  initialOutputs?: AgentOutputItem[];
+}) {
   const [running, setRunning] = useState<AgentKind | null>(null);
-  const [interview, setInterview] = useState<InterviewPrepResponse | null>(null);
-  const [research, setResearch] = useState<ResearchBriefResponse | null>(null);
-  const [skillGap, setSkillGap] = useState<SkillGapPlanResponse | null>(null);
+  const [interview, setInterview] = useState<InterviewPrepResponse | null>(
+    () => seed<InterviewPrepResponse>(initialOutputs, 'interview'),
+  );
+  const [research, setResearch] = useState<ResearchBriefResponse | null>(
+    () => seed<ResearchBriefResponse>(initialOutputs, 'research'),
+  );
+  const [skillGap, setSkillGap] = useState<SkillGapPlanResponse | null>(
+    () => seed<SkillGapPlanResponse>(initialOutputs, 'skillGap'),
+  );
+  const [meta, setMeta] = useState<Record<AgentKind, OutputMeta>>(() => ({
+    interview: seedMeta(initialOutputs, 'interview'),
+    research: seedMeta(initialOutputs, 'research'),
+    skillGap: seedMeta(initialOutputs, 'skillGap'),
+  }));
 
   async function run<T>(kind: AgentKind, task: () => Promise<T>, onDone: (result: T) => void) {
     setRunning(kind);
     try {
-      onDone(await task());
+      const result = await task();
+      onDone(result);
+      // The server upserts and stamps the row; mirror that on the client without a refetch.
+      setMeta((current) => ({
+        ...current,
+        [kind]: { createdAt: new Date().toISOString(), modelUsed: modelFrom(result) },
+      }));
     } catch (error) {
       toast.error(error instanceof ApiRequestError ? error.message : 'The agent run failed.');
     } finally {
@@ -129,6 +197,7 @@ export function JobAgentsPanel({ jobId }: { jobId: string }) {
             />
             {interview ? (
               <>
+                <GeneratedLine meta={meta.interview} />
                 <ListBlock title="Likely questions" items={interview.likely_questions} />
                 <ListBlock title="Talking points" items={interview.talking_points} />
                 <ListBlock title="Gaps to address" items={interview.gaps_to_address} />
@@ -150,6 +219,7 @@ export function JobAgentsPanel({ jobId }: { jobId: string }) {
             />
             {research ? (
               <>
+                <GeneratedLine meta={meta.research} />
                 {research.used_web_search ? (
                   <Badge variant="secondary" className="w-fit gap-1">
                     <Search className="size-3" /> web search used
@@ -176,6 +246,7 @@ export function JobAgentsPanel({ jobId }: { jobId: string }) {
             />
             {skillGap ? (
               <>
+                <GeneratedLine meta={meta.skillGap} />
                 <p className="text-sm leading-relaxed">{skillGap.summary}</p>
                 <div className="space-y-3">
                   {skillGap.prioritized_skills.map((item, index) => (

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -255,6 +255,27 @@ export async function runSkillGap(payload: {
   });
 }
 
+/** Store-side agent kinds, as persisted by the API (mapped to panel tabs client-side). */
+export type AgentOutputKind = 'interview_prep' | 'research' | 'skill_gap';
+
+export interface AgentOutputItem {
+  jobId: string;
+  kind: AgentOutputKind;
+  /** The raw agent response JSON, stored verbatim (shape depends on `kind`). */
+  payload: unknown;
+  modelUsed?: string;
+  createdAt: string;
+}
+
+/** The persisted agent outputs for a job — `GET /api/jobs/:id/agent-outputs`. */
+export async function fetchAgentOutputs(jobId: string): Promise<AgentOutputItem[]> {
+  const response = await requestJson<{ outputs: AgentOutputItem[] }>(
+    `/api/jobs/${jobId}/agent-outputs`,
+    { cache: 'no-store' },
+  );
+  return response.outputs;
+}
+
 export interface TelemetryInsightsResponse {
   metric: string;
   total: number;


### PR DESCRIPTION
## What & why

Phase 4 (#121) **PR B** — the frontend half of persistent AI agent outputs. PR A (#135, merged) added the `agent_outputs` table, the dual-mode store, persist-on-run in the 3 agent endpoints, and `GET /api/jobs/:id/agent-outputs`. This PR surfaces those persisted outputs in the UI so interview-prep / research / skill-gap results survive tab switches, reloads, and logout — and re-running is a deliberate action (no silent recompute).

Closes the frontend slice of #121. Spec: `docs/superpowers/specs/2026-06-24-agent-output-persistence-design.md`.

## Changes

- **`apps/web/src/lib/api.ts`** — `fetchAgentOutputs(jobId)` client + `AgentOutputItem` / `AgentOutputKind` types hitting `GET /api/jobs/:id/agent-outputs`.
- **`jobs/[jobId]/page.tsx`** — server-fetches agent outputs in parallel with the job + profile (`Promise.all`, `.catch(() => [])` — never blocks the page) and passes them to `JobAgentsPanel` as `initialOutputs`.
- **`JobAgentsPanel`** — seeds `interview`/`research`/`skillGap` from `initialOutputs` so a persisted result renders on mount; the action button reads **"Regenerate"** when a result is present (else "Run agent") and overwrites on re-run; each result shows a **"Generated {date} · {model}"** line. Maps store kinds (`interview_prep`/`research`/`skill_gap`) ↔ panel tab keys (`interview`/`research`/`skillGap`).

## Notes

- The run response types don't expose `model_used`; on regenerate the client stamps `createdAt = now` and reads `model_used` defensively off the payload if present (mirrors the server upsert without a refetch).

## Testing

- New `job-agents-panel.test.tsx`: renders persisted output on mount, "Regenerate" labelling, the generated-at/model line, and regenerate replacing the shown result.
- Full web suite green (60 tests), `tsc --noEmit` clean, `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)