### PR TITLE
feat: global floating assistant widget — frontend (#118 → #122 · PR B)

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
 import { AppHeader } from '@/components/app-header';
 import { AppSidebar } from '@/components/app-sidebar';
+import { AssistantWidget } from '@/components/assistant-widget';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import { fetchProfile } from '@/lib/api';
 
@@ -31,6 +32,8 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         </Suspense>
         <main className="flex-1 p-4 md:p-6 lg:p-8">{children}</main>
       </SidebarInset>
+      {/* Global conversational assistant — available on every authed page. */}
+      <AssistantWidget />
     </SidebarProvider>
   );
 }

--- a/apps/web/src/app/api/assistant-chat/route.ts
+++ b/apps/web/src/app/api/assistant-chat/route.ts
@@ -1,0 +1,42 @@
+import { auth } from '@clerk/nextjs/server';
+import type { NextRequest } from 'next/server';
+
+/**
+ * Streaming proxy to the Express conversational-chat SSE route (Phase 5 · global widget).
+ *
+ * Mirrors `assistant-stream/route.ts`: the catch-all `/api/proxy` buffers and can't stream
+ * SSE, so the chat stream gets its own route that attaches the Clerk token + shared secret
+ * server-side and returns the upstream `ReadableStream` **unbuffered**.
+ */
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const API_BASE = (process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://127.0.0.1:4000').replace(/\/$/, '');
+const SHARED_SECRET = process.env.API_SHARED_SECRET?.trim();
+
+export async function POST(request: NextRequest) {
+  const headers = new Headers();
+  headers.set('content-type', 'application/json');
+
+  const { getToken } = await auth();
+  const token = await getToken();
+  if (token) headers.set('authorization', `Bearer ${token}`);
+  if (SHARED_SECRET) headers.set('x-api-key', SHARED_SECRET);
+
+  const upstream = await fetch(`${API_BASE}/api/ai/assistant/chat`, {
+    method: 'POST',
+    headers,
+    body: await request.arrayBuffer(),
+    cache: 'no-store',
+  });
+
+  // Pass the stream through untouched (do NOT buffer with arrayBuffer()).
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      'content-type': upstream.headers.get('content-type') ?? 'text/event-stream',
+      'cache-control': 'no-cache, no-transform',
+    },
+  });
+}

--- a/apps/web/src/components/assistant-widget.test.tsx
+++ b/apps/web/src/components/assistant-widget.test.tsx
@@ -1,0 +1,109 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+const { state, streamAssistantChat } = vi.hoisted(() => ({
+  state: { pathname: '/dashboard' },
+  streamAssistantChat: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({ usePathname: () => state.pathname }));
+vi.mock('@clerk/nextjs', () => ({ useAuth: () => ({ userId: 'u1', isLoaded: true }) }));
+vi.mock('@/lib/assistant-chat', () => ({ streamAssistantChat }));
+
+import { AssistantWidget } from './assistant-widget';
+
+const STORAGE_KEY = 'jobops:assistant-chat';
+
+beforeEach(() => {
+  state.pathname = '/dashboard';
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+it('renders a launcher and opens the panel', async () => {
+  render(<AssistantWidget />);
+  const launcher = screen.getByRole('button', { name: /open assistant/i });
+  await userEvent.click(launcher);
+  expect(screen.getByRole('dialog', { name: /assistant/i })).toBeInTheDocument();
+  expect(screen.getByLabelText(/message the assistant/i)).toBeInTheDocument();
+});
+
+it('shows job-specific quick prompts on a job page', async () => {
+  state.pathname = '/jobs/job-123';
+  render(<AssistantWidget />);
+  await userEvent.click(screen.getByRole('button', { name: /open assistant/i }));
+  expect(screen.getByRole('button', { name: /what am i missing for this role/i })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /summarize my pipeline/i })).not.toBeInTheDocument();
+});
+
+it('shows general quick prompts off a job page', async () => {
+  render(<AssistantWidget />);
+  await userEvent.click(screen.getByRole('button', { name: /open assistant/i }));
+  expect(screen.getByRole('button', { name: /summarize my pipeline/i })).toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: /what am i missing for this role/i }),
+  ).not.toBeInTheDocument();
+});
+
+it('streams tokens into an assistant message and passes the jobId', async () => {
+  state.pathname = '/jobs/job-123';
+  streamAssistantChat.mockImplementation(async ({ onToken, onDone }) => {
+    onToken('Hello ');
+    onToken('there');
+    onDone({ modelUsed: 'm' });
+  });
+
+  render(<AssistantWidget />);
+  await userEvent.click(screen.getByRole('button', { name: /open assistant/i }));
+  await userEvent.type(screen.getByLabelText(/message the assistant/i), 'hi');
+  await userEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+  expect(await screen.findByText('Hello there')).toBeInTheDocument();
+  expect(screen.getByText('hi')).toBeInTheDocument();
+  expect(streamAssistantChat).toHaveBeenCalledWith(expect.objectContaining({ jobId: 'job-123' }));
+});
+
+it('persists the thread to sessionStorage scoped to the user', async () => {
+  streamAssistantChat.mockImplementation(async ({ onToken, onDone }) => {
+    onToken('Pipeline summary');
+    onDone({});
+  });
+
+  render(<AssistantWidget />);
+  await userEvent.click(screen.getByRole('button', { name: /open assistant/i }));
+  await userEvent.click(screen.getByRole('button', { name: /summarize my pipeline/i }));
+  await screen.findByText('Pipeline summary');
+
+  const stored = JSON.parse(window.sessionStorage.getItem(STORAGE_KEY) ?? '{}');
+  expect(stored.userId).toBe('u1');
+  expect(stored.messages.at(-1)).toEqual({ role: 'assistant', content: 'Pipeline summary' });
+});
+
+it('does not restore another user’s stored thread', async () => {
+  window.sessionStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ userId: 'someone-else', messages: [{ role: 'user', content: 'secret note' }] }),
+  );
+
+  render(<AssistantWidget />);
+  await userEvent.click(screen.getByRole('button', { name: /open assistant/i }));
+
+  expect(screen.queryByText('secret note')).not.toBeInTheDocument();
+});
+
+it('restores the current user’s stored thread on open', async () => {
+  window.sessionStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ userId: 'u1', messages: [{ role: 'assistant', content: 'welcome back' }] }),
+  );
+
+  render(<AssistantWidget />);
+  await userEvent.click(screen.getByRole('button', { name: /open assistant/i }));
+
+  expect(screen.getByText('welcome back')).toBeInTheDocument();
+});

--- a/apps/web/src/components/assistant-widget.tsx
+++ b/apps/web/src/components/assistant-widget.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useAuth } from '@clerk/nextjs';
+import { usePathname } from 'next/navigation';
+import { Loader2, Send, Sparkles, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { streamAssistantChat, type ChatMessage } from '@/lib/assistant-chat';
+
+const STORAGE_KEY = 'jobops:assistant-chat';
+
+interface StoredThread {
+  userId: string;
+  messages: ChatMessage[];
+}
+
+/** Derive the current job id from the path (`/jobs/<id>`), excluding `/jobs/new`. */
+function jobIdFromPath(pathname: string | null): string | undefined {
+  if (!pathname) return undefined;
+  const match = pathname.match(/^\/jobs\/([^/]+)$/);
+  if (!match || match[1] === 'new') return undefined;
+  return match[1];
+}
+
+function quickPromptsFor(jobId: string | undefined): string[] {
+  return jobId
+    ? [
+        'What am I missing for this role?',
+        'Improve my resume for this job',
+        'Draft outreach for this job',
+      ]
+    : [
+        'What should I focus on next?',
+        'Summarize my pipeline',
+        'How do I improve my fit scores?',
+      ];
+}
+
+function readStored(): StoredThread | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredThread;
+    if (typeof parsed?.userId === 'string' && Array.isArray(parsed.messages)) return parsed;
+  } catch {
+    // ignore malformed storage
+  }
+  return null;
+}
+
+export function AssistantWidget() {
+  const pathname = usePathname();
+  const { userId } = useAuth();
+  const jobId = jobIdFromPath(pathname);
+
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [streaming, setStreaming] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hydratedRef = useRef(false);
+  const launcherRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Persist after a turn — but never clobber a prior session's history with an
+  // empty mount; an explicit clear removes the key instead.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !userId || messages.length === 0) return;
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ userId, messages }));
+  }, [userId, messages]);
+
+  // Abort any in-flight stream when the widget unmounts.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  function openPanel() {
+    // Hydrate once, lazily, on first open (by which point Clerk's userId is loaded).
+    // Restore only the *current* user's thread so a logged-out→in switch can't leak.
+    if (!hydratedRef.current) {
+      hydratedRef.current = true;
+      const stored = readStored();
+      if (stored && stored.userId === userId && stored.messages.length > 0) {
+        setMessages(stored.messages);
+      }
+    }
+    setOpen(true);
+  }
+
+  function closePanel() {
+    setOpen(false);
+    launcherRef.current?.focus();
+  }
+
+  async function send(text: string) {
+    const content = text.trim();
+    if (!content || busy) return;
+
+    const next: ChatMessage[] = [...messages, { role: 'user', content }];
+    setMessages(next);
+    setInput('');
+    setStreaming('');
+    setError(null);
+    setBusy(true);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    let acc = '';
+
+    await streamAssistantChat({
+      messages: next,
+      jobId,
+      signal: controller.signal,
+      onToken: (token) => {
+        acc += token;
+        setStreaming(acc);
+      },
+      onDone: () => {
+        if (acc) setMessages((current) => [...current, { role: 'assistant', content: acc }]);
+        setStreaming('');
+        setBusy(false);
+      },
+      onError: (message) => {
+        setError(message);
+        setStreaming('');
+        setBusy(false);
+      },
+    });
+  }
+
+  const prompts = quickPromptsFor(jobId);
+  const empty = messages.length === 0 && !streaming;
+
+  return (
+    <>
+      {/* Launcher */}
+      <Button
+        ref={launcherRef}
+        type="button"
+        aria-label={open ? 'Close assistant' : 'Open assistant'}
+        aria-expanded={open}
+        onClick={() => (open ? closePanel() : openPanel())}
+        className="fixed right-4 bottom-4 z-50 size-12 rounded-full p-0 shadow-lg motion-reduce:transition-none sm:right-6 sm:bottom-6"
+      >
+        {open ? <X className="size-5" /> : <Sparkles className="size-5" />}
+      </Button>
+
+      {/* Panel */}
+      {open ? (
+        <div
+          role="dialog"
+          aria-label="JobOps assistant"
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') closePanel();
+          }}
+          className="bg-background fixed right-4 bottom-20 z-50 flex h-[28rem] max-h-[70vh] w-[calc(100vw-2rem)] max-w-sm flex-col rounded-xl border shadow-2xl sm:right-6 sm:bottom-24"
+        >
+          <header className="flex items-center gap-2 border-b px-4 py-3">
+            <Sparkles className="size-4 text-indigo-500" />
+            <p className="text-sm font-semibold">Assistant</p>
+            {jobId ? (
+              <span className="text-muted-foreground ml-auto text-xs">This job</span>
+            ) : null}
+          </header>
+
+          <div className="flex-1 space-y-3 overflow-y-auto p-4" aria-live="polite">
+            {empty ? (
+              <p className="text-muted-foreground text-sm">
+                Ask anything about your search{jobId ? ' or this job' : ''}. I can advise and draft —
+                actions still happen in the app.
+              </p>
+            ) : null}
+
+            {messages.map((message, index) => (
+              <div
+                key={index}
+                className={cn(
+                  'max-w-[85%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap',
+                  message.role === 'user'
+                    ? 'bg-primary text-primary-foreground ml-auto'
+                    : 'bg-muted',
+                )}
+              >
+                {message.content}
+              </div>
+            ))}
+
+            {streaming ? (
+              <div className="bg-muted max-w-[85%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap">
+                {streaming}
+              </div>
+            ) : null}
+
+            {error ? <p className="text-destructive text-sm">{error}</p> : null}
+          </div>
+
+          {empty ? (
+            <div className="flex flex-wrap gap-1.5 px-4 pb-2">
+              {prompts.map((prompt) => (
+                <button
+                  key={prompt}
+                  type="button"
+                  onClick={() => send(prompt)}
+                  className="bg-muted hover:bg-muted/70 rounded-full px-3 py-1 text-xs motion-reduce:transition-none"
+                >
+                  {prompt}
+                </button>
+              ))}
+            </div>
+          ) : null}
+
+          <form
+            className="flex items-center gap-2 border-t p-3"
+            onSubmit={(event) => {
+              event.preventDefault();
+              send(input);
+            }}
+          >
+            <Input
+              ref={inputRef}
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              placeholder="Ask the assistant…"
+              aria-label="Message the assistant"
+              autoFocus
+            />
+            <Button type="submit" size="icon" disabled={busy || !input.trim()} aria-label="Send">
+              {busy ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
+            </Button>
+          </form>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/components/assistant-widget.tsx
+++ b/apps/web/src/components/assistant-widget.tsx
@@ -78,16 +78,20 @@ export function AssistantWidget() {
   // Abort any in-flight stream when the widget unmounts.
   useEffect(() => () => abortRef.current?.abort(), []);
 
-  function openPanel() {
-    // Hydrate once, lazily, on first open (by which point Clerk's userId is loaded).
-    // Restore only the *current* user's thread so a logged-out→in switch can't leak.
-    if (!hydratedRef.current) {
-      hydratedRef.current = true;
-      const stored = readStored();
-      if (stored && stored.userId === userId && stored.messages.length > 0) {
-        setMessages(stored.messages);
-      }
+  // Hydrate once, as soon as Clerk's userId is known — not on first open, which
+  // can race with Clerk still loading (userId undefined) and permanently skip the
+  // restore. Restore only the *current* user's thread so a logout→login can't leak.
+  useEffect(() => {
+    if (!userId || hydratedRef.current) return;
+    hydratedRef.current = true;
+    const stored = readStored();
+    if (stored && stored.userId === userId && stored.messages.length > 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time hydration from sessionStorage, gated on the async Clerk userId
+      setMessages(stored.messages);
     }
+  }, [userId]);
+
+  function openPanel() {
     setOpen(true);
   }
 

--- a/apps/web/src/lib/assistant-chat.test.ts
+++ b/apps/web/src/lib/assistant-chat.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { streamAssistantChat } from './assistant-chat';
+
+function sseResponse(frames: string[], status = 200): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const frame of frames) controller.enqueue(encoder.encode(frame));
+      controller.close();
+    },
+  });
+  return new Response(body, { status, headers: { 'content-type': 'text/event-stream' } });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it('emits token then done on a clean stream', async () => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    sseResponse([
+      'event: token\ndata: {"text":"hel"}\n\n',
+      'event: token\ndata: {"text":"lo"}\n\n',
+      'event: done\ndata: {"model_used":"m"}\n\n',
+    ]),
+  );
+  const onToken = vi.fn();
+  const onDone = vi.fn();
+  const onError = vi.fn();
+  await streamAssistantChat({
+    messages: [{ role: 'user', content: 'hi' }],
+    onToken,
+    onDone,
+    onError,
+  });
+  expect(onToken.mock.calls.flat()).toEqual(['hel', 'lo']);
+  expect(onDone).toHaveBeenCalledWith({ modelUsed: 'm' });
+  expect(onError).not.toHaveBeenCalled();
+});
+
+it('treats an error frame as terminal — onError, never onDone', async () => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    sseResponse([
+      'event: token\ndata: {"text":"partial"}\n\n',
+      'event: error\ndata: {"message":"boom"}\n\n',
+      // A trailing done frame must be ignored once the stream has errored.
+      'event: done\ndata: {}\n\n',
+    ]),
+  );
+  const onToken = vi.fn();
+  const onDone = vi.fn();
+  const onError = vi.fn();
+  await streamAssistantChat({
+    messages: [{ role: 'user', content: 'hi' }],
+    onToken,
+    onDone,
+    onError,
+  });
+  expect(onToken).toHaveBeenCalledWith('partial');
+  expect(onError).toHaveBeenCalledWith('boom');
+  expect(onDone).not.toHaveBeenCalled();
+});
+
+it('reports a non-OK response via onError', async () => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({ error: 'Daily limit reached' }), { status: 429 }),
+  );
+  const onToken = vi.fn();
+  const onDone = vi.fn();
+  const onError = vi.fn();
+  await streamAssistantChat({
+    messages: [{ role: 'user', content: 'hi' }],
+    onToken,
+    onDone,
+    onError,
+  });
+  expect(onError).toHaveBeenCalledWith('Daily limit reached');
+  expect(onDone).not.toHaveBeenCalled();
+});

--- a/apps/web/src/lib/assistant-chat.ts
+++ b/apps/web/src/lib/assistant-chat.ts
@@ -89,7 +89,11 @@ export async function streamAssistantChat({
           doneEmitted = true;
           onDone({ modelUsed: (parsed.data.model_used as string) ?? undefined });
         } else if (parsed.event === 'error') {
+          // Terminal: stop reading so the clean-end fallback can't fire `onDone`
+          // afterwards and let the widget persist the partial text as a real reply.
           onError((parsed.data.message as string) ?? 'The assistant stream errored.');
+          await reader.cancel().catch(() => {});
+          return;
         }
       }
     }

--- a/apps/web/src/lib/assistant-chat.ts
+++ b/apps/web/src/lib/assistant-chat.ts
@@ -1,0 +1,104 @@
+/**
+ * Client for the conversational assistant stream (Phase 5 · global widget).
+ *
+ * POSTs to the dedicated streaming Next route and parses the SSE frames the
+ * Express → Python chain emits: `token` (append text), `done` (final, carries
+ * `model_used`), `error` (upstream failure). Non-OK responses (e.g. 429 budget,
+ * 503 unavailable) surface through `onError` with the upstream message.
+ */
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface StreamAssistantChatOptions {
+  messages: ChatMessage[];
+  jobId?: string;
+  signal?: AbortSignal;
+  onToken: (text: string) => void;
+  onDone: (meta: { modelUsed?: string }) => void;
+  onError: (message: string) => void;
+}
+
+function parseFrame(frame: string): { event?: string; data: Record<string, unknown> } | null {
+  const lines = frame.split('\n');
+  const event = lines.find((line) => line.startsWith('event:'))?.slice(6).trim();
+  const dataLine = lines.find((line) => line.startsWith('data:'))?.slice(5).trim();
+  if (!event || !dataLine) return null;
+  try {
+    return { event, data: JSON.parse(dataLine) as Record<string, unknown> };
+  } catch {
+    return null;
+  }
+}
+
+export async function streamAssistantChat({
+  messages,
+  jobId,
+  signal,
+  onToken,
+  onDone,
+  onError,
+}: StreamAssistantChatOptions): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch('/api/assistant-chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages, jobId }),
+      signal,
+    });
+  } catch {
+    onError('The assistant is unreachable right now.');
+    return;
+  }
+
+  if (!response.ok || !response.body) {
+    let message =
+      response.status === 503
+        ? "The assistant isn't available right now."
+        : 'The assistant request failed.';
+    try {
+      const payload = (await response.json()) as { error?: string };
+      if (payload?.error) message = payload.error;
+    } catch {
+      // non-JSON body — keep the default message
+    }
+    onError(message);
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let doneEmitted = false;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const frames = buffer.split('\n\n');
+      buffer = frames.pop() ?? '';
+      for (const frame of frames) {
+        const parsed = parseFrame(frame);
+        if (!parsed) continue;
+        if (parsed.event === 'token') {
+          onToken(String(parsed.data.text ?? ''));
+        } else if (parsed.event === 'done') {
+          doneEmitted = true;
+          onDone({ modelUsed: (parsed.data.model_used as string) ?? undefined });
+        } else if (parsed.event === 'error') {
+          onError((parsed.data.message as string) ?? 'The assistant stream errored.');
+        }
+      }
+    }
+  } catch {
+    // Aborted (user closed / navigated) or the stream dropped mid-flight.
+    if (!signal?.aborted) onError('The assistant stream was interrupted.');
+    return;
+  }
+
+  // A clean end without a `done` frame still resolves the turn.
+  if (!doneEmitted) onDone({});
+}


### PR DESCRIPTION
## What & why

Phase 5 (#122) **PR B** — the frontend for the global assistant. A floating, **multi-turn, context-aware** chat widget on every authed page, consuming the streamed chat endpoint from **PR A (#137)**. The existing structured-run `/assistant` page is untouched. **Also closes #113 · J5** (assistant a11y).

Spec: `docs/superpowers/specs/2026-06-25-global-assistant-widget-design.md`.

## Changes

- **`app/api/assistant-chat/route.ts`** — dedicated Next streaming route (clone of `assistant-stream`) that attaches the Clerk token + shared secret server-side and returns the upstream SSE **unbuffered** (the catch-all `/api/proxy` buffers and can't stream).
- **`lib/assistant-chat.ts`** — `streamAssistantChat({ messages, jobId, signal, onToken, onDone, onError })`; parses `token`/`done`/`error` SSE frames; surfaces non-OK upstream messages (429 budget / 503 unavailable).
- **`components/assistant-widget.tsx`** — fixed bottom-right launcher + chat panel:
  - **Multi-turn** conversation state; streaming assistant bubble appends tokens live.
  - **Context-aware** via `usePathname` — `jobId` from `/jobs/<id>` (excl. `/jobs/new`) passed to the stream, so the API grounds answers in that job.
  - **Context-aware quick prompts** — job page (“What am I missing for this role?”, …) vs general (“Summarize my pipeline”, …); clicking sends immediately.
  - **Persistence** — `sessionStorage` keyed by Clerk `userId`: survives reload + full navigation, restores only the current user’s thread (no leak after a logout→login as a different user), and never clobbers prior history with an empty mount.
  - **a11y** — `Esc` closes and returns focus to the launcher, `aria-live` stream region, `aria-label`s, `motion-reduce` on transitions.
  - Mounted once in `(app)/layout.tsx` so it appears everywhere.

## Notes / nuance

- Persistence is intentionally client-side (per the brainstorm: survives reload/navigation, gone after logout) — no DB table. Same-user/same-tab logout→login still sees prior history; documented in the spec as acceptable (avoids a fragile sign-out hook).
- A mid-flight stream is dropped on full reload (no resume) — explicit YAGNI in the spec.

## Testing

- `assistant-widget.test.tsx`: launcher + open; context-aware prompts (job vs general); token streaming into an assistant message + `jobId` passthrough; `sessionStorage` persist scoped to the user; restores the current user’s thread; ignores another user’s thread.
- Full web suite green (**67**); `tsc --noEmit` + `eslint` clean.

## Merge order

PR A (#137) is the backend it calls at runtime; merge **#137 first**, then this. (They’re independent at the code level — this branches off `main` — so review can proceed in parallel.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)