### PR TITLE
feat: consolidate profile management on Clerk (#118 → #123)

### DIFF
--- a/apps/api/src/data/profile-store.test.ts
+++ b/apps/api/src/data/profile-store.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getUserProfile, upsertUserProfile } from './profile-store';
+
+async function withTempStore(run: () => Promise<void>) {
+  const originalCwd = process.cwd();
+  delete process.env.DATABASE_URL; // force the file store
+  const dir = await mkdtemp(join(tmpdir(), 'jobops-profile-'));
+  try {
+    process.chdir(dir);
+    await run();
+  } finally {
+    process.chdir(originalCwd);
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('round-trips resume + profileText and carries no displayName (Phase 6)', async () => {
+  await withTempStore(async () => {
+    const saved = await upsertUserProfile('u1', {
+      resumeText: 'my resume',
+      resumeFileName: 'cv.pdf',
+      profileText: 'profile grounding',
+    });
+    assert.equal('displayName' in saved, false);
+    assert.equal(saved.resumeText, 'my resume');
+    assert.equal(saved.profileText, 'profile grounding');
+
+    const got = await getUserProfile('u1');
+    assert.equal(got?.resumeFileName, 'cv.pdf');
+    assert.equal(got?.profileText, 'profile grounding');
+    assert.equal((got as unknown as Record<string, unknown>).displayName, undefined);
+  });
+});
+
+test('a later upsert preserves prior fields (coalesce semantics)', async () => {
+  await withTempStore(async () => {
+    await upsertUserProfile('u1', { resumeText: 'R', resumeFileName: 'cv.pdf' });
+    await upsertUserProfile('u1', { profileText: 'P' });
+
+    const got = await getUserProfile('u1');
+    assert.equal(got?.resumeText, 'R');
+    assert.equal(got?.resumeFileName, 'cv.pdf');
+    assert.equal(got?.profileText, 'P');
+  });
+});

--- a/apps/api/src/data/profile-store.ts
+++ b/apps/api/src/data/profile-store.ts
@@ -4,7 +4,6 @@ import { getPool, hasPostgresConnection } from '@/lib/postgres';
 
 export interface UserProfile {
   userId: string;
-  displayName?: string;
   resumeText?: string;
   resumeFileName?: string;
   resumeFileUrl?: string;
@@ -14,7 +13,6 @@ export interface UserProfile {
 
 type ProfileRow = {
   user_id: string;
-  display_name: string | null;
   resume_text: string | null;
   resume_file_name: string | null;
   resume_file_url: string | null;
@@ -25,7 +23,6 @@ type ProfileRow = {
 function mapRow(row: ProfileRow): UserProfile {
   return {
     userId: row.user_id,
-    displayName: row.display_name ?? undefined,
     resumeText: row.resume_text ?? undefined,
     resumeFileName: row.resume_file_name ?? undefined,
     resumeFileUrl: row.resume_file_url ?? undefined,
@@ -71,19 +68,17 @@ export async function upsertUserProfile(
     const pool = getPool()!;
     const { rows } = await pool.query<ProfileRow>(
       `
-        insert into user_profiles (user_id, display_name, resume_text, resume_file_name, resume_file_url, profile_text)
-        values ($1, $2, $3, $4, $5, $6)
+        insert into user_profiles (user_id, resume_text, resume_file_name, resume_file_url, profile_text)
+        values ($1, $2, $3, $4, $5)
         on conflict (user_id) do update set
-          display_name = coalesce($2, user_profiles.display_name),
-          resume_text = coalesce($3, user_profiles.resume_text),
-          resume_file_name = coalesce($4, user_profiles.resume_file_name),
-          resume_file_url = coalesce($5, user_profiles.resume_file_url),
-          profile_text = coalesce($6, user_profiles.profile_text)
+          resume_text = coalesce($2, user_profiles.resume_text),
+          resume_file_name = coalesce($3, user_profiles.resume_file_name),
+          resume_file_url = coalesce($4, user_profiles.resume_file_url),
+          profile_text = coalesce($5, user_profiles.profile_text)
         returning *
       `,
       [
         userId,
-        patch.displayName ?? null,
         patch.resumeText ?? null,
         patch.resumeFileName ?? null,
         patch.resumeFileUrl ?? null,

--- a/apps/api/src/routes/profile.ts
+++ b/apps/api/src/routes/profile.ts
@@ -17,8 +17,8 @@ function publicProfile(profile: Awaited<ReturnType<typeof getUserProfile>>) {
     return null;
   }
   // Never ship the full resume text to the client; expose presence + metadata.
+  // Identity (name/avatar/email) lives in Clerk — not here (Phase 6).
   return {
-    displayName: profile.displayName ?? null,
     resumeFileName: profile.resumeFileName ?? null,
     hasResume: Boolean(profile.resumeText),
     profileText: profile.profileText ?? null,
@@ -41,9 +41,8 @@ profileRouter.put('/', async (request, response, next) => {
   try {
     const userId = requireUser(request, response);
     if (!userId) return;
-    const body = request.body as { displayName?: string; profileText?: string };
+    const body = request.body as { profileText?: string };
     const updated = await upsertUserProfile(userId, {
-      displayName: body.displayName?.trim() || undefined,
       profileText: body.profileText?.trim() || undefined,
     });
     response.json({ profile: publicProfile(updated) });
@@ -58,7 +57,7 @@ profileRouter.post('/resume', upload.single('file'), async (request, response, n
     const userId = requireUser(request, response);
     if (!userId) return;
 
-    const body = request.body as { resume_text?: string; display_name?: string };
+    const body = request.body as { resume_text?: string };
     let resumeText = body.resume_text?.trim();
     let resumeFileName: string | undefined;
 
@@ -76,7 +75,6 @@ profileRouter.post('/resume', upload.single('file'), async (request, response, n
     const updated = await upsertUserProfile(userId, {
       resumeText,
       resumeFileName: resumeFileName ?? 'resume.txt',
-      displayName: body.display_name?.trim() || undefined,
     });
 
     response.json({ profile: publicProfile(updated) });

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -10,6 +10,10 @@ const nextConfig: NextConfig = {
   // Keep applicationinsights as a Node.js external so Turbopack/webpack never
   // tries to bundle its dynamic-require internals (mysql, etc.).
   serverExternalPackages: ['applicationinsights'],
+  // Clerk-hosted avatars (the single source of identity — Phase 6).
+  images: {
+    remotePatterns: [{ protocol: 'https', hostname: 'img.clerk.com' }],
+  },
 };
 
 export default nextConfig;

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next';
+import Image from 'next/image';
+import { currentUser } from '@clerk/nextjs/server';
 import { Database, FileText, Webhook } from 'lucide-react';
 import { SectionCard } from '@/components/section-card';
 import { DemoDataActions, ExportDataButton, ResumeReupload } from '@/components/settings-actions';
@@ -22,10 +24,13 @@ const PROVIDER_LABELS: Record<string, string> = {
 };
 
 export default async function SettingsPage() {
-  const [profile, status] = await Promise.all([
+  // Identity (name + avatar) comes from Clerk — the single source (Phase 6).
+  const [user, profile, status] = await Promise.all([
+    currentUser().catch(() => null),
     fetchProfile().catch(() => null),
     fetchStatus().catch(() => null),
   ]);
+  const fullName = user?.fullName ?? user?.firstName ?? null;
 
   const provider = status?.agent.provider ?? null;
   // The agent is a scale-to-zero Container App: when it's asleep, /api/status can't
@@ -46,7 +51,7 @@ export default async function SettingsPage() {
     : agentEnabled
       ? 'Idle — the agent scales to zero and wakes on the first request'
       : 'Deterministic mock (no LLM provider attached)';
-  const initial = (profile?.displayName ?? 'You').slice(0, 1).toUpperCase();
+  const initial = (fullName ?? 'You').slice(0, 1).toUpperCase();
 
   const integrations = [
     {
@@ -76,18 +81,36 @@ export default async function SettingsPage() {
         <p className="text-muted-foreground text-sm">Manage your profile, providers, and data.</p>
       </div>
 
-      <SectionCard title="Profile & resume" description="Used to ground fit scoring and outreach.">
-        <div className="flex flex-wrap items-center gap-3">
-          <span className="bg-primary/10 text-primary flex size-11 items-center justify-center rounded-full text-base font-semibold">
-            {initial}
-          </span>
-          <div className="mr-auto">
-            <p className="text-sm font-medium">{profile?.displayName ?? 'Your profile'}</p>
-            <p className="text-muted-foreground text-xs">
-              {profile?.hasResume ? (profile.resumeFileName ?? 'Resume on file') : 'No resume uploaded yet'}
-            </p>
+      <SectionCard
+        title="Profile & resume"
+        description="Your resume grounds fit scoring and outreach. Name, email & avatar are managed by your account."
+      >
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-3">
+            {user?.imageUrl ? (
+              <Image
+                src={user.imageUrl}
+                alt=""
+                width={44}
+                height={44}
+                className="size-11 rounded-full object-cover"
+              />
+            ) : (
+              <span className="bg-primary/10 text-primary flex size-11 items-center justify-center rounded-full text-base font-semibold">
+                {initial}
+              </span>
+            )}
+            <div className="mr-auto">
+              <p className="text-sm font-medium">{fullName ?? 'Your profile'}</p>
+              <p className="text-muted-foreground text-xs">
+                {profile?.hasResume ? (profile.resumeFileName ?? 'Resume on file') : 'No resume uploaded yet'}
+              </p>
+            </div>
+            <ResumeReupload />
           </div>
-          <ResumeReupload />
+          <p className="text-muted-foreground text-xs">
+            Manage your name, email &amp; avatar from the account menu (top-right).
+          </p>
         </div>
       </SectionCard>
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -317,7 +317,6 @@ export async function fetchStatus(): Promise<SystemStatus> {
 }
 
 export interface UserProfile {
-  displayName: string | null;
   resumeFileName: string | null;
   hasResume: boolean;
   profileText: string | null;
@@ -332,7 +331,6 @@ export async function fetchProfile(): Promise<UserProfile | null> {
 }
 
 export async function updateProfile(payload: {
-  displayName?: string;
   profileText?: string;
 }): Promise<UserProfile | null> {
   const response = await requestJson<{ profile: UserProfile | null }>('/api/profile', {

--- a/db/migrations/009_drop_display_name.sql
+++ b/db/migrations/009_drop_display_name.sql
@@ -1,0 +1,4 @@
+-- Phase 6 — consolidate identity on Clerk. The app no longer stores or presents
+-- its own name; Clerk owns name/avatar/email. `profile_text` (grounding) and the
+-- resume columns stay. Idempotent so db-init can re-run it safely.
+alter table user_profiles drop column if exists display_name;

--- a/docs/superpowers/specs/2026-06-25-clerk-profile-consolidation-design.md
+++ b/docs/superpowers/specs/2026-06-25-clerk-profile-consolidation-design.md
@@ -1,0 +1,114 @@
+# Phase 6 — Consolidate profile management on Clerk (design)
+
+**Date:** 2026-06-25
+**Epic:** #124 · **Phase issue:** #123 (final overhaul phase)
+**Status:** Approved (brainstorm), pending implementation plan
+
+## Goal
+
+One source of truth for identity. Clerk owns name / avatar / email / connected
+accounts / security (already surfaced via `<UserButton>` in the header). The app
+keeps only what's app-specific — the **resume** (for fit scoring / outreach) and
+the grounding **`profileText`**. Remove the duplicate app-side identity field
+(`displayName`) and stop presenting it.
+
+## Root cause (verified)
+
+- The app stores its own `display_name` in `user_profiles`
+  (`apps/api/src/data/profile-store.ts`) and the Settings "Profile & resume" card
+  renders an avatar initial + name from it (`apps/web/src/app/(app)/settings/page.tsx:49,85`).
+- Clerk already provides name / email / avatar / connected accounts / security via
+  `<UserButton>` (`apps/web/src/components/app-header.tsx`). Result: name + avatar
+  are presented in two places.
+- **`displayName` is vestigial:** no UI writes it — `updateProfile` (the only client
+  that sends it) has **zero callers**, and `saveResumeText` / `uploadResumeFile`
+  never send `display_name`. It is only *read* in the Settings card.
+- **`profileText` is NOT identity** — it is grounding text used by fit scoring
+  (`analysis-core.ts`, `ai.ts:95`) and outreach (`ai.ts:179`), set via the n8n
+  intake route. It stays.
+
+## Locked decisions (from brainstorm)
+
+1. **Settings card** shows the real Clerk **identity (read-only)** — avatar + name
+   from `currentUser()` — alongside resume management, plus a pointer:
+   "Manage your name, email & avatar from the account menu (top-right)." No
+   duplicate *editing*; the displayed identity is sourced from Clerk (the single
+   source), not the app.
+2. **Remove `displayName`** entirely: a migration drops the column and it is
+   stripped from the store, profile routes, API types, and web client.
+3. **One PR** off `main` — frontend + backend cleanup + migration are coupled by
+   the `displayName` type removal and the change is small.
+
+## Architecture
+
+### Identity source (Settings, server component)
+
+`settings/page.tsx` is already an async Server Component. Use
+`currentUser()` from `@clerk/nextjs/server` for `fullName` / `firstName` /
+`imageUrl`. No client island, no loading flicker. Fetch it in parallel with the
+existing `fetchProfile()` (resume presence) and `fetchStatus()`.
+
+### Components touched
+
+| File | Change |
+|------|--------|
+| `db/migrations/009_drop_display_name.sql` | `alter table user_profiles drop column if exists display_name;` |
+| `apps/api/src/data/profile-store.ts` | Drop `displayName` from `UserProfile`, `display_name` from `ProfileRow`, `mapRow`, and the upsert column list / params. |
+| `apps/api/src/routes/profile.ts` | Drop `displayName` from `publicProfile`, the `PUT /` body type + param, and the `POST /resume` `display_name` body field. Keep `profileText`. |
+| `apps/web/src/lib/api.ts` | Drop `displayName` from `UserProfile` and from the `updateProfile` payload type. |
+| `apps/web/src/app/(app)/settings/page.tsx` | Replace the `displayName` avatar/name with Clerk `currentUser()` avatar + name (read-only); keep the resume row + `ResumeReupload`; add the account-menu pointer line. |
+
+### Settings "Profile" card (after)
+
+- Avatar: Clerk `imageUrl` (Next `<Image>` / `<img>`); fallback to the initial of
+  `fullName` (else "You") when no image.
+- Name: Clerk `fullName` (fallback "Your profile").
+- Resume row: unchanged — `resumeFileName` / "No resume uploaded yet" + `ResumeReupload`.
+- Helper line: "Manage your name, email & avatar from the account menu (top-right)."
+- Card description shifts to resume framing: "Resume grounds fit scoring & outreach."
+
+## Data flow
+
+```
+Settings (server) → Promise.all[ currentUser() (Clerk identity),
+                                 fetchProfile() (resume presence),
+                                 fetchStatus() ]
+  → render Clerk avatar + name (read-only) + resume management + account-menu pointer
+No displayName is read, returned, or stored anywhere.
+```
+
+## Error handling
+
+- `currentUser()` → null only when unauthenticated; the `(app)` group is auth-gated,
+  so fall back to "You" / "Your profile" defensively.
+- `fetchProfile()` / `fetchStatus()` already degrade to `null` on failure (unchanged).
+- Migration uses `drop column if exists` → idempotent and safe to re-run via `db-init`.
+
+## Testing
+
+- **API:** a `profile.ts` route test asserting `publicProfile` no longer exposes
+  `displayName` and still exposes `profileText` / `hasResume` / `resumeFileName`.
+  Confirm the store upsert + resume route still work without `display_name`
+  (existing profile tests must stay green). No existing test references the profile
+  `displayName` (the only `display_name` test refs are unrelated Adzuna fields).
+- **Web:** the Settings Server Component using `currentUser()` is not cheaply
+  unit-testable; it is presentational and covered by `tsc` + the existing
+  `settings-actions` tests. Verify the full web suite + `tsc` + `eslint` stay green.
+- **Backend gates:** full API (`node:test`) + Python (`pytest`) suites + `ruff`.
+
+## Build slice — 1 PR off `main`
+
+| PR | Scope |
+|----|-------|
+| **A** | migration `009` + strip `displayName` from store/routes/web client + Settings card on Clerk identity + tests |
+
+## YAGNI (out of scope)
+
+No editing Clerk fields from inside the app; no Clerk→app sync; no changes to
+`profileText` / resume storage; no removing the dead `updateProfile` / `PUT /api/profile`
+endpoint beyond dropping its `displayName` param.
+
+## Workflow
+
+One branch off `main`; one PR; address Codex review; **owner merges**. Verify per
+`docs/TESTING.md`.


### PR DESCRIPTION
## What & why

Phase 6 (#123) — the **final** overhaul phase. Identity (name / avatar / email / connected accounts / security) is consolidated on **Clerk**, already surfaced via `<UserButton>` in the header. The app keeps only what's app-specific: the **resume** and the grounding **`profileText`**. The duplicate, **vestigial `displayName`** field is removed.

Spec: `docs/superpowers/specs/2026-06-25-clerk-profile-consolidation-design.md`.

### Why `displayName` was safe to remove
- No UI ever wrote it — `updateProfile` (its only client) has **zero callers**, and the resume upload paths never sent `display_name`. It was only *read* in the Settings card.
- `profileText` is **not identity** — it grounds fit scoring (`analysis-core.ts`, `ai.ts`) and outreach, and is set via n8n intake. **Kept everywhere.**

## Changes

- **`db/migrations/009_drop_display_name.sql`** — `alter table user_profiles drop column if exists display_name` (idempotent, applied by `db-init`).
- **api** — `profile-store.ts`: removed `displayName`/`display_name` from the interface, row type, `mapRow`, and the upsert columns/params. `profile.ts`: removed `displayName` from `publicProfile`, the `PUT /` body, and the `POST /resume` `display_name` field.
- **web** — `lib/api.ts`: dropped `displayName` from `UserProfile` + the `updateProfile` payload. `settings/page.tsx`: the Profile card now shows the real Clerk **avatar + name (read-only)** via `currentUser()`, with the pointer *"Manage your name, email & avatar from the account menu (top-right)."* — resume row + `ResumeReupload` unchanged. `next.config.ts`: allow `img.clerk.com` for `next/image`.

## Decisions (from brainstorm)
- Settings shows Clerk identity **read-only** (single source) + resume management — no duplicate editing.
- `displayName` **removed** (migration), not just hidden.

## Testing
- `profile-store.test.ts`: round-trip asserts **no `displayName` leaks** + `profileText` preserved + coalesce semantics on a second upsert.
- The Settings Server Component (`currentUser()`) is presentational — covered by `tsc` + existing `settings-actions` tests.
- Suites green: **API 171**, **web 70**; `tsc` + `eslint` clean.

## Note
- A live deploy runs migration 009 via `db-init`; `drop column if exists` is safe/idempotent.

This closes the epic (#124): all 6 overhaul phases done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)