### PR TITLE
fix: cold-start retry + retry affordance for streaming assistant (#142)

### DIFF
--- a/apps/api/src/lib/agent-client.ts
+++ b/apps/api/src/lib/agent-client.ts
@@ -148,12 +148,17 @@ export async function streamAssistantUpstream(payload: unknown): Promise<Respons
   if (!isAgentEnabled()) {
     throw new AgentDisabledError();
   }
-  return fetch(`${AGENT_URL}/assistant/stream`, {
-    method: 'POST',
-    headers: agentHeaders({ 'Content-Type': 'application/json' }),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(AGENT_TASK_TIMEOUT_MS),
-  });
+  // Retry once on cold-start timeout. Streaming needs the full AGENT_TASK_TIMEOUT_MS on
+  // the retry too (the container wakes during the first attempt; the retry still streams),
+  // so we pass a fixed-timeout lambda and ignore the attempt number.
+  return withColdStartRetry(() =>
+    fetch(`${AGENT_URL}/assistant/stream`, {
+      method: 'POST',
+      headers: agentHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(AGENT_TASK_TIMEOUT_MS),
+    }),
+  );
 }
 
 /** Open the conversational chat token stream on the agent service (Phase 5). */
@@ -161,12 +166,15 @@ export async function streamAssistantChatUpstream(payload: unknown): Promise<Res
   if (!isAgentEnabled()) {
     throw new AgentDisabledError();
   }
-  return fetch(`${AGENT_URL}/assistant/chat`, {
-    method: 'POST',
-    headers: agentHeaders({ 'Content-Type': 'application/json' }),
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(AGENT_TASK_TIMEOUT_MS),
-  });
+  // Same cold-start retry as streamAssistantUpstream — see comment there.
+  return withColdStartRetry(() =>
+    fetch(`${AGENT_URL}/assistant/chat`, {
+      method: 'POST',
+      headers: agentHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(AGENT_TASK_TIMEOUT_MS),
+    }),
+  );
 }
 
 /** Analyze the activity series via the agent (pandas + LLM narration). */

--- a/apps/web/src/components/assistant-widget.tsx
+++ b/apps/web/src/components/assistant-widget.tsx
@@ -62,6 +62,10 @@ export function AssistantWidget() {
   const [streaming, setStreaming] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [retryPayload, setRetryPayload] = useState<{
+    messages: ChatMessage[];
+    jobId: string | undefined;
+  } | null>(null);
 
   const hydratedRef = useRef(false);
   const launcherRef = useRef<HTMLButtonElement>(null);
@@ -109,6 +113,7 @@ export function AssistantWidget() {
     setInput('');
     setStreaming('');
     setError(null);
+    setRetryPayload(null);
     setBusy(true);
 
     const controller = new AbortController();
@@ -132,6 +137,41 @@ export function AssistantWidget() {
         setError(message);
         setStreaming('');
         setBusy(false);
+        setRetryPayload({ messages: next, jobId });
+      },
+    });
+  }
+
+  async function retry() {
+    if (!retryPayload || busy) return;
+    const { messages: retryMessages, jobId: retryJobId } = retryPayload;
+    setRetryPayload(null);
+    setError(null);
+    setStreaming('');
+    setBusy(true);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    let acc = '';
+
+    await streamAssistantChat({
+      messages: retryMessages,
+      jobId: retryJobId,
+      signal: controller.signal,
+      onToken: (token) => {
+        acc += token;
+        setStreaming(acc);
+      },
+      onDone: () => {
+        if (acc) setMessages((current) => [...current, { role: 'assistant', content: acc }]);
+        setStreaming('');
+        setBusy(false);
+      },
+      onError: (message) => {
+        setError(message);
+        setStreaming('');
+        setBusy(false);
+        setRetryPayload({ messages: retryMessages, jobId: retryJobId });
       },
     });
   }
@@ -199,7 +239,20 @@ export function AssistantWidget() {
               </div>
             ) : null}
 
-            {error ? <p className="text-destructive text-sm">{error}</p> : null}
+            {error ? (
+              <div className="flex items-center gap-2">
+                <p className="text-destructive text-sm">{error}</p>
+                {retryPayload ? (
+                  <button
+                    type="button"
+                    onClick={() => retry()}
+                    className="text-muted-foreground hover:text-foreground text-xs underline motion-reduce:transition-none"
+                  >
+                    Retry
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
           </div>
 
           {empty ? (


### PR DESCRIPTION
## Summary

- **Backend** (`agent-client.ts`): both `streamAssistantUpstream` and `streamAssistantChatUpstream` now wrap their `fetch` in `withColdStartRetry` — if the Container App times out on a cold start the open is retried once. Unlike the parse/score callers the retry keeps the full `AGENT_TASK_TIMEOUT_MS` (streaming needs the full window even after the container wakes, so the attempt number is ignored).
- **Frontend** (`assistant-widget.tsx`): `onError` now captures the failed messages array as `retryPayload`; a **Retry** button appears inline with the error message and re-submits without re-appending the user turn. A second failure restores the button so the user can keep retrying.

## Test plan

- [ ] API: 172 pass (`npm run test --workspace apps/api`)
- [ ] Web: 70 pass (`npx vitest run --root apps/web`)
- [ ] `tsc --noEmit` clean on both apps
- [ ] ESLint clean (`npm run lint --workspace apps/web`)
- [ ] Manual: open widget, send a message while agent is cold → should recover after ~120s retry window or show Retry button if it fails a second time
- [ ] Manual: Retry button appears on error and re-submits successfully when agent is warm

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)