### PR TITLE
fix(auth): fail closed when auth is unconfigured on a production runtime

### DIFF
--- a/apps/api/src/lib/auth.test.ts
+++ b/apps/api/src/lib/auth.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import http from 'node:http';
 import test from 'node:test';
 import express from 'express';
-import { attachUserId } from './auth';
+import { assertProductionAuthConfigured, attachUserId } from './auth';
 
 function snapshotEnv(keys: string[]) {
   const snapshot = new Map<string, string | undefined>();
@@ -55,6 +55,58 @@ test('the service path requires both the key and X-User-Id', async () => {
     // erroring or acting as an empty user.
     const userId = await whoami({ 'X-API-Key': 'svc-secret' });
     assert.equal(userId, 'user_local_dev');
+  } finally {
+    restore();
+  }
+});
+
+test('production with Clerk disabled ignores X-User-Id (fail closed)', async () => {
+  const restore = snapshotEnv(['NODE_ENV', 'CLERK_SECRET_KEY', 'WEBSITE_SITE_NAME', 'API_SHARED_SECRET']);
+  process.env.NODE_ENV = 'production';
+  delete process.env.CLERK_SECRET_KEY;
+  delete process.env.WEBSITE_SITE_NAME;
+  delete process.env.API_SHARED_SECRET;
+  try {
+    // A misconfigured prod deploy (no Clerk) must NOT let an anonymous caller pick an identity.
+    const userId = await whoami({ 'X-User-Id': 'u_attacker' });
+    assert.equal(userId, null);
+  } finally {
+    restore();
+  }
+});
+
+test('outside production, X-User-Id still resolves the dev user', async () => {
+  const restore = snapshotEnv(['NODE_ENV', 'CLERK_SECRET_KEY', 'WEBSITE_SITE_NAME']);
+  delete process.env.NODE_ENV;
+  delete process.env.CLERK_SECRET_KEY;
+  delete process.env.WEBSITE_SITE_NAME;
+  try {
+    const userId = await whoami({ 'X-User-Id': 'u_dev' });
+    assert.equal(userId, 'u_dev');
+  } finally {
+    restore();
+  }
+});
+
+test('assertProductionAuthConfigured throws when production and Clerk is unconfigured', () => {
+  const restore = snapshotEnv(['NODE_ENV', 'CLERK_SECRET_KEY', 'WEBSITE_SITE_NAME']);
+  process.env.NODE_ENV = 'production';
+  delete process.env.CLERK_SECRET_KEY;
+  delete process.env.WEBSITE_SITE_NAME;
+  try {
+    assert.throws(() => assertProductionAuthConfigured(), /CLERK_SECRET_KEY/);
+  } finally {
+    restore();
+  }
+});
+
+test('assertProductionAuthConfigured is a no-op in local development', () => {
+  const restore = snapshotEnv(['NODE_ENV', 'CLERK_SECRET_KEY', 'WEBSITE_SITE_NAME']);
+  delete process.env.NODE_ENV;
+  delete process.env.CLERK_SECRET_KEY;
+  delete process.env.WEBSITE_SITE_NAME;
+  try {
+    assert.doesNotThrow(() => assertProductionAuthConfigured());
   } finally {
     restore();
   }

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -26,6 +26,19 @@ export const clerkAuth: RequestHandler = clerkEnabled
   ? clerkMiddleware()
   : (_request, _response, next) => next();
 
+/**
+ * True when running as a real deployment: an explicit `NODE_ENV=production`, or an Azure
+ * runtime (App Service sets `WEBSITE_SITE_NAME`, Container Apps sets `CONTAINER_APP_NAME`).
+ * Read dynamically so a misconfigured deploy is caught regardless of how prod is signalled.
+ */
+function inProduction(): boolean {
+  return (
+    process.env.NODE_ENV === 'production' ||
+    Boolean(process.env.WEBSITE_SITE_NAME?.trim()) ||
+    Boolean(process.env.CONTAINER_APP_NAME?.trim())
+  );
+}
+
 /** Resolves `req.userId` from Clerk (or the dev/n8n fallback). */
 export function attachUserId(request: Request, _response: Response, next: NextFunction) {
   if (request.path.startsWith('/api/n8n')) {
@@ -49,11 +62,30 @@ export function attachUserId(request: Request, _response: Response, next: NextFu
     if (userId) {
       request.userId = userId;
     }
-  } else {
+  } else if (!inProduction()) {
+    // Dev/test only: with Clerk unconfigured, honor an explicit X-User-Id or the dev default.
+    // In production this branch is skipped, so `userId` stays undefined and `requireUser` 401s —
+    // a deploy that lost its Clerk key fails closed instead of trusting a client header.
     request.userId = request.header('X-User-Id')?.trim() || DEV_USER_ID;
   }
 
   next();
+}
+
+/**
+ * Boot-time guard (called from `server.ts`): refuse to start a production deploy whose auth
+ * would be silently disabled. In production Clerk must be configured; otherwise the API would
+ * fall back to trusting an unauthenticated `X-User-Id` header. Fails loud instead of open.
+ */
+export function assertProductionAuthConfigured(): void {
+  const clerkConfigured = Boolean(process.env.CLERK_SECRET_KEY?.trim());
+  if (inProduction() && !clerkConfigured) {
+    throw new Error(
+      'FATAL: production runtime detected but CLERK_SECRET_KEY is not set. Refusing to start — ' +
+        'the API would otherwise trust an unauthenticated X-User-Id header. Set CLERK_SECRET_KEY ' +
+        '(or run locally without the production / Azure env vars).',
+    );
+  }
 }
 
 /** Returns the request user id, or sends 401 and returns null when absent. */

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -4,7 +4,11 @@ import { startAppInsights } from '@/lib/app-insights';
 startAppInsights();
 
 import { createApp } from '@/app';
+import { assertProductionAuthConfigured } from '@/lib/auth';
 import { registerGracefulShutdown } from '@/lib/shutdown';
+
+// Fail closed: refuse to boot a production deploy whose authentication would be disabled.
+assertProductionAuthConfigured();
 
 const port = Number(process.env.PORT ?? 4000);
 const app = createApp();

--- a/services/agent/app/auth.py
+++ b/services/agent/app/auth.py
@@ -14,6 +14,7 @@ without the secret. When ``AGENT_API_KEY`` is unset, auth is disabled entirely
 from __future__ import annotations
 
 import hmac
+import os
 from collections.abc import Mapping
 
 from app.config import settings
@@ -24,6 +25,30 @@ from app.config import settings
 # The rendered doc explorers (/docs, /redoc) are deliberately NOT exempt so an
 # unauthenticated caller can't browse the full route map on an internet-facing service.
 PUBLIC_PATHS: frozenset[str] = frozenset({"/health", "/openapi.json"})
+
+
+def is_production_runtime() -> bool:
+    """True on an Azure cloud runtime.
+
+    Container Apps sets ``CONTAINER_APP_NAME``; App Service sets ``WEBSITE_SITE_NAME``.
+    Either signals an internet-facing deployment where auth must not be disabled.
+    """
+    return bool(os.environ.get("CONTAINER_APP_NAME") or os.environ.get("WEBSITE_SITE_NAME"))
+
+
+def assert_auth_configured() -> None:
+    """Fail closed: refuse to start on a cloud runtime without a shared secret.
+
+    Unset ``AGENT_API_KEY`` disables auth entirely, which is fine for local dev but would
+    leave the public Container App open. Called at startup so a misconfigured deploy fails
+    loud instead of silently serving unauthenticated.
+    """
+    if is_production_runtime() and not settings.agent_api_key:
+        raise RuntimeError(
+            "FATAL: agent running on a cloud runtime (CONTAINER_APP_NAME / WEBSITE_SITE_NAME set) "
+            "without AGENT_API_KEY. Refusing to start — auth would be disabled on an "
+            "internet-facing service. Provision AGENT_API_KEY."
+        )
 
 
 def extract_key(headers: Mapping[str, str]) -> str | None:

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -19,7 +19,7 @@ from langgraph.types import Command
 from pydantic import BaseModel, Field
 
 from app.agents.runner import run_interview_prep, run_research, run_skill_gap
-from app.auth import is_authorized
+from app.auth import assert_auth_configured, is_authorized
 from app.chains.draft_outreach import draft_outreach
 from app.chains.parse_job import parse_job
 from app.chains.score_fit import score_fit
@@ -133,6 +133,8 @@ async def _lifespan(_app: FastAPI):
     startup when DATABASE_URL is set; degrade to the in-memory saver on any
     failure so a checkpointer outage never blocks the service from starting."""
     global _assistant_graph, _checkpointer_pool
+    # Fail closed: refuse to start on a public cloud runtime with auth disabled.
+    assert_auth_configured()
     if settings.database_url:
         try:
             _assistant_graph, _checkpointer_pool = await _build_durable_assistant_graph()

--- a/services/agent/tests/test_auth.py
+++ b/services/agent/tests/test_auth.py
@@ -5,6 +5,7 @@ is set, while keeping the health/docs probe paths open and staying a no-op when
 no key is configured.
 """
 
+import pytest
 from fastapi.testclient import TestClient
 
 import app.auth as auth
@@ -100,3 +101,32 @@ def test_extract_key_unit():
     assert auth.extract_key({"authorization": f"Bearer {KEY}"}) == KEY
     assert auth.extract_key({"x-agent-key": KEY}) == KEY
     assert auth.extract_key({}) is None
+
+
+def test_is_production_runtime_detects_cloud(monkeypatch):
+    monkeypatch.delenv("CONTAINER_APP_NAME", raising=False)
+    monkeypatch.delenv("WEBSITE_SITE_NAME", raising=False)
+    assert auth.is_production_runtime() is False
+    monkeypatch.setenv("WEBSITE_SITE_NAME", "jobops-agent")
+    assert auth.is_production_runtime() is True
+
+
+def test_assert_auth_configured_raises_in_cloud_without_key(monkeypatch):
+    # The public Container App must refuse to start with auth disabled.
+    monkeypatch.setenv("CONTAINER_APP_NAME", "jobops-agent")
+    monkeypatch.setattr(settings, "agent_api_key", None)
+    with pytest.raises(RuntimeError):
+        auth.assert_auth_configured()
+
+
+def test_assert_auth_configured_ok_in_cloud_with_key(monkeypatch):
+    monkeypatch.setenv("CONTAINER_APP_NAME", "jobops-agent")
+    monkeypatch.setattr(settings, "agent_api_key", KEY)
+    auth.assert_auth_configured()  # no raise
+
+
+def test_assert_auth_configured_ok_locally_without_key(monkeypatch):
+    monkeypatch.delenv("CONTAINER_APP_NAME", raising=False)
+    monkeypatch.delenv("WEBSITE_SITE_NAME", raising=False)
+    monkeypatch.setattr(settings, "agent_api_key", None)
+    auth.assert_auth_configured()  # no raise


### PR DESCRIPTION
Closes #153 · part of epic #152.

## Problem (audit SEC-1 / BE-1, Critical)
Both auth tiers failed **open**. The Express API trusted a client-supplied `X-User-Id` header whenever `CLERK_SECRET_KEY` was unset (`auth.ts`), and the internet-facing Python agent disabled auth entirely when `AGENT_API_KEY` was unset (`auth.py`). One dropped env var = anonymous cross-tenant read/write, failing **silently** (200s). The IaC does not set these vars, so the failure mode is realistic.

## Fix — fail closed on a production runtime
Production is detected via `NODE_ENV=production` or an Azure runtime (`WEBSITE_SITE_NAME` on App Service, `CONTAINER_APP_NAME` on Container Apps), read dynamically so it holds regardless of how prod is signalled.

**API**
- `attachUserId` only honors the `X-User-Id` dev fallback **outside** production — in prod `userId` stays undefined and `requireUser()` returns 401.
- `assertProductionAuthConfigured()` (called from `server.ts`) refuses to boot when a production runtime is detected but Clerk is unconfigured — a loud deploy failure instead of a silent downgrade.

**Agent**
- `assert_auth_configured()` runs at lifespan startup and raises on a cloud runtime when `AGENT_API_KEY` is unset.

Local dev and the test suites are unchanged (no cloud env vars → dev behavior preserved).

## Tests (TDD — written failing first)
- API: production-mode ignores `X-User-Id`; dev still resolves it; the boot guard throws in prod-without-Clerk and is a no-op in dev.
- Agent: `is_production_runtime` detection; the startup guard raises in-cloud-without-key and is a no-op locally / in-cloud-with-key.

## Verification
- API: **184** tests pass (was 180), `tsc --noEmit` clean, eslint clean.
- Agent: **172** passed (was 168), `ruff check` clean.

## Deploy note
For this to actually protect production, the deploy must set `CLERK_SECRET_KEY` (API) and `AGENT_API_KEY` (agent) — which they already do today. This change makes their *absence* a hard failure rather than a silent open door. Follow-up (epic #152, Phase 2) will bake these into the Bicep as required Key Vault references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)