### PR TITLE
fix(agent): scope RAG retrieval to the tenant; never search all users

### DIFF
--- a/docs/AUDIT_REMEDIATION.md
+++ b/docs/AUDIT_REMEDIATION.md
@@ -1,0 +1,49 @@
+# Audit Remediation
+
+Follow-up work to the **2026-07-22 full-stack engineering & security audit** (7 parallel
+specialist passes; overall grade **B**). This is the running journal of the remediation
+program — one finding per branch, test-first, closed by its own PR.
+
+- **Full audit report:** <https://claude.ai/code/artifact/6b022354-a3c5-4a35-8040-045efd2b8327>
+- **Tracking epic:** [#152](https://github.com/Taleef7/jobops-copilot/issues/152)
+- **Dominant theme:** a *fail-open* reflex — controls were present but silently downgraded to
+  "trust the caller" when their config was absent. The program makes them fail **closed**.
+
+## Phase 1 — Stop the bleeding ✅ merged
+
+| Finding | Severity | Issue | PR |
+| --- | --- | --- | --- |
+| Auth fails open in both tiers → fail closed on a cloud runtime (API + agent) | Critical | [#153](https://github.com/Taleef7/jobops-copilot/issues/153) | [#157](https://github.com/Taleef7/jobops-copilot/pull/157) |
+| `next@16.1.6` middleware-bypass CVEs → upgrade to 16.2.11 | High | [#154](https://github.com/Taleef7/jobops-copilot/issues/154) | [#160](https://github.com/Taleef7/jobops-copilot/pull/160) |
+| Unhandled promise rejection could crash the API → `asyncHandler` + process net | High | [#155](https://github.com/Taleef7/jobops-copilot/issues/155) | [#158](https://github.com/Taleef7/jobops-copilot/pull/158) |
+| Resilience: pool-listener leak, unguarded telemetry routes, timeout-less Gmail calls | High | [#156](https://github.com/Taleef7/jobops-copilot/issues/156) | [#159](https://github.com/Taleef7/jobops-copilot/pull/159) |
+
+**Owner action (no PR):** rotate the OpenAI/Gemini/Tavily keys that were in the working-tree
+`.env` (not committed, but in a OneDrive-synced path) and move the working copy off OneDrive.
+
+### Behavioral note — auth now fails closed
+In a production/Azure runtime (`NODE_ENV=production`, or `WEBSITE_SITE_NAME` / `CONTAINER_APP_NAME`
+present) the API refuses to boot without `CLERK_SECRET_KEY`, the agent refuses to boot without
+`AGENT_API_KEY`, and the `X-User-Id` dev shortcut is ignored. The live deploys already set these,
+so nothing changes operationally — a future deploy that *loses* one now fails loudly instead of
+silently serving unauthenticated. Local dev and tests are unchanged.
+
+## Phase 2 — Close tenancy & gating holes 🚧 in progress
+
+| Finding | Severity | Issue | PR |
+| --- | --- | --- | --- |
+| Cross-tenant RAG: `retrieve(user_id=None)` searched all tenants → scope to `IS NULL`; require `user_id` on `/rag/search` | High | [#161](https://github.com/Taleef7/jobops-copilot/issues/161) | _this PR_ |
+| Gate merges + deploys on the full CI suite | High | [#162](https://github.com/Taleef7/jobops-copilot/issues/162) | _pending_ |
+| Test the Postgres stores + tenancy SQL against a real DB in CI | Medium | [#163](https://github.com/Taleef7/jobops-copilot/issues/163) | _pending_ |
+| Supply chain: SHA-pin Actions, add audit gates, pin the agent image | Medium | [#164](https://github.com/Taleef7/jobops-copilot/issues/164) | _pending_ |
+
+## Phase 3 — Make the flagship AI claims true 📋 planned
+
+Fix the eval "off" baseline and re-state the faithfulness numbers; distill the retrieval query so
+the lexical + rerank sides actually fire; skip re-embedding unchanged résumés; trace the
+assistant/chat paths; add an injection guard to `draft_outreach`.
+
+## Phase 4 — Polish & harden for scale 📋 planned
+
+Assistant a11y/stream fixes; loading/error boundaries; pagination + externalized limiter/cache;
+reconcile the Bicep with live reality; refresh remaining stale docs.

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -15,6 +15,13 @@ It now also has a real AI layer: a Python agent service with multi-provider
 LLMs, RAG over pgvector, multi-step LangChain agents, and time-series telemetry
 intelligence.
 
+## Security & audit remediation
+
+A 2026-07 full-stack security + engineering audit (overall grade **B**) is being remediated in
+phases. Phase 1 — fail-closed auth (API + agent), the Next.js middleware-CVE patch, an
+API crash guard, and three resilience fixes — is merged. The running journal, per-finding PR
+log, and behavioral notes live in [AUDIT_REMEDIATION.md](AUDIT_REMEDIATION.md) (epic #152).
+
 ## Verified Milestones
 
 - Multi-tenant: every account is isolated. Data (jobs, reports, outreach, embeddings) is scoped to the Clerk user id; the web forwards the session token to the API via a server-side proxy (`/api/proxy/*`), which `@clerk/express` verifies. New accounts start empty and complete a resume onboarding step (PDF upload or paste); a per-account "Load sample data" / "Clear my data" control lives in Settings. RAG retrieval is user-scoped. The EV/telemetry feature was removed from the app shell (endpoints retained in `services/agent` for demos).

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -274,6 +274,12 @@ def rag_ingest_endpoint(req: IngestRequest) -> dict:
 
 @app.post("/rag/search")
 def rag_search_endpoint(req: SearchRequest) -> dict:
+    # Retrieval must be scoped to a tenant. Reject an unscoped search rather than let a
+    # missing user_id fall through to a cross-tenant read (AI-4).
+    if not (req.user_id and req.user_id.strip()):
+        raise HTTPException(
+            status_code=400, detail="user_id is required to scope retrieval to a tenant."
+        )
     if not rag_available():
         raise HTTPException(status_code=503, detail="RAG is disabled; set DATABASE_URL.")
     matches = _run(retrieve, req.query, req.k, req.source_type, req.source_id, req.user_id)

--- a/services/agent/app/rag/store.py
+++ b/services/agent/app/rag/store.py
@@ -147,9 +147,11 @@ def retrieve(
         if source_id:
             conditions.append("source_id = %s")
             params.append(source_id)
-        if user_id is not None:
-            conditions.append("user_id = %s")
-            params.append(user_id)
+        # Always scope by user, mirroring ingest's `is not distinct from`: a value matches
+        # that user's rows; None matches only unowned (NULL) rows — never every tenant's.
+        # (The prior `if user_id is not None` dropped the filter for None → cross-tenant read.)
+        conditions.append("user_id is not distinct from %s")
+        params.append(user_id)
         where_sql = ("where " + " and ".join(conditions)) if conditions else ""
 
         with _connect() as conn, conn.cursor() as cur:

--- a/services/agent/tests/test_endpoints.py
+++ b/services/agent/tests/test_endpoints.py
@@ -106,6 +106,18 @@ def test_rag_ingest_returns_503_when_disabled(monkeypatch):
     assert res.status_code == 503
 
 
+def test_rag_search_requires_user_id():
+    # Security (AI-4): retrieval must be scoped to a tenant; an unscoped search is rejected.
+    res = client.post("/rag/search", json={"query": "x"})
+    assert res.status_code == 400
+
+
+def test_rag_search_accepts_scoped_user_id(monkeypatch):
+    monkeypatch.setattr(main, "rag_available", lambda: False)
+    res = client.post("/rag/search", json={"query": "x", "user_id": "u1"})
+    assert res.status_code == 503  # validation passed; then rag disabled
+
+
 def test_assistant_run_returns_503_without_provider(monkeypatch):
     monkeypatch.setattr(main, "llm_available", lambda: False)
     res = client.post("/assistant/run", json={"description_text": "Build AI agents."})

--- a/services/agent/tests/test_rag.py
+++ b/services/agent/tests/test_rag.py
@@ -146,11 +146,24 @@ def test_hybrid_scoping_flows_into_lexical_query(monkeypatch):
     lexical_sql, lexical_params = next(
         (sql, params) for sql, params in cursor.calls if "websearch_to_tsquery" in sql
     )
-    assert "user_id = %s" in lexical_sql
+    assert "user_id is not distinct from %s" in lexical_sql
     # Scoping binds precede the two tsquery binds, which precede the limit.
     assert lexical_params[:3] == ["resume", "resume-x", "u1"]
     assert lexical_params[3] == "python backend" and lexical_params[4] == "python backend"
     assert lexical_params[-1] == store.settings.rag_candidate_pool  # pool, then RRF to k
+
+
+def test_retrieve_scopes_to_null_user_when_user_id_missing(monkeypatch):
+    # Security (AI-4): user_id=None must scope to unowned rows (IS NULL), never search
+    # across all tenants. Mirrors ingest's `is not distinct from` semantics.
+    cursor = _FakeCursor(DENSE_ROWS, LEXICAL_ROWS)
+    _patch_store(monkeypatch, cursor)
+    store.retrieve("python backend", k=2, mode="vector", user_id=None)
+    dense_sql, dense_params = next(
+        (sql, params) for sql, params in cursor.calls if "websearch_to_tsquery" not in sql
+    )
+    assert "user_id is not distinct from %s" in dense_sql
+    assert None in dense_params  # the None user_id is bound (scoped), not dropped
 
 
 # --- reranker wiring (Phase 4 · P2) --------------------------------------------------


### PR DESCRIPTION
Closes #161 · part of epic #152 (Phase 2).

## Problem (audit AI-4, High)
`retrieve()` (`services/agent/app/rag/store.py`) added the `user_id` filter **only when `user_id is not None`**, so a `None` (e.g. a Node call that omitted the scope) meant "no filter" — a search across **all tenants'** embeddings. This is asymmetric with `ingest_document`, which correctly uses `user_id is not distinct from %s`. Exposed via `/rag/search`, which took `user_id` from the request body with no requirement that it be present.

## Fix
- **`store.py`** — always scope with `user_id is not distinct from %s`. A value matches that user's rows; `None` matches only unowned (`NULL`) rows — never every tenant's. Now symmetric with ingestion, and the filter reaches both the dense and lexical (FTS) sides.
- **`/rag/search`** — require a non-empty `user_id` (400) instead of letting a missing scope fall through to a cross-tenant read.

(The `/rag/ingest` poisoning path is already closed by the Phase-1 agent auth + this retrieve symmetry: an attacker can't reach the endpoint without the shared key, and unscoped `NULL`-owned rows are unreachable by any real tenant's scoped query.)

## Tests (TDD — written failing first)
- `retrieve(user_id=None)` binds `user_id is not distinct from %s` with `None` — the scope is present, not dropped.
- `/rag/search` returns 400 without `user_id`, and passes validation (then 503 when RAG disabled) with one.
- Updated the existing lexical-scoping assertion to the new SQL.

## Docs
- New **`docs/AUDIT_REMEDIATION.md`** — the running remediation journal (Phase 1 merged + this PR + the roadmap), linked from `IMPLEMENTATION_STATUS.md`.

## Verification
- Agent: **175** tests pass (was 172), `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)