### PR TITLE
ci: harden the supply chain — SHA-pin Actions, Dependabot, critical audit gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions fresh (and patched) — Dependabot bumps the pin
+  # and updates the `# vN` comment, so pinning never means going stale.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # npm workspaces (web + api) resolve from the root lockfile.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # Python agent service.
+  - package-ecosystem: pip
+    directory: /services/agent
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # Python MCP server.
+  - package-ecosystem: pip
+    directory: /services/mcp
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0 # full history so `git log -- services/agent` is accurate
 

--- a/.github/workflows/azure-app-service.yml
+++ b/.github/workflows/azure-app-service.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.x
           cache: npm
@@ -45,7 +45,7 @@ jobs:
       # combined workflow covers web and the code-deploy agent path only.
       - name: Deploy web app
         if: ${{ inputs.target == 'all' || inputs.target == 'web' }}
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3
         with:
           app-name: ${{ vars.AZURE_WEBAPP_NAME_WEB }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_WEB }}
@@ -57,7 +57,7 @@ jobs:
       # This code-deploy path works for a no-RAG agent (core requirements only).
       - name: Deploy agent service
         if: ${{ inputs.target == 'all' || inputs.target == 'agent' }}
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3
         with:
           app-name: ${{ vars.AZURE_WEBAPP_NAME_AGENT }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_AGENT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -58,10 +58,10 @@ jobs:
         working-directory: services/agent
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip
@@ -84,10 +84,10 @@ jobs:
         working-directory: services/mcp
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # Compile the Bicep to ARM — fails on any template error. No Azure login
       # needed (az + Bicep ship on the GitHub-hosted runner).
@@ -127,7 +127,7 @@ jobs:
       CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Gate on Clerk secrets
         id: gate
@@ -141,7 +141,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.gate.outputs.ready == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.x
           cache: npm
@@ -160,3 +160,25 @@ jobs:
         env:
           CI: true
         run: npm run test:e2e
+
+  security:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Gate on CRITICAL advisories only (0 today). Dependabot handles high/moderate as
+      # PRs so this never blocks a merge on a pre-existing transitive advisory, while a
+      # newly-introduced critical fails the build.
+      - name: npm audit (critical)
+        run: npm audit --audit-level=critical

--- a/.github/workflows/deploy-agent.yml
+++ b/.github/workflows/deploy-agent.yml
@@ -33,7 +33,7 @@ jobs:
       IMAGE: ca9ee6437892acr.azurecr.io/jobops-agent
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Log in to ACR
         run: echo "${{ secrets.ACR_PASSWORD }}" | docker login "${ACR}.azurecr.io" -u "${{ secrets.ACR_USERNAME }}" --password-stdin

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -38,10 +38,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.x
           cache: npm
@@ -70,7 +70,7 @@ jobs:
           ( cd apps/api/.deploy && node -e "const d=require('./package.json').dependencies||{};for(const k of Object.keys(d))require.resolve(k);console.log('OK:',Object.keys(d).length,'prod deps resolve');" )
 
       - name: Deploy to Azure App Service
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3
         with:
           app-name: ${{ vars.AZURE_WEBAPP_NAME_API }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.x
           cache: npm
@@ -49,7 +49,7 @@ jobs:
           fi
 
       - name: Deploy to Azure App Service
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3
         with:
           app-name: ${{ vars.AZURE_WEBAPP_NAME_WEB }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_WEB }}

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -38,10 +38,10 @@ jobs:
         working-directory: services/agent
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: eval-report
           path: |

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install k6
-        uses: grafana/setup-k6-action@v1
+        uses: grafana/setup-k6-action@db07bd9765aac508ef18982e52ab937fe633a065 # v1
 
       - name: Run k6
         env:


### PR DESCRIPTION
Part of #164 · epic #152 (Phase 2).

## Problem (audit supply-chain, Medium)
GitHub Actions floated on major tags across all 9 workflows, so a compromised tag — e.g. `azure/webapps-deploy@v3`, which receives the publish-profile credentials — would run arbitrary code in CI. There was also no dependency-advisory gate.

## Fix
- **SHA-pin every action** to a full commit SHA, with a `# vN` comment so the version stays readable and Dependabot can bump it: `checkout`, `setup-node`, `setup-python`, `upload-artifact`, `webapps-deploy`, `setup-k6`.
- **`.github/dependabot.yml`** — weekly updates for `github-actions` + `npm` + `pip` (agent & mcp), so the pins stay fresh and high/moderate advisories arrive as PRs.
- **`security` CI job** — `npm audit --audit-level=critical`: a real gate that is **green today (0 critical)** and fails only on a newly-introduced critical, so it never blocks a merge on a pre-existing transitive advisory.

## Verification
- All 10 YAML files (9 workflows + dependabot) parse.
- `npm audit --audit-level=critical` passes locally (0 critical).
- Every action ref is now `@<sha>` (0 remaining `@vN`).

## Remaining (tracked separately)
Pinning the **agent Docker image** for reproducible builds (base image by digest + `torch` pinned + a `constraints.txt`) needs a Docker-verified pass, so it's split into a follow-up issue rather than done blind here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)