### PR TITLE
test(api): run the Postgres stores against a real DB in CI (tenancy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,45 @@ jobs:
           CI: true
         run: npm test
 
+  db:
+    name: Postgres stores (real DB)
+    runs-on: ubuntu-latest
+    # Runs the *.postgres.ts stores against a real pgvector Postgres — the tenancy SQL
+    # (`where user_id = $1`) that every file-mode store test skips. See src/data/*.pgtest.ts.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: jobops_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/jobops_test
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply migrations
+        run: npm run db:init --workspace @jobops/api
+
+      - name: Postgres store tenancy tests
+        run: npm run test:pg --workspace @jobops/api
+
   agent:
     name: Agent service (Python)
     runs-on: ubuntu-latest

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,6 +6,7 @@
     "dev": "tsx watch src/server.ts",
     "db:init": "tsx scripts/db-init.ts",
     "test": "node scripts/run-tests.mjs",
+    "test:pg": "node --import tsx --test \"src/**/*.pgtest.ts\"",
     "build": "tsc -p tsconfig.json && tsc-alias -p tsconfig.json",
     "start": "node dist/server.js",
     "lint": "eslint .",

--- a/apps/api/src/data/postgres-tenancy.pgtest.ts
+++ b/apps/api/src/data/postgres-tenancy.pgtest.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import { createJob, getJobById, getStoreMode, listJobs } from './job-store';
+import { createSavedSearch, deleteSavedSearch, listSavedSearches } from './saved-search-store';
+
+// This suite runs ONLY against a real Postgres. It is named *.pgtest.ts so the file-mode
+// runner (`npm test`, which globs *.test.ts) never picks it up; run it via `npm run test:pg`
+// with DATABASE_URL pointed at an EPHEMERAL database (see the `db` CI job). It proves the
+// hand-written `where user_id = $1` tenancy boundary in the *.postgres.ts stores — the code
+// every file-mode store test skips by deleting DATABASE_URL.
+const DB = process.env.DATABASE_URL?.trim();
+
+test(
+  'Postgres stores enforce cross-tenant isolation',
+  { skip: DB ? false : 'DATABASE_URL not set — Postgres integration test skipped' },
+  async (t) => {
+    assert.equal(getStoreMode(), 'postgres', 'expected the Postgres backend to be active');
+
+    const suffix = randomUUID().slice(0, 8);
+    const userA = `itest_A_${suffix}`;
+    const userB = `itest_B_${suffix}`;
+
+    await t.test('jobs: a user cannot list or read another user’s job', async () => {
+      const jobA = await createJob(userA, { company: 'Acme', title: 'Eng A', descriptionText: 'a' });
+      const jobB = await createJob(userB, { company: 'Globex', title: 'Eng B', descriptionText: 'b' });
+
+      const listA = await listJobs(userA);
+      assert.ok(listA.some((j) => j.id === jobA.id), 'A sees its own job');
+      assert.ok(!listA.some((j) => j.id === jobB.id), 'A must NOT see B’s job in its list');
+
+      assert.equal(await getJobById(userA, jobB.id), undefined, 'A cannot read B’s job by id');
+      assert.equal(await getJobById(userB, jobA.id), undefined, 'B cannot read A’s job by id');
+    });
+
+    await t.test('saved searches: scoped per user; cannot delete another user’s', async () => {
+      const searchA = await createSavedSearch(userA, { query: 'python backend' });
+      const searchB = await createSavedSearch(userB, { query: 'rust systems' });
+
+      const listA = await listSavedSearches(userA);
+      assert.ok(listA.some((s) => s.id === searchA.id), 'A sees its own saved search');
+      assert.ok(!listA.some((s) => s.id === searchB.id), 'A must NOT see B’s saved search');
+
+      assert.equal(await deleteSavedSearch(userA, searchB.id), false, 'A cannot delete B’s saved search');
+      assert.ok(
+        (await listSavedSearches(userB)).some((s) => s.id === searchB.id),
+        'B’s saved search must survive A’s delete attempt',
+      );
+    });
+  },
+);


### PR DESCRIPTION
Closes #163 · part of epic #152 (Phase 2).

## Problem (audit CI-3, Medium)
Every store test does `delete process.env.DATABASE_URL` to force the **file** backend, so the hand-written `where user_id = $1` SQL in the `*.postgres.ts` stores — the code that actually runs in production and *is* the tenancy boundary — had **zero tests**. The good cross-tenant assertions that exist validate the file implementation only.

## Fix
- **`src/data/postgres-tenancy.pgtest.ts`** — cross-tenant isolation over the real stores: a user can't list or read another user's job, and can't delete another user's saved search. Named `*.pgtest.ts` so the file-mode runner (`npm test`, which globs `*.test.ts`) never picks it up; it **skips cleanly** when `DATABASE_URL` is unset.
- **`npm run test:pg`** runs the `*.pgtest.ts` suite.
- **CI `db` job** — a `pgvector/pgvector:pg16` service, applies migrations via `db:init`, then runs `test:pg`.

## Verification (local, against pgvector/pgvector:pg16)
- Both isolation subtests **pass** against real Postgres (migrations applied, real `WHERE user_id` queries exercised).
- The file-mode suite is still **192** green — the pgtest is excluded from it.
- `test:pg` with no `DATABASE_URL` → **1 skipped** (safe for local dev / other CI jobs).
- `tsc --noEmit` clean.

## Merge note
This adds a `db:` job near the top of `ci.yml`; #167 (supply-chain) adds a `security:` job at the bottom and SHA-pins actions. If #167 merges first, expect a trivial `ci.yml` conflict (keep both jobs) — the `db` job's two actions are already SHA-pinned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)