### PR TITLE
chore(deps): group Dependabot minor/patch updates + go monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # npm workspaces (web + api) resolve from the root lockfile.
   - package-ecosystem: npm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
 version: 2
+# Grouped + monthly to keep the noise down: each ecosystem batches its minor/patch bumps
+# into ONE PR per month. MAJOR bumps are intentionally left OUT of the groups so they
+# arrive as individual PRs and get reviewed on their own (a major can break at runtime in
+# ways CI doesn't exercise — e.g. a provider SDK).
 updates:
-  # Keep the SHA-pinned GitHub Actions fresh (and patched) — Dependabot bumps the pin
-  # and updates the `# vN` comment, so pinning never means going stale.
+  # Keep the SHA-pinned GitHub Actions fresh — Dependabot bumps the pin and its `# vN` comment.
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       actions:
         patterns: ["*"]
@@ -14,19 +17,31 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Python agent service.
   - package-ecosystem: pip
     directory: /services/agent
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5
+    groups:
+      agent-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Python MCP server.
   - package-ecosystem: pip
     directory: /services/mcp
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5
+    groups:
+      mcp-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Tames the Dependabot noise. The first run opened **15** individual PRs because only `github-actions` was grouped. This:

- **Groups** each ecosystem's **minor/patch** bumps into one PR (npm, agent pip, mcp pip) — so a future run is ~4 grouped PRs instead of 15.
- Leaves **major** bumps **out** of the groups, so they arrive individually and get reviewed on their own (a major can break at runtime in ways CI can't exercise — e.g. a provider SDK).
- Switches the schedule from **weekly → monthly**.

Only touches `.github/dependabot.yml`; affects future runs. The current batch of individual PRs is set to auto-merge and draining separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)