### PR TITLE
fix(evals): stop the retrieval sweep leaking the résumé to the generator; re-state the numbers

### DIFF
--- a/EVALS.md
+++ b/EVALS.md
@@ -30,13 +30,25 @@ quality measured and gated here.
 
 Hybrid retrieval (dense pgvector + Postgres FTS via RRF) and the CPU cross-encoder
 reranker are **measured, not assumed**. `evals/retrieval.py` runs the *same*
-fit-score eval under each retrieval mode — only the retrieved evidence changes — so
-the table is a true **downstream delta**:
+fit-score eval under each mode — only the evidence changes — so the table is a true
+**downstream delta**.
 
-- **off** — no resume evidence (JD only); the no-retrieval baseline.
+**Ablation** — the resume reaches the model *only* through retrieval:
+
+- **off** — no resume at all (JD only); the no-retrieval floor.
 - **vector** — dense pgvector only.
 - **hybrid** — dense + FTS fused via Reciprocal Rank Fusion.
 - **hybrid+rerank** — the hybrid pool reranked by `cross-encoder/ms-marco-MiniLM-L-6-v2`.
+
+**Production-path reference** — the whole resume in the prompt, which is what
+`score_fit` actually receives live:
+
+- **full-resume** — whole resume, no retrieved chunks (the no-database fallback).
+- **full-resume+vector** — whole resume *plus* top-k chunks (the live RAG path).
+
+The two groups answer different questions. The ablation asks *what does retrieval buy
+versus nothing?*; the reference pair asks *what does retrieval buy on top of the real
+product prompt?* — the second is the one that matters for the shipped system.
 
 ```bash
 cd services/agent
@@ -47,36 +59,94 @@ Needs **both** a `DATABASE_URL` (with the `chunk_tsv` column + `embeddings_tsv_i
 from migration `007_fts.sql`) **and** a provider key; otherwise it writes a skipped
 report and exits 0. Hybrid modes are marked **N/A** (not silently reported as ≈vector)
 when the FTS column/index are absent, so a missing migration can't masquerade as "no
-gain". Note the sweep's `off` mode feeds the JD only (no resume evidence at all) — it is
-the no-retrieval floor, distinct from the *main* eval's default baseline (`python -m
-evals.run`), which feeds the whole resume. Because the retrieval modes feed only top-k
-chunks, **context-recall can fall even as faithfulness/precision rise** — read all four
-columns, not one headline.
+gain". A sweep ingests the sample resume under a dedicated `eval-harness` tenant so eval
+rows can never land in a shared table as unowned (`user_id IS NULL`) data. Because the
+retrieval modes feed only top-k chunks, **context-recall can fall even as
+faithfulness/precision rise** — read all four columns, not one headline.
 
-### Results (gpt-4o-mini judge, dev DB, 2026-06)
+### Harness integrity
+
+The judge's contexts are derived from the **same `Evidence` value** the generator
+received (`evals/evidence.py`), so a mode cannot score better merely by showing the
+judge more. This was not always true — see the correction below.
+
+### ⚠️ Correction (2026-07-23) — the previous numbers on this page were invalid
+
+An earlier version of this section reported that retrieval lifted faithfulness from
+**0.25 → ~0.83, "a ~3× gain."** **That claim is withdrawn.** It measured what the *judge*
+could see, not what retrieval contributed.
+
+The harness passed `resume_text` to `score_fit` in **every** mode, and `score_fit` puts it
+in the prompt unconditionally. So the `off` arm — documented here as "JD only, no resume
+evidence at all" — had the whole resume in its prompt the entire time. Only the Ragas
+judge's contexts were withheld, which manufactured a low baseline faithfulness for an arm
+that was not actually resume-blind.
+
+The tell was published in the old table and went unnoticed: `off` scored the **highest**
+fit-vs-label Spearman (0.705) of any mode. A model with no resume cannot rank candidates
+against a job description. Under the corrected harness the same arm scores **0.407**.
+
+Fixed in [#197](https://github.com/Taleef7/jobops-copilot/issues/197): the judge's contexts
+are now derived from the same `Evidence` value handed to the generator, and a parametrized
+regression test fails if the two ever diverge again.
+
+### Results (gpt-4o-mini judge, 2026-07-23)
 
 Captured by `python -m evals.run --retrieval-modes`; the raw artifact is committed at
 `services/agent/evals/retrieval_report.json` for auditability. n = 16, 0 errors per mode.
 
 | mode | fit-vs-label Spearman | faithfulness | answer relevancy | context recall |
 | --- | --- | --- | --- | --- |
-| off (JD only) | 0.705 | 0.251 | 0.237 | 0.333 |
-| vector | 0.701 | **0.827** | 0.154 | **0.479** |
-| hybrid | 0.687 | 0.813 | 0.214 | 0.365 |
-| hybrid+rerank | 0.688 | 0.804 | 0.222 | 0.417 |
+| _Ablation_ | | | | |
+| off (JD only, truly resume-blind) | 0.407 | 0.139 | 0.485 | 0.427 |
+| vector | 0.721 | 0.824 | 0.212 | 0.479 |
+| hybrid | 0.779 | 0.922 | 0.167 | 0.417 |
+| hybrid+rerank | 0.704 | 0.777 | 0.225 | 0.427 |
+| _Production-path reference_ | | | | |
+| full-resume | 0.684 | 0.805 | 0.200 | **0.542** |
+| full-resume+vector | 0.726 | 0.795 | 0.157 | 0.490 |
 
-**What the numbers say (honestly).** The headline win is **retrieval vs. no retrieval**:
-grounding the fit summary in retrieved resume evidence lifts **faithfulness from 0.25 →
-~0.80–0.83** — a ~3× gain — because the model stops inventing un-grounded claims. Fit-vs-label
-**Spearman is flat (~0.69–0.70)** across all modes: retrieval mode doesn't change how the
-model *ranks* candidates on this set. On this **16-row** gold set the **hybrid and reranker
-upgrades do not beat plain vector** — vector edges them on faithfulness and context-recall,
-and the hybrid/rerank differences sit within judge variance. That's a legitimate,
-evidence-based result: the infrastructure degrades gracefully and is measured, and at this
-gold-set size the lexical+rerank refinements aren't yet justified over dense-only for *this*
-resume/JD mix. A larger, more lexically diverse gold set (deferred — see the epic) is where
-hybrid/rerank would be expected to pull ahead. Answer-relevancy stays low for the same reason
-as the main eval (lightweight MiniLM embeddings + JD-as-question framing).
+#### The measured noise floor — read this before comparing any two rows
+
+On this gold set **`hybrid` and `vector` are the same experiment.** The lexical side is
+structurally dead: `_lexical_candidates` builds `websearch_to_tsquery('english', <whole JD>)`,
+which **ANDs** every term, so a JD becomes a ~98-node conjunction that no resume chunk can
+satisfy. Verified directly against the database: **0 of 16** JDs match a single chunk, and
+`hybrid` returns **byte-identical chunks to `vector` on 16/16 rows**. RRF fusing
+`[dense, []]` is just `dense`.
+
+So the apparent "hybrid beats vector" gap — **Δ0.058 Spearman, Δ0.098 faithfulness** — comes
+from *provably identical generator input*. It is pure sampling noise (temperature 0.2 plus
+Ragas judge variance), and it is the best error bar we have:
+
+> **On this 16-row set, no difference below ~0.06 Spearman / ~0.10 faithfulness is
+> interpretable.** Every hybrid/rerank comparison in this table sits inside that band.
+
+Fixing the lexical query is tracked as
+[#198](https://github.com/Taleef7/jobops-copilot/issues/198); until then, **hybrid and
+hybrid+rerank are unmeasured**, not measured-and-equal.
+
+#### What the numbers actually support
+
+**Retrieval works, and the honest claim is stronger than a faithfulness ratio.** A
+resume-blind model (`off`) ranks candidates at **0.407** Spearman and grounds almost nothing
+(**0.139** faithfulness) — it fabricates a candidate. Feeding it only **four retrieved
+chunks** restores **0.721 / 0.824**, which matches the **whole-resume** prompt's **0.684 /
+0.805** within the noise floor. That is the defensible result: *top-k retrieval recovers
+full-resume quality from a fraction of the context.*
+
+**Retrieval adds nothing measurable on top of the production prompt.** `full-resume+vector`
+(0.726 / 0.795) versus `full-resume` (0.684 / 0.805) is well inside the noise band. For a
+single-resume prompt that already fits the context window, RAG is buying context *efficiency*,
+not accuracy — which is the honest engineering justification for it here.
+
+**Context-recall behaves exactly as it should**, which is a useful sanity check on the judge:
+`full-resume` scores highest (0.542) because the whole resume covers the reference rationale
+by construction, while top-k modes trade recall for precision.
+
+**Answer-relevancy inverts, and that is not a win.** `off` scores *highest* (0.485) because a
+model with no resume writes generic, on-topic prose about the role. The metric rewards
+addressing the question, not being right — treat it as a foil, not a quality signal.
 
 ## Gold set
 

--- a/EVALS.md
+++ b/EVALS.md
@@ -106,7 +106,7 @@ Captured by `python -m evals.run --retrieval-modes`; the raw artifact is committ
 | full-resume | 0.684 | 0.805 | 0.200 | **0.542** |
 | full-resume+vector | 0.726 | 0.795 | 0.157 | 0.490 |
 
-#### The measured noise floor — read this before comparing any two rows
+#### `hybrid` and `vector` are the same experiment — read this before comparing any two rows
 
 On this gold set **`hybrid` and `vector` are the same experiment.** The lexical side is
 structurally dead: `_lexical_candidates` builds `websearch_to_tsquery('english', <whole JD>)`,
@@ -115,30 +115,69 @@ satisfy. Verified directly against the database: **0 of 16** JDs match a single 
 `hybrid` returns **byte-identical chunks to `vector` on 16/16 rows**. RRF fusing
 `[dense, []]` is just `dense`.
 
-So the apparent "hybrid beats vector" gap — **Δ0.058 Spearman, Δ0.098 faithfulness** — comes
-from *provably identical generator input*. It is pure sampling noise (temperature 0.2 plus
-Ragas judge variance), and it is the best error bar we have:
-
-> **On this 16-row set, no difference below ~0.06 Spearman / ~0.10 faithfulness is
-> interpretable.** Every hybrid/rerank comparison in this table sits inside that band.
+So the apparent "hybrid beats vector" gap — Δ0.058 Spearman, Δ0.098 faithfulness — comes from
+*provably identical generator input*. It is pure sampling noise (temperature 0.2 plus Ragas
+judge variance).
 
 Fixing the lexical query is tracked as
 [#198](https://github.com/Taleef7/jobops-copilot/issues/198); until then, **hybrid and
 hybrid+rerank are unmeasured**, not measured-and-equal.
 
+### How much does this eval move when nothing changes?
+
+One identical-input pair shows variance of a given size *occurred*; it does not bound the
+variance. So the spread is measured directly — the same configuration, scored five times:
+
+```bash
+python -m evals.run --noise-floor 5   # writes evals/noise_report.{json,md}
+```
+
+Retrieval is frozen up front (retrieved once, reused), so every replicate receives byte-identical
+evidence and all movement is generator + judge variance.
+
+| metric | mean | stdev | min | max | max pairwise Δ |
+| --- | --- | --- | --- | --- | --- |
+| fit-vs-label Spearman | 0.767 | 0.034 | 0.721 | 0.797 | **0.076** |
+| faithfulness | 0.778 | 0.039 | 0.741 | 0.821 | **0.080** |
+| answer relevancy | 0.225 | 0.052 | 0.160 | 0.291 | **0.131** |
+| context recall | 0.488 | 0.043 | 0.448 | 0.542 | **0.094** |
+
+**Five replicates are still not enough to bound the tail, and the table above proves it.** The
+sweep's `hybrid` faithfulness of **0.922** lies *outside* the entire replicate range
+(0.741–0.821) — and `hybrid` is, by construction, the same experiment as `vector`. A single
+extra draw landed beyond five prior ones, so treat these figures as a **floor on the spread**,
+not a confidence interval. Reporting `n` and the observed range beats reporting a threshold.
+
+**Practical rule:** a between-mode difference on the order of **0.08 Spearman / 0.08–0.10
+faithfulness or smaller is unresolved** on this gold set. Resolving effects that small needs a
+larger gold set, a fixed-seed judge, or replicate-averaged scores per mode — not a closer read
+of a single sweep.
+
 #### What the numbers actually support
 
-**Retrieval works, and the honest claim is stronger than a faithfulness ratio.** A
-resume-blind model (`off`) ranks candidates at **0.407** Spearman and grounds almost nothing
-(**0.139** faithfulness) — it fabricates a candidate. Feeding it only **four retrieved
-chunks** restores **0.721 / 0.824**, which matches the **whole-resume** prompt's **0.684 /
-0.805** within the noise floor. That is the defensible result: *top-k retrieval recovers
-full-resume quality from a fraction of the context.*
+**Retrieval works, and this is the one effect large enough to be safe.** A resume-blind model
+(`off`) ranks candidates at **0.407** Spearman and grounds almost nothing (**0.139**
+faithfulness) — it fabricates a candidate. Feeding it only **four retrieved chunks** gives
+**0.721 / 0.824**. Those gaps are **0.31 Spearman and 0.69 faithfulness — roughly 4× and 9×
+the largest no-op movement measured above.** No plausible amount of judge variance explains
+them. This is the defensible result: *top-k retrieval recovers most of the model's ability to
+assess a candidate, from a fraction of the context.*
 
-**Retrieval adds nothing measurable on top of the production prompt.** `full-resume+vector`
-(0.726 / 0.795) versus `full-resume` (0.684 / 0.805) is well inside the noise band. For a
-single-resume prompt that already fits the context window, RAG is buying context *efficiency*,
-not accuracy — which is the honest engineering justification for it here.
+**Everything else in the table is unresolved, and that is a limit of the measurement, not a
+finding.** Both remaining comparisons sit inside the noise:
+
+| comparison | Δ Spearman | Δ faithfulness | verdict |
+| --- | --- | --- | --- |
+| retrieval-only (`vector`) vs whole résumé (`full-resume`) | 0.037 | 0.019 | unresolved |
+| `full-resume+vector` vs `full-resume` | 0.042 | 0.010 | unresolved |
+| no-op replicate spread (reference) | 0.076 | 0.080 | — |
+
+So the correct statement is *"we cannot detect a difference,"* **not** *"there is no
+difference."* These deltas put a rough **upper bound on the effect size** — whatever retrieval
+adds on top of a whole-résumé prompt is smaller than this setup can see. That is still useful:
+it means top-k retrieval is not measurably *worse* than sending the entire résumé, which is
+what justifies it here on **context efficiency** grounds. It is not evidence that retrieval is
+useless on the production path, and it must not be quoted as such.
 
 **Context-recall behaves exactly as it should**, which is a useful sanity check on the judge:
 `full-resume` scores highest (0.542) because the whole resume covers the reference rationale
@@ -186,6 +225,7 @@ pip install -r requirements-dev.txt -r requirements-evals.txt
 python -m evals.run               # writes evals/report.json + evals/report.md
 python -m evals.run --gate        # also fails (exit 1) if a metric is below threshold
 python -m evals.run --retrieval-modes  # per-mode retrieval comparison (needs DB + key)
+python -m evals.run --noise-floor 5    # run-to-run spread, same config (needs DB + key)
 ```
 
 (`requirements-evals.txt` carries Ragas; it is intentionally **not** in the runtime

--- a/docs/AUDIT_REMEDIATION.md
+++ b/docs/AUDIT_REMEDIATION.md
@@ -62,10 +62,16 @@ Two things came out of the re-measurement that are worth more than the original 
 1. **A real result.** Four retrieved chunks recover whole-résumé quality (0.721/0.824 vs
    0.684/0.805) — retrieval buys context *efficiency*, not accuracy, on a prompt that already
    fits. That is the honest engineering justification.
-2. **A measured noise floor.** `hybrid` and `vector` retrieve byte-identical chunks on 16/16
-   rows (the lexical side matches 0/16 JDs — see #198), yet scored Δ0.058 Spearman and Δ0.098
-   faithfulness apart. Identical inputs, different outputs: that gap *is* the error bar, and
-   every hybrid/rerank comparison ever published on this gold set sits inside it.
+2. **An honest measure of how noisy this eval is.** `hybrid` and `vector` retrieve
+   byte-identical chunks on 16/16 rows (the lexical side matches 0/16 JDs — see #198) yet
+   scored Δ0.058 Spearman / Δ0.098 faithfulness apart. One such pair only shows variance of
+   that order *occurred*, so the spread is now measured properly: `--noise-floor 5` scores one
+   fixed configuration five times. Result — Spearman sd 0.034 (range 0.721–0.797),
+   faithfulness sd 0.039 (range 0.741–0.821). Even that understates it: the sweep's `hybrid`
+   faithfulness (0.922) lands outside all five replicates despite being the same experiment,
+   so the figures are a **floor on the spread, not a bound**. Only the retrieval-vs-nothing
+   effect (4–9× the largest no-op movement) clears it; every other comparison in the table is
+   *unresolved*, which is a limit of the measurement rather than a finding.
 
 Structural fix: `evals/evidence.py` makes the generator's inputs and the judge's contexts
 derive from one `Evidence` value, with a parametrized regression test that fails if they

--- a/docs/AUDIT_REMEDIATION.md
+++ b/docs/AUDIT_REMEDIATION.md
@@ -37,11 +37,39 @@ silently serving unauthenticated. Local dev and tests are unchanged.
 | Test the Postgres stores + tenancy SQL against a real DB in CI | Medium | [#163](https://github.com/Taleef7/jobops-copilot/issues/163) | _pending_ |
 | Supply chain: SHA-pin Actions, add audit gates, pin the agent image | Medium | [#164](https://github.com/Taleef7/jobops-copilot/issues/164) | _pending_ |
 
-## Phase 3 — Make the flagship AI claims true 📋 planned
+## Phase 3 — Make the flagship AI claims true 🚧 in progress
 
-Fix the eval "off" baseline and re-state the faithfulness numbers; distill the retrieval query so
-the lexical + rerank sides actually fire; skip re-embedding unchanged résumés; trace the
-assistant/chat paths; add an injection guard to `draft_outreach`.
+| Finding | Severity | Issue | PR |
+| --- | --- | --- | --- |
+| Eval sweep leaked the résumé to the generator → "~3× faithfulness" withdrawn | High | [#197](https://github.com/Taleef7/jobops-copilot/issues/197) | _this PR_ |
+| Retrieval query is the raw JD: lexical side never fires, dense query truncated | High | [#198](https://github.com/Taleef7/jobops-copilot/issues/198) | _pending_ |
+| Skip re-embedding unchanged résumés; structured-output retry + clamp | Medium | [#199](https://github.com/Taleef7/jobops-copilot/issues/199) | _pending_ |
+| Trace assistant/chat paths; injection-guard `draft_outreach` | Medium | [#200](https://github.com/Taleef7/jobops-copilot/issues/200) | _pending_ |
+
+### What the eval correction found
+
+The retrieval sweep passed `resume_text` to `score_fit` in **every** mode, and `score_fit`
+puts it in the prompt unconditionally — so the `off` arm, documented as "JD only", always had
+the whole résumé. Only the Ragas judge's contexts varied. The published "faithfulness
+0.25 → 0.83, a ~3× gain" measured judge visibility.
+
+The evidence was already in the published table: `off` scored the *highest* fit-vs-label
+Spearman (0.705). A résumé-blind model cannot rank candidates. Corrected, that arm scores
+**0.407**.
+
+Two things came out of the re-measurement that are worth more than the original claim:
+
+1. **A real result.** Four retrieved chunks recover whole-résumé quality (0.721/0.824 vs
+   0.684/0.805) — retrieval buys context *efficiency*, not accuracy, on a prompt that already
+   fits. That is the honest engineering justification.
+2. **A measured noise floor.** `hybrid` and `vector` retrieve byte-identical chunks on 16/16
+   rows (the lexical side matches 0/16 JDs — see #198), yet scored Δ0.058 Spearman and Δ0.098
+   faithfulness apart. Identical inputs, different outputs: that gap *is* the error bar, and
+   every hybrid/rerank comparison ever published on this gold set sits inside it.
+
+Structural fix: `evals/evidence.py` makes the generator's inputs and the judge's contexts
+derive from one `Evidence` value, with a parametrized regression test that fails if they
+diverge.
 
 ## Phase 4 — Polish & harden for scale 📋 planned
 

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -57,9 +57,13 @@ log, and behavioral notes live in [AUDIT_REMEDIATION.md](AUDIT_REMEDIATION.md) (
   bridge, #65); agent-as-MCP-client consuming external tools (#66).
 - **Phase 4 — hybrid retrieval, reranker & eval (epic #70):** hybrid retrieval (pgvector +
   Postgres FTS via RRF, #67); CPU cross-encoder reranker (opt-in, graceful, #68); retrieval-mode
-  eval with the per-mode comparison committed to `EVALS.md` (#69). Measured: retrieval grounding
-  ≈3× faithfulness; hybrid/rerank within judge variance vs vector on the 16-row gold set.
-  Fine-tuning dropped (CPU-only infra).
+  eval with the per-mode comparison committed to `EVALS.md` (#69). Fine-tuning dropped
+  (CPU-only infra). **Numbers re-stated 2026-07-23 (#197):** the original "≈3× faithfulness"
+  was a judge-visibility artifact — the sweep leaked the resume to the generator in every mode.
+  Corrected measurement: top-k retrieval recovers whole-resume quality (0.72 vs 0.68 Spearman,
+  0.82 vs 0.81 faithfulness) from a fraction of the context, while a truly resume-blind
+  baseline collapses to 0.41 / 0.14. Hybrid/rerank remain **unmeasured** — the lexical side
+  matches 0/16 JDs, so hybrid is byte-identical to vector (#198).
 - **Phase 5 — operational hardening (epic #76):** job-search TTL cache + the API `node:test`
   suite wired into CI (#77); Bicep IaC of the live Azure topology, CI-validated + `what-if`-verified
   (#78); k6 load test verified against the live API (#79); Playwright e2e verified locally and

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -200,8 +200,11 @@ Design + plans live under `docs/superpowers/specs|plans/`.
   Fusion, with graceful vector-only fallback.
 - **CPU cross-encoder reranker** (#68): opt-in, graceful, no new dependency.
 - **Retrieval-mode eval** (#69): off/vector/hybrid/hybrid+rerank downstream delta; results in
-  `EVALS.md` (retrieval grounding ≈3× faithfulness; hybrid/rerank within variance vs vector on
-  the 16-row gold set). **Fine-tuning was dropped** (CPU-only infra; needs labeled data + GPU).
+  `EVALS.md`. **Fine-tuning was dropped** (CPU-only infra; needs labeled data + GPU).
+  **Corrected 2026-07-23 (#197):** the original "≈3× faithfulness" headline was withdrawn —
+  the harness leaked the resume to the generator in every arm, so the baseline was never
+  resume-blind. See the correction notice in `EVALS.md` for the re-measured table and the
+  measured noise floor.
 
 ### Phase 5 — Operational hardening (complete, epic #76)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -204,7 +204,8 @@ Design + plans live under `docs/superpowers/specs|plans/`.
   **Corrected 2026-07-23 (#197):** the original "≈3× faithfulness" headline was withdrawn —
   the harness leaked the resume to the generator in every arm, so the baseline was never
   resume-blind. See the correction notice in `EVALS.md` for the re-measured table and the
-  measured noise floor.
+  replicate-derived run-to-run spread (`python -m evals.run --noise-floor N`), which shows
+  only the retrieval-vs-nothing effect is large enough to resolve on this gold set.
 
 ### Phase 5 — Operational hardening (complete, epic #76)
 

--- a/services/agent/evals/evidence.py
+++ b/services/agent/evals/evidence.py
@@ -1,0 +1,49 @@
+"""What the generator is allowed to see for one eval row — and therefore what the
+judge is allowed to see.
+
+Both sides used to be built independently: the runner always handed the whole resume
+to ``score_fit`` while the retrieval sweep varied only the Ragas judge's contexts. The
+two drifted, and the drift *was* the published headline — a resume-blind ``off``
+baseline that had the resume in its prompt the whole time scored low faithfulness
+purely because the judge could not see what the model was working from.
+
+``Evidence`` makes that impossible: the generator's inputs and the judge's contexts
+are derived from one value, so an ablation can only be run by actually withholding
+evidence from the model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.rag.chunk import chunk_text
+
+
+@dataclass(frozen=True)
+class Evidence:
+    """The candidate evidence available for one row.
+
+    ``resume_text`` is the whole resume handed to the generator (``""`` means the
+    model gets no resume at all); ``retrieved_context`` is the top-k retrieved chunks.
+    A pure retrieval ablation sets only the latter, so the resume can reach the model
+    *only* through retrieval.
+    """
+
+    resume_text: str = ""
+    retrieved_context: tuple[str, ...] = field(default_factory=tuple)
+
+    def judge_contexts(self, job_description: str) -> list[str]:
+        """The Ragas ``retrieved_contexts`` for this evidence — never more, never less.
+
+        The resume is chunked so the judge receives it in the same granularity the
+        retrieval modes do; a retrieved chunk that is also part of the full resume is
+        counted once. The job description is always appended: a fit summary
+        legitimately cites role requirements and gaps, which live in the JD, not the
+        resume, so a resume-only context would mark those claims unfaithful.
+        """
+        contexts: list[str] = []
+        for context in (*chunk_text(self.resume_text), *self.retrieved_context):
+            if context not in contexts:
+                contexts.append(context)
+        contexts.append(job_description)
+        return contexts

--- a/services/agent/evals/noise.py
+++ b/services/agent/evals/noise.py
@@ -1,0 +1,188 @@
+"""Replicate-run noise estimation: how much does this eval move when nothing changes?
+
+The retrieval sweep compares modes whose scores differ by a few hundredths. Before any
+such delta can be called a result, you need to know how much the pipeline moves on its
+own — the generator samples at a non-zero temperature and the Ragas judge is itself an
+LLM.
+
+Observing that two identical-input runs differed by some amount shows variance of that
+order *occurred*; it does not bound it. This module runs the same configuration N times
+and reports an actual interval, so a between-mode delta can be compared against the
+spread of a no-op change.
+
+Retrieval is held fixed: ``vector`` mode over an already-ingested resume returns the
+same chunks every time, so all observed movement is generator + judge variance.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.config import settings
+from app.rag.store import retrieve_resume_evidence
+from evals.evidence import Evidence
+from evals.retrieval import EVAL_USER_ID
+from evals.run import run_fit_score_eval
+
+logger = logging.getLogger("jobops.evals")
+
+# Metrics worth a spread estimate: the rank correlation plus every Ragas score.
+_RAGAS_METRICS = ("faithfulness", "answer_relevancy", "context_recall")
+
+
+def summarize_spread(values: list[float | None]) -> dict:
+    """Centre and worst case for one metric across replicates.
+
+    ``max_pairwise_delta`` is the headline: it is the widest gap between any two runs
+    of the *same* configuration, which is directly comparable to a between-mode delta.
+    ``None`` values (a Ragas metric that failed to score) are dropped rather than
+    treated as zero.
+    """
+    present = [v for v in values if v is not None]
+    if not present:
+        return {
+            "n": 0,
+            "mean": None,
+            "stdev": None,
+            "min": None,
+            "max": None,
+            "max_pairwise_delta": None,
+        }
+    return {
+        "n": len(present),
+        "mean": round(statistics.fmean(present), 4),
+        # Sample stdev: these replicates are a sample of possible runs, not the
+        # population of them. Undefined for a single observation.
+        "stdev": round(statistics.stdev(present), 4) if len(present) > 1 else None,
+        "min": round(min(present), 4),
+        "max": round(max(present), 4),
+        "max_pairwise_delta": round(max(present) - min(present), 4),
+    }
+
+
+def run_replicates(
+    rows: list[dict],
+    resume_text: str,
+    *,
+    replicates: int = 5,
+    k: int = 4,
+    retrieve_evidence: Callable = retrieve_resume_evidence,
+    score_eval: Callable = run_fit_score_eval,
+) -> dict:
+    """Score the same evidence ``replicates`` times; return the per-metric spread.
+
+    Every replicate is handed the *same* ``Evidence``, retrieved once up front — if the
+    inputs varied between runs this would measure retrieval, not noise.
+    """
+    if replicates < 2:
+        raise ValueError("noise estimation needs at least 2 replicates")
+
+    original = (settings.rag_retrieval_mode, settings.rag_rerank_enabled)
+    try:
+        settings.rag_retrieval_mode = "vector"
+        settings.rag_rerank_enabled = False
+        # Retrieve once and freeze it, so every replicate is byte-identical.
+        frozen = {
+            index: Evidence(
+                retrieved_context=tuple(
+                    retrieve_evidence(
+                        resume_text, row["description_text"], k=k, user_id=EVAL_USER_ID
+                    )
+                )
+            )
+            for index, row in enumerate(rows)
+        }
+        by_row = {id(row): frozen[index] for index, row in enumerate(rows)}
+
+        runs = []
+        for attempt in range(replicates):
+            logger.info("noise replicate %d/%d", attempt + 1, replicates)
+            metrics = score_eval(rows, resume_text, evidence_for=lambda row: by_row[id(row)])
+            runs.append(
+                {
+                    "rank_correlation_spearman": metrics.get("rank_correlation_spearman"),
+                    **{name: (metrics.get("ragas") or {}).get(name) for name in _RAGAS_METRICS},
+                }
+            )
+    finally:
+        settings.rag_retrieval_mode, settings.rag_rerank_enabled = original
+
+    metric_names = ("rank_correlation_spearman", *_RAGAS_METRICS)
+    return {
+        "mode": "vector",
+        "replicates": replicates,
+        "runs": runs,
+        "spread": {name: summarize_spread([run[name] for run in runs]) for name in metric_names},
+    }
+
+
+def render_noise_markdown(report: dict) -> str:
+    lines = ["# JobOps Copilot — Eval Noise Floor", ""]
+    lines.append(f"- Generated: `{report['generated_at']}`")
+    lines.append(f"- Judge / model: `{report.get('provider') or 'n/a'}`")
+    if report["status"] != "ok":
+        lines += ["", f"> Skipped: {report.get('skipped_reason')}"]
+        return "\n".join(lines) + "\n"
+
+    lines += [
+        f"- Configuration: `{report['mode']}` retrieval, **{report['replicates']} replicates**",
+        "",
+        "Identical evidence every run — retrieval is frozen up front, so all movement below",
+        "is generator sampling + Ragas judge variance. Compare a between-mode delta against",
+        "`max pairwise Δ`: a difference smaller than what a *no-op change* produces is not a",
+        "result.",
+        "",
+        "| metric | mean | stdev | min | max | max pairwise Δ |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for name, spread in report["spread"].items():
+        if not spread["n"]:
+            lines.append(f"| {name} | _n/a_ | _n/a_ | _n/a_ | _n/a_ | _n/a_ |")
+            continue
+        lines.append(
+            f"| {name} | {spread['mean']} | {spread['stdev']} | {spread['min']} "
+            f"| {spread['max']} | **{spread['max_pairwise_delta']}** |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def noise_main(output_dir: Path | None = None, replicates: int = 5) -> int:
+    """Entry for ``python -m evals.run --noise-floor [N]``."""
+    logging.basicConfig(level=logging.INFO)
+    output_dir = output_dir or Path(__file__).parent
+    generated_at = datetime.now(UTC).isoformat(timespec="seconds")
+
+    from app.rag.store import rag_available
+    from evals.run import _DATA_DIR, _load_jsonl, _provider_ready, get_model
+
+    if not _provider_ready() or not rag_available():
+        reason = "no provider key configured" if not _provider_ready() else "no database configured"
+        report = {
+            "generated_at": generated_at,
+            "status": "skipped",
+            "skipped_reason": reason,
+            "provider": None,
+        }
+    else:
+        _, provider_label = get_model()
+        rows = _load_jsonl(_DATA_DIR / "fit_score.jsonl")
+        resume = (_DATA_DIR / "sample_resume.txt").read_text(encoding="utf-8")
+        report = {
+            "generated_at": generated_at,
+            "status": "ok",
+            "provider": provider_label,
+            **run_replicates(rows, resume, replicates=replicates),
+        }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "noise_report.json").write_text(
+        json.dumps(report, indent=2) + "\n", encoding="utf-8"
+    )
+    (output_dir / "noise_report.md").write_text(render_noise_markdown(report), encoding="utf-8")
+    print(render_noise_markdown(report))
+    return 0

--- a/services/agent/evals/noise_report.json
+++ b/services/agent/evals/noise_report.json
@@ -1,0 +1,73 @@
+{
+  "generated_at": "2026-07-23T22:45:44+00:00",
+  "status": "ok",
+  "provider": "openai:gpt-4o-mini",
+  "mode": "vector",
+  "replicates": 5,
+  "runs": [
+    {
+      "rank_correlation_spearman": 0.7973,
+      "faithfulness": 0.8205,
+      "answer_relevancy": 0.1965,
+      "context_recall": 0.4479
+    },
+    {
+      "rank_correlation_spearman": 0.7801,
+      "faithfulness": 0.7409,
+      "answer_relevancy": 0.2622,
+      "context_recall": 0.4792
+    },
+    {
+      "rank_correlation_spearman": 0.7944,
+      "faithfulness": 0.7498,
+      "answer_relevancy": 0.2166,
+      "context_recall": 0.4479
+    },
+    {
+      "rank_correlation_spearman": 0.7209,
+      "faithfulness": 0.7562,
+      "answer_relevancy": 0.2912,
+      "context_recall": 0.5208
+    },
+    {
+      "rank_correlation_spearman": 0.7413,
+      "faithfulness": 0.8201,
+      "answer_relevancy": 0.1604,
+      "context_recall": 0.5417
+    }
+  ],
+  "spread": {
+    "rank_correlation_spearman": {
+      "n": 5,
+      "mean": 0.7668,
+      "stdev": 0.034,
+      "min": 0.7209,
+      "max": 0.7973,
+      "max_pairwise_delta": 0.0764
+    },
+    "faithfulness": {
+      "n": 5,
+      "mean": 0.7775,
+      "stdev": 0.0394,
+      "min": 0.7409,
+      "max": 0.8205,
+      "max_pairwise_delta": 0.0796
+    },
+    "answer_relevancy": {
+      "n": 5,
+      "mean": 0.2254,
+      "stdev": 0.052,
+      "min": 0.1604,
+      "max": 0.2912,
+      "max_pairwise_delta": 0.1308
+    },
+    "context_recall": {
+      "n": 5,
+      "mean": 0.4875,
+      "stdev": 0.0426,
+      "min": 0.4479,
+      "max": 0.5417,
+      "max_pairwise_delta": 0.0938
+    }
+  }
+}

--- a/services/agent/evals/noise_report.md
+++ b/services/agent/evals/noise_report.md
@@ -1,0 +1,17 @@
+# JobOps Copilot — Eval Noise Floor
+
+- Generated: `2026-07-23T22:45:44+00:00`
+- Judge / model: `openai:gpt-4o-mini`
+- Configuration: `vector` retrieval, **5 replicates**
+
+Identical evidence every run — retrieval is frozen up front, so all movement below
+is generator sampling + Ragas judge variance. Compare a between-mode delta against
+`max pairwise Δ`: a difference smaller than what a *no-op change* produces is not a
+result.
+
+| metric | mean | stdev | min | max | max pairwise Δ |
+| --- | --- | --- | --- | --- | --- |
+| rank_correlation_spearman | 0.7668 | 0.034 | 0.7209 | 0.7973 | **0.0764** |
+| faithfulness | 0.7775 | 0.0394 | 0.7409 | 0.8205 | **0.0796** |
+| answer_relevancy | 0.2254 | 0.052 | 0.1604 | 0.2912 | **0.1308** |
+| context_recall | 0.4875 | 0.0426 | 0.4479 | 0.5417 | **0.0938** |

--- a/services/agent/evals/retrieval.py
+++ b/services/agent/evals/retrieval.py
@@ -1,19 +1,29 @@
 """Retrieval-mode eval (Phase 4 · Q): the downstream fit-score quality delta.
 
 Runs the existing fit-score eval (rank correlation + Ragas) under each retrieval
-mode and reports a per-mode comparison:
+mode and reports a per-mode comparison.
 
-- ``off``           — no resume evidence (JD only); the true no-retrieval baseline.
+**Retrieval ablation** — the resume reaches the generator *only* through retrieval:
+
+- ``off``           — no resume at all (JD only); the true no-retrieval floor.
 - ``vector``        — dense pgvector only.
 - ``hybrid``        — dense + Postgres FTS fused via RRF.
 - ``hybrid+rerank`` — hybrid pool reranked by the CPU cross-encoder.
 
-The point is *downstream delta*: same gold set, same scorer, only the retrieved
-context changes — so we measure what retrieval actually buys the fit score.
+**Production-path reference** — the whole resume in the prompt, which is what
+``score_fit`` actually receives in production:
 
-Note: ``off`` (and today's default baseline) feed the *whole* resume, while the
-retrieval modes feed only top-k chunks. Context-recall can therefore fall even as
-faithfulness/precision rise — read all four metrics, not one headline.
+- ``full-resume``        — whole resume, no retrieved chunks (the no-DB fallback).
+- ``full-resume+vector`` — whole resume *plus* top-k chunks (the live RAG path).
+
+Together the two groups answer different questions: the ablation measures what
+retrieval buys versus nothing, the reference pair measures what retrieval buys *on
+top of* the real product prompt.
+
+The point is *downstream delta*: same gold set, same scorer, only the evidence
+changes. Because the judge's contexts are derived from the same ``Evidence`` the
+generator received (see ``evals.evidence``), a mode can only look better by actually
+grounding the summary better — not by showing the judge more (#197).
 """
 
 from __future__ import annotations
@@ -23,19 +33,36 @@ from collections.abc import Callable, Sequence
 
 from app.config import settings
 from app.rag.store import retrieve_resume_evidence
+from evals.evidence import Evidence
 from evals.run import run_fit_score_eval
 
 logger = logging.getLogger("jobops.evals")
 
-RETRIEVAL_MODES = ("off", "vector", "hybrid", "hybrid+rerank")
+RETRIEVAL_MODES = (
+    "off",
+    "vector",
+    "hybrid",
+    "hybrid+rerank",
+    "full-resume",
+    "full-resume+vector",
+)
+
+# A sweep ingests the sample resume to retrieve against. Scope those rows to a
+# dedicated tenant: unowned (user_id IS NULL) rows are exactly what any
+# `retrieve(user_id=None)` caller reads, so an eval run against a shared database
+# would otherwise leave the sample resume inside real retrieval's reach.
+EVAL_USER_ID = "eval-harness"
 
 # (rag_retrieval_mode, rag_rerank_enabled) toggles for each evidence-bearing mode.
 _MODE_TOGGLES = {
     "vector": ("vector", False),
     "hybrid": ("hybrid", False),
     "hybrid+rerank": ("hybrid", True),
+    "full-resume+vector": ("vector", False),
 }
 _FTS_MODES = ("hybrid", "hybrid+rerank")
+# Modes that also put the whole resume in the prompt (the production path).
+_FULL_RESUME_MODES = ("full-resume", "full-resume+vector")
 
 
 def _fts_ready() -> bool:
@@ -61,24 +88,32 @@ def _fts_ready() -> bool:
         return False
 
 
-def _make_contexts_for(
+def _make_evidence_for(
     mode: str, resume_text: str, k: int, retrieve_evidence: Callable
-) -> Callable[[dict], list[str]]:
-    """A ``contexts_for(row)`` callable for one retrieval mode."""
-    if mode == "off":
-        return lambda _row: []  # JD only — the true no-retrieval baseline
+) -> Callable[[dict], Evidence]:
+    """An ``evidence_for(row)`` callable for one mode.
+
+    ``resume_in_prompt`` is what separates the ablation from the production-path
+    reference: the ablation withholds the resume so retrieval is the only way the
+    model can learn anything about the candidate.
+    """
+    resume_in_prompt = resume_text if mode in _FULL_RESUME_MODES else ""
+
+    if mode not in _MODE_TOGGLES:  # "off" and "full-resume" retrieve nothing
+        return lambda _row: Evidence(resume_text=resume_in_prompt)
 
     retrieval_mode, rerank = _MODE_TOGGLES[mode]
 
-    def contexts_for(row: dict) -> list[str]:
+    def evidence_for(row: dict) -> Evidence:
         # retrieve() takes mode= but rerank is read from settings, so we toggle both
         # here. Safe only because this eval is single-process / non-concurrent (a CLI
         # run); run_retrieval_modes restores the original settings in its finally.
         settings.rag_retrieval_mode = retrieval_mode
         settings.rag_rerank_enabled = rerank
-        return retrieve_evidence(resume_text, row["description_text"], k=k)
+        chunks = retrieve_evidence(resume_text, row["description_text"], k=k, user_id=EVAL_USER_ID)
+        return Evidence(resume_text=resume_in_prompt, retrieved_context=tuple(chunks))
 
-    return contexts_for
+    return evidence_for
 
 
 def run_retrieval_modes(
@@ -111,8 +146,8 @@ def run_retrieval_modes(
                         "reason": "chunk_tsv / embeddings_tsv_idx absent",
                     }
                     continue
-            contexts_for = _make_contexts_for(mode, resume_text, k, retrieve_evidence)
-            metrics = score_eval(rows, resume_text, contexts_for=contexts_for)
+            evidence_for = _make_evidence_for(mode, resume_text, k, retrieve_evidence)
+            metrics = score_eval(rows, resume_text, evidence_for=evidence_for)
             metrics["status"] = "ok"
             results[mode] = metrics
     finally:

--- a/services/agent/evals/retrieval_report.json
+++ b/services/agent/evals/retrieval_report.json
@@ -1,55 +1,79 @@
 {
-  "generated_at": "2026-06-18T16:52:55+00:00",
+  "generated_at": "2026-07-23T22:22:41+00:00",
   "status": "ok",
   "provider": "openai:gpt-4o-mini",
   "modes_order": [
     "off",
     "vector",
     "hybrid",
-    "hybrid+rerank"
+    "hybrid+rerank",
+    "full-resume",
+    "full-resume+vector"
   ],
   "modes": {
     "off": {
       "n": 16,
       "errors": 0,
-      "rank_correlation_spearman": 0.7049,
+      "rank_correlation_spearman": 0.4067,
       "ragas": {
-        "faithfulness": 0.2506,
-        "context_recall": 0.3333,
-        "answer_relevancy": 0.2369
+        "faithfulness": 0.1392,
+        "context_recall": 0.4271,
+        "answer_relevancy": 0.4847
       },
       "status": "ok"
     },
     "vector": {
       "n": 16,
       "errors": 0,
-      "rank_correlation_spearman": 0.7014,
+      "rank_correlation_spearman": 0.7209,
       "ragas": {
-        "faithfulness": 0.8268,
+        "faithfulness": 0.8236,
         "context_recall": 0.4792,
-        "answer_relevancy": 0.1541
+        "answer_relevancy": 0.2124
       },
       "status": "ok"
     },
     "hybrid": {
       "n": 16,
       "errors": 0,
-      "rank_correlation_spearman": 0.687,
+      "rank_correlation_spearman": 0.7789,
       "ragas": {
-        "faithfulness": 0.8134,
-        "context_recall": 0.3646,
-        "answer_relevancy": 0.2139
+        "faithfulness": 0.9221,
+        "context_recall": 0.4167,
+        "answer_relevancy": 0.1671
       },
       "status": "ok"
     },
     "hybrid+rerank": {
       "n": 16,
       "errors": 0,
-      "rank_correlation_spearman": 0.688,
+      "rank_correlation_spearman": 0.7043,
       "ragas": {
-        "faithfulness": 0.8036,
-        "context_recall": 0.4167,
-        "answer_relevancy": 0.2219
+        "faithfulness": 0.7768,
+        "context_recall": 0.4271,
+        "answer_relevancy": 0.2245
+      },
+      "status": "ok"
+    },
+    "full-resume": {
+      "n": 16,
+      "errors": 0,
+      "rank_correlation_spearman": 0.684,
+      "ragas": {
+        "faithfulness": 0.8046,
+        "context_recall": 0.5417,
+        "answer_relevancy": 0.1995
+      },
+      "status": "ok"
+    },
+    "full-resume+vector": {
+      "n": 16,
+      "errors": 0,
+      "rank_correlation_spearman": 0.7262,
+      "ragas": {
+        "faithfulness": 0.795,
+        "context_recall": 0.4896,
+        "answer_relevancy": 0.1565
       },
       "status": "ok"
     }

--- a/services/agent/evals/retrieval_report.md
+++ b/services/agent/evals/retrieval_report.md
@@ -1,15 +1,21 @@
 # JobOps Copilot — Retrieval-Mode Comparison
 
-- Generated: `2026-06-18T16:52:55+00:00`
+- Generated: `2026-07-23T22:22:41+00:00`
 - Judge / model: `openai:gpt-4o-mini`
 
-Same gold set + scorer; only the retrieved evidence changes (downstream delta).
-`off` feeds **no** resume evidence (JD only); retrieval modes feed only top-k chunks,
-so context-recall can fall even as faithfulness rises — read all four columns.
+Same gold set + scorer; only the evidence changes (downstream delta). The judge's
+contexts are derived from exactly what the generator received, so a mode cannot look
+better merely by showing the judge more.
+
+**Ablation** (`off` … `hybrid+rerank`): the resume reaches the model *only* through
+retrieval — `off` gets the JD and nothing else. **Reference** (`full-resume*`): the
+whole resume in the prompt, which is what `score_fit` does in production.
 
 | mode | fit-vs-label Spearman | faithfulness | answer relevancy | context recall | n (errors) |
 | --- | --- | --- | --- | --- | --- |
-| off | 0.7049 | 0.2506 | 0.2369 | 0.3333 | 16 (0) |
-| vector | 0.7014 | 0.8268 | 0.1541 | 0.4792 | 16 (0) |
-| hybrid | 0.687 | 0.8134 | 0.2139 | 0.3646 | 16 (0) |
-| hybrid+rerank | 0.688 | 0.8036 | 0.2219 | 0.4167 | 16 (0) |
+| off | 0.4067 | 0.1392 | 0.4847 | 0.4271 | 16 (0) |
+| vector | 0.7209 | 0.8236 | 0.2124 | 0.4792 | 16 (0) |
+| hybrid | 0.7789 | 0.9221 | 0.1671 | 0.4167 | 16 (0) |
+| hybrid+rerank | 0.7043 | 0.7768 | 0.2245 | 0.4271 | 16 (0) |
+| full-resume | 0.684 | 0.8046 | 0.1995 | 0.5417 | 16 (0) |
+| full-resume+vector | 0.7262 | 0.795 | 0.1565 | 0.4896 | 16 (0) |

--- a/services/agent/evals/run.py
+++ b/services/agent/evals/run.py
@@ -356,4 +356,10 @@ if __name__ == "__main__":
 
     if "--retrieval-modes" in sys.argv:
         raise SystemExit(retrieval_main())
+    if "--noise-floor" in sys.argv:
+        from evals.noise import noise_main
+
+        index = sys.argv.index("--noise-floor") + 1
+        replicates = int(sys.argv[index]) if len(sys.argv) > index else 5
+        raise SystemExit(noise_main(replicates=replicates))
     raise SystemExit(main(gate="--gate" in sys.argv))

--- a/services/agent/evals/run.py
+++ b/services/agent/evals/run.py
@@ -21,8 +21,8 @@ from app.chains.parse_job import parse_job
 from app.chains.score_fit import score_fit
 from app.config import settings
 from app.llm.provider import get_model, resolve_provider
-from app.rag.chunk import chunk_text
 from app.schemas import ScoreFitRequest
+from evals.evidence import Evidence
 from evals.gate import check_regression, check_thresholds, load_baseline, load_thresholds
 from evals.metrics.extraction import exact_match, skill_prf
 from evals.metrics.ragas_fit import fit_ragas_scores, mean, spearman
@@ -122,27 +122,30 @@ def run_parse_job_eval(rows: list[dict]) -> dict:
 def run_fit_score_eval(
     rows: list[dict],
     resume_text: str,
-    contexts_for: Callable[[dict], list[str]] | None = None,
+    evidence_for: Callable[[dict], Evidence] | None = None,
 ) -> dict:
     """Score-fit rank correlation + Ragas faithfulness/relevance/context-recall.
 
-    ``contexts_for`` injects the retrieved evidence per row; it defaults to the
-    whole resume chunked (today's behavior). The retrieval-mode sweep
-    (``evals.retrieval``) passes a function that returns each mode's top-k chunks
-    so the same scorer measures every retrieval mode.
+    ``evidence_for`` decides what the generator may see for each row; it defaults to
+    the whole resume, which is what ``score_fit`` receives in production. The
+    retrieval-mode sweep (``evals.retrieval``) passes a function that withholds the
+    resume and returns each mode's top-k chunks instead, so the ablation is real.
+
+    The judge's contexts come from the *same* ``Evidence``, so the generator's inputs
+    and the judge's view can never drift apart again (#197).
     """
-    contexts_for = contexts_for or (lambda _row: chunk_text(resume_text))
+    evidence_for = evidence_for or (lambda _row: Evidence(resume_text=resume_text))
     predicted_scores, gold_labels, ragas_samples = [], [], []
     errors = 0
     for row in rows:
         expected = row["expected"]
-        contexts = contexts_for(row)
+        evidence = evidence_for(row)
         try:
             request = ScoreFitRequest(
                 description_text=row["description_text"],
-                resume_text=resume_text,
+                resume_text=evidence.resume_text,
                 profile_text="",
-                retrieved_context=contexts,
+                retrieved_context=list(evidence.retrieved_context),
             )
             response = score_fit(request)
         except Exception:  # noqa: BLE001 - one bad row shouldn't kill the run
@@ -162,11 +165,9 @@ def run_fit_score_eval(
                     + row["description_text"]
                 ),
                 "response": response.fit_summary,
-                # Ground faithfulness in BOTH the resume and the JD: a fit summary
-                # legitimately cites role requirements/gaps, which live in the JD,
-                # not the resume — so resume-only contexts would mark those claims
-                # unfaithful and corrupt the score.
-                "retrieved_contexts": [*contexts, row["description_text"]],
+                # Derived from the same Evidence the generator got — see
+                # Evidence.judge_contexts for why the JD is always included.
+                "retrieved_contexts": evidence.judge_contexts(row["description_text"]),
                 "reference": expected["reference"],
             }
         )
@@ -236,9 +237,13 @@ def render_retrieval_markdown(report: dict) -> str:
 
     lines += [
         "",
-        "Same gold set + scorer; only the retrieved evidence changes (downstream delta).",
-        "`off` feeds **no** resume evidence (JD only); retrieval modes feed only top-k chunks,",
-        "so context-recall can fall even as faithfulness rises — read all four columns.",
+        "Same gold set + scorer; only the evidence changes (downstream delta). The judge's",
+        "contexts are derived from exactly what the generator received, so a mode cannot look",
+        "better merely by showing the judge more.",
+        "",
+        "**Ablation** (`off` … `hybrid+rerank`): the resume reaches the model *only* through",
+        "retrieval — `off` gets the JD and nothing else. **Reference** (`full-resume*`): the",
+        "whole resume in the prompt, which is what `score_fit` does in production.",
         "",
         "| mode | fit-vs-label Spearman | faithfulness | answer relevancy | context recall "
         "| n (errors) |",
@@ -247,9 +252,7 @@ def render_retrieval_markdown(report: dict) -> str:
     for mode in report["modes_order"]:
         metrics = report["modes"].get(mode, {})
         if metrics.get("status") == "n/a":
-            lines.append(
-                f"| {mode} | _n/a_ | _n/a_ | _n/a_ | _n/a_ | _{metrics.get('reason')}_ |"
-            )
+            lines.append(f"| {mode} | _n/a_ | _n/a_ | _n/a_ | _n/a_ | _{metrics.get('reason')}_ |")
             continue
         ragas = metrics.get("ragas", {})
         lines.append(

--- a/services/agent/tests/test_eval_evidence.py
+++ b/services/agent/tests/test_eval_evidence.py
@@ -1,0 +1,214 @@
+"""Eval-harness integrity: what the generator sees must equal what the judge sees.
+
+These are the tests that would have caught the leak fixed in #197 — the retrieval
+sweep fed the *whole* resume to the generator in every mode (including ``off``) and
+only varied the judge's contexts, so the published "~3x faithfulness" delta measured
+judge visibility rather than retrieval.
+
+Every assertion here is about the *inputs* to the generator and the judge, so they
+run with no provider, no database, and no LLM.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.rag.chunk import chunk_text
+from evals import retrieval, run
+from evals.evidence import Evidence
+
+_JD = "Senior Python engineer. Must know Django, Postgres, and Kubernetes."
+_RESUME = "Jane Doe.\n\nBuilt Django services on Postgres.\n\nRan Kubernetes in production."
+
+
+def _rows():
+    return [
+        {"id": "r1", "description_text": _JD, "expected": {"fit_label": 70, "reference": "ref"}}
+    ]
+
+
+@pytest.fixture
+def capture(monkeypatch):
+    """Capture the generator request and the judge samples for one eval run."""
+    seen: dict = {}
+
+    def fake_score_fit(request):
+        seen["request"] = request
+
+        class _Resp:
+            fit_score = 50
+            fit_summary = "summary"
+
+        return _Resp()
+
+    def fake_ragas(samples, _model, _embeddings):
+        seen["samples"] = samples
+        return {"faithfulness": 0.5}
+
+    monkeypatch.setattr(run, "score_fit", fake_score_fit)
+    monkeypatch.setattr(run, "get_model", lambda: (object(), "fake:model"))
+    monkeypatch.setattr(run, "fit_ragas_scores", fake_ragas)
+    return seen
+
+
+# --- the leak itself -------------------------------------------------------
+
+
+def test_off_mode_hides_the_resume_from_the_generator(capture):
+    """``off`` is the no-retrieval floor: the model gets the JD and nothing else.
+
+    Before #197 this passed the whole resume via ``resume_text`` while telling the
+    judge there was no evidence -- which is how a resume-blind baseline scored the
+    *highest* fit-vs-label Spearman in the published table.
+    """
+    run.run_fit_score_eval(_rows(), _RESUME, evidence_for=lambda _row: Evidence())
+
+    request = capture["request"]
+    assert request.resume_text == ""
+    assert list(request.retrieved_context) == []
+    assert _RESUME not in _generator_prompt_inputs(request)
+
+
+def test_retrieval_modes_feed_the_resume_only_through_retrieval(capture):
+    """In the sweep the resume reaches the generator *only* as retrieved chunks."""
+    chunks = ("Built Django services on Postgres.",)
+    run.run_fit_score_eval(
+        _rows(), _RESUME, evidence_for=lambda _row: Evidence(retrieved_context=chunks)
+    )
+
+    request = capture["request"]
+    assert request.resume_text == ""
+    assert tuple(request.retrieved_context) == chunks
+
+
+def test_full_resume_mode_feeds_the_whole_resume(capture):
+    """The production-path reference row: the whole resume in the prompt, no chunks."""
+    run.run_fit_score_eval(
+        _rows(), _RESUME, evidence_for=lambda _row: Evidence(resume_text=_RESUME)
+    )
+
+    request = capture["request"]
+    assert request.resume_text == _RESUME
+    assert list(request.retrieved_context) == []
+
+
+# --- the invariant that keeps it fixed -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        Evidence(),
+        Evidence(retrieved_context=("Ran Kubernetes in production.",)),
+        Evidence(resume_text=_RESUME),
+        Evidence(resume_text=_RESUME, retrieved_context=("Built Django services on Postgres.",)),
+    ],
+    ids=["off", "retrieval-only", "full-resume", "full-resume+retrieval"],
+)
+def test_judge_sees_exactly_what_the_generator_saw(capture, evidence):
+    """The judge's contexts are derived from the same Evidence the generator got.
+
+    The JD is always included: a fit summary legitimately cites role requirements,
+    which live in the JD, not the resume.
+    """
+    run.run_fit_score_eval(_rows(), _RESUME, evidence_for=lambda _row: evidence)
+
+    judge_contexts = capture["samples"][0]["retrieved_contexts"]
+    assert judge_contexts == evidence.judge_contexts(_JD)
+
+    # Nothing the generator could not see may appear in the judge's contexts.
+    # Compared on normalized whitespace: chunk_text re-joins paragraphs with a single
+    # newline, so a chunk is not a literal substring of the resume it came from.
+    generator_text = _normalize(" ".join(_generator_prompt_inputs(capture["request"])))
+    for context in judge_contexts:
+        if context != _JD:
+            assert _normalize(context) in generator_text
+
+
+def test_evidence_judge_contexts_chunk_the_resume_and_dedupe():
+    """A retrieved chunk that is also part of the full resume is not double-counted."""
+    chunk = chunk_text(_RESUME)[0]
+    evidence = Evidence(resume_text=_RESUME, retrieved_context=(chunk,))
+
+    contexts = evidence.judge_contexts(_JD)
+    assert contexts.count(chunk) == 1
+    assert contexts[-1] == _JD
+    assert set(chunk_text(_RESUME)).issubset(set(contexts))
+
+
+def test_default_evidence_is_the_whole_resume(capture):
+    """``python -m evals.run`` (no ``evidence_for``) keeps measuring the production path."""
+    run.run_fit_score_eval(_rows(), _RESUME)
+
+    request = capture["request"]
+    assert request.resume_text == _RESUME
+    assert capture["samples"][0]["retrieved_contexts"] == [*chunk_text(_RESUME), _JD]
+
+
+# --- the sweep wires the modes to the right evidence ------------------------
+
+
+def test_sweep_modes_map_to_the_documented_evidence():
+    """Each mode's Evidence matches the table published in EVALS.md."""
+    plans: dict[str, Evidence] = {}
+
+    def fake_score(rows, resume_text, evidence_for):
+        plans[fake_score.mode] = evidence_for(rows[0])
+        return {"rank_correlation_spearman": 0.5, "ragas": {}}
+
+    for mode in retrieval.RETRIEVAL_MODES:
+        fake_score.mode = mode
+        retrieval.run_retrieval_modes(
+            _rows(),
+            _RESUME,
+            modes=(mode,),
+            retrieve_evidence=lambda *a, **k: ["retrieved-chunk"],
+            score_eval=fake_score,
+            fts_ready=lambda: True,
+        )
+
+    assert plans["off"] == Evidence()
+    for mode in ("vector", "hybrid", "hybrid+rerank"):
+        assert plans[mode] == Evidence(retrieved_context=("retrieved-chunk",)), mode
+    assert plans["full-resume"] == Evidence(resume_text=_RESUME)
+    assert plans["full-resume+vector"] == Evidence(
+        resume_text=_RESUME, retrieved_context=("retrieved-chunk",)
+    )
+
+
+def test_sweep_scopes_ingest_to_an_eval_tenant(monkeypatch):
+    """A sweep must never write unowned (``user_id IS NULL``) rows into ``embeddings``.
+
+    Unowned rows are readable by any ``retrieve(user_id=None)`` caller, so an eval run
+    against a shared database would otherwise leave the sample resume where real
+    retrieval could reach it.
+    """
+    seen: dict = {}
+
+    def fake_retrieve_evidence(resume_text, jd, k, user_id=None):
+        seen["user_id"] = user_id
+        return ["chunk"]
+
+    retrieval.run_retrieval_modes(
+        _rows(),
+        _RESUME,
+        modes=("vector",),
+        retrieve_evidence=fake_retrieve_evidence,
+        score_eval=lambda rows, resume_text, evidence_for: (
+            evidence_for(rows[0]),
+            {"rank_correlation_spearman": 0.5, "ragas": {}},
+        )[1],
+        fts_ready=lambda: True,
+    )
+
+    assert seen["user_id"] == retrieval.EVAL_USER_ID
+    assert seen["user_id"]
+
+
+def _generator_prompt_inputs(request) -> list[str]:
+    """Every string the score-fit prompt is built from (see chains/score_fit.py)."""
+    return [request.description_text, request.resume_text, *request.retrieved_context]
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.split())

--- a/services/agent/tests/test_eval_noise.py
+++ b/services/agent/tests/test_eval_noise.py
@@ -1,0 +1,165 @@
+"""Replicate-run noise estimation — no LLM (the scorer is injected).
+
+Two identical-input runs differing by some amount tells you variance of that order
+*occurred*; it does not bound the variance. These tests cover the machinery that
+turns repeated trials into an actual interval (Codex review on #201).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from evals import noise
+
+
+def _rows():
+    return [{"description_text": "jd", "expected": {"fit_label": 60, "reference": "ref"}}]
+
+
+# --- spread statistics ------------------------------------------------------
+
+
+def test_summarize_spread_reports_centre_and_worst_case_pair():
+    summary = noise.summarize_spread([0.70, 0.80, 0.75])
+
+    assert summary["n"] == 3
+    assert summary["mean"] == pytest.approx(0.75)
+    assert summary["min"] == pytest.approx(0.70)
+    assert summary["max"] == pytest.approx(0.80)
+    # Sample (n-1) standard deviation, not population.
+    assert summary["stdev"] == pytest.approx(0.05)
+    # The widest gap between any two replicates — directly comparable to a
+    # between-mode delta, which is what the report actually needs.
+    assert summary["max_pairwise_delta"] == pytest.approx(0.10)
+
+
+def test_summarize_spread_needs_two_points_for_a_deviation():
+    summary = noise.summarize_spread([0.5])
+    assert summary["n"] == 1
+    assert summary["mean"] == pytest.approx(0.5)
+    assert summary["stdev"] is None  # undefined for a single sample
+    assert summary["max_pairwise_delta"] == pytest.approx(0.0)
+
+
+def test_summarize_spread_ignores_missing_metrics():
+    """A Ragas metric can come back ``None``; it must not poison the statistics."""
+    summary = noise.summarize_spread([0.4, None, 0.6])
+    assert summary["n"] == 2
+    assert summary["mean"] == pytest.approx(0.5)
+    assert summary["max_pairwise_delta"] == pytest.approx(0.2)
+
+
+def test_summarize_spread_with_no_values_is_empty_not_an_error():
+    summary = noise.summarize_spread([None, None])
+    assert summary["n"] == 0
+    assert summary["mean"] is None
+    assert summary["stdev"] is None
+
+
+# --- the replication driver -------------------------------------------------
+
+
+def test_run_replicates_scores_the_same_configuration_repeatedly():
+    calls = []
+    scores = iter([0.70, 0.76, 0.73])
+
+    def fake_score(rows, resume_text, evidence_for):
+        calls.append(evidence_for(rows[0]))
+        return {
+            "n": 1,
+            "errors": 0,
+            "rank_correlation_spearman": next(scores),
+            "ragas": {"faithfulness": 0.8},
+        }
+
+    report = noise.run_replicates(
+        _rows(),
+        "resume",
+        replicates=3,
+        retrieve_evidence=lambda *a, **k: ["chunk"],
+        score_eval=fake_score,
+    )
+
+    assert len(calls) == 3
+    # Every replicate must see byte-identical evidence, or it is not a noise measurement.
+    assert len({(e.resume_text, e.retrieved_context) for e in calls}) == 1
+
+    spearman = report["spread"]["rank_correlation_spearman"]
+    assert spearman["n"] == 3
+    assert spearman["max_pairwise_delta"] == pytest.approx(0.06)
+    assert report["spread"]["faithfulness"]["max_pairwise_delta"] == pytest.approx(0.0)
+    assert report["replicates"] == 3
+    assert report["runs"][0]["rank_correlation_spearman"] == pytest.approx(0.70)
+
+
+def test_run_replicates_rejects_fewer_than_two():
+    """One run has no spread; asking for it is a mistake worth surfacing loudly."""
+    with pytest.raises(ValueError, match="at least 2"):
+        noise.run_replicates(_rows(), "resume", replicates=1)
+
+
+def test_run_replicates_restores_retrieval_settings():
+    from app.config import settings
+
+    before = (settings.rag_retrieval_mode, settings.rag_rerank_enabled)
+    noise.run_replicates(
+        _rows(),
+        "resume",
+        replicates=2,
+        retrieve_evidence=lambda *a, **k: ["chunk"],
+        score_eval=lambda rows, resume_text, evidence_for: {
+            "rank_correlation_spearman": 0.5,
+            "ragas": {},
+        },
+    )
+    assert (settings.rag_retrieval_mode, settings.rag_rerank_enabled) == before
+
+
+def test_render_noise_markdown_reports_the_interval():
+    report = {
+        "generated_at": "2026-07-23T00:00:00+00:00",
+        "status": "ok",
+        "provider": "openai:gpt-4o-mini",
+        "mode": "vector",
+        "replicates": 3,
+        "runs": [],
+        "spread": {
+            "rank_correlation_spearman": {
+                "n": 3,
+                "mean": 0.75,
+                "stdev": 0.05,
+                "min": 0.7,
+                "max": 0.8,
+                "max_pairwise_delta": 0.1,
+            }
+        },
+    }
+    md = noise.render_noise_markdown(report)
+    assert "vector" in md and "3" in md
+    assert "0.1" in md  # the worst-case pair is what a reader compares against
+
+
+def test_render_noise_markdown_handles_skipped():
+    md = noise.render_noise_markdown(
+        {
+            "generated_at": "x",
+            "status": "skipped",
+            "skipped_reason": "no provider key configured",
+            "provider": None,
+        }
+    )
+    assert "Skipped" in md
+
+
+def test_stdev_is_the_sample_not_population_deviation():
+    """Guard the n-1 choice explicitly: population stdev here would be 1.118."""
+    values = [1.0, 2.0, 3.0, 4.0]
+    sample = math.sqrt(sum((v - 2.5) ** 2 for v in values) / 3)  # 1.2910
+    population = math.sqrt(sum((v - 2.5) ** 2 for v in values) / 4)  # 1.1180
+
+    # Reported values are rounded to 4dp for readability, so compare at that precision.
+    stdev = noise.summarize_spread(values)["stdev"]
+    assert stdev == pytest.approx(sample, abs=5e-4)
+    assert stdev != pytest.approx(population, abs=5e-4)

--- a/services/agent/tests/test_retrieval_eval.py
+++ b/services/agent/tests/test_retrieval_eval.py
@@ -15,13 +15,14 @@ def _rows():
 def test_run_retrieval_modes_runs_each_mode_and_aggregates():
     fed: dict[str, bool] = {}
 
-    def fake_retrieve(resume_text, jd, k):
+    def fake_retrieve(resume_text, jd, k, user_id=None):
         # Reflect the per-mode settings toggles the sweep applies.
         return [f"ctx-{settings.rag_retrieval_mode}:{settings.rag_rerank_enabled}"]
 
-    def fake_score(rows, resume_text, contexts_for):
-        ctx = contexts_for(rows[0])
-        fed[ctx[0] if ctx else "EMPTY"] = True
+    def fake_score(rows, resume_text, evidence_for):
+        evidence = evidence_for(rows[0])
+        chunks = evidence.retrieved_context
+        fed[chunks[0] if chunks else "EMPTY"] = True
         return {"rank_correlation_spearman": 0.5, "ragas": {"faithfulness": 0.8}}
 
     result = retrieval.run_retrieval_modes(
@@ -37,7 +38,7 @@ def test_run_retrieval_modes_runs_each_mode_and_aggregates():
     for metrics in result.values():
         assert "rank_correlation_spearman" in metrics and "ragas" in metrics
         assert metrics["status"] == "ok"
-    # "off" feeds no evidence; the three retrieval modes feed distinct toggled contexts.
+    # "off" retrieves nothing; the three retrieval modes feed distinct toggled contexts.
     assert "EMPTY" in fed
     assert "ctx-vector:False" in fed
     assert "ctx-hybrid:False" in fed
@@ -50,7 +51,7 @@ def test_run_retrieval_modes_marks_hybrid_na_without_fts():
         "resume text",
         modes=("vector", "hybrid", "hybrid+rerank"),
         retrieve_evidence=lambda *a, **k: ["c"],
-        score_eval=lambda rows, resume_text, contexts_for: {
+        score_eval=lambda rows, resume_text, evidence_for: {
             "rank_correlation_spearman": 0.5,
             "ragas": {},
         },
@@ -128,8 +129,8 @@ def test_run_retrieval_modes_restores_settings():
         "resume text",
         modes=("hybrid+rerank",),
         retrieve_evidence=lambda *a, **k: ["c"],
-        score_eval=lambda rows, resume_text, contexts_for: (
-            contexts_for(rows[0]),
+        score_eval=lambda rows, resume_text, evidence_for: (
+            evidence_for(rows[0]),
             {"rank_correlation_spearman": 0.5, "ragas": {}},
         )[1],
         fts_ready=lambda: True,
@@ -140,7 +141,7 @@ def test_run_retrieval_modes_restores_settings():
 def test_run_retrieval_modes_restores_settings_after_exception():
     before = (settings.rag_retrieval_mode, settings.rag_rerank_enabled)
 
-    def boom(rows, resume_text, contexts_for):
+    def boom(rows, resume_text, evidence_for):
         raise RuntimeError("scorer blew up mid-sweep")
 
     with pytest.raises(RuntimeError):
@@ -156,15 +157,20 @@ def test_run_retrieval_modes_restores_settings_after_exception():
     assert (settings.rag_retrieval_mode, settings.rag_rerank_enabled) == before
 
 
-def test_default_contexts_for_chunks_whole_resume(monkeypatch):
-    # The default seam (no contexts_for) must still feed the whole resume chunked.
-    from app.rag.chunk import chunk_text
+def test_default_evidence_feeds_the_whole_resume(monkeypatch):
+    """The default seam (no ``evidence_for``) measures the production prompt.
+
+    It used to pass the resume *twice* -- once as ``resume_text`` and again as
+    ``retrieved_context`` -- which is not what ``score_fit`` receives in production.
+    Now it carries the resume once, the way the live no-RAG path does.
+    """
     from evals import run
 
     resume = "Para one.\n\nPara two."
     captured = {}
 
     def fake_score_fit(request):
+        captured["resume_text"] = request.resume_text
         captured["contexts"] = list(request.retrieved_context)
 
         class _Resp:
@@ -178,5 +184,6 @@ def test_default_contexts_for_chunks_whole_resume(monkeypatch):
     monkeypatch.setattr(run, "get_model", lambda: (object(), "fake:model"))
     monkeypatch.setattr(run, "fit_ragas_scores", lambda *a, **k: {})
     rows = [{"description_text": "jd", "expected": {"fit_label": 50, "reference": "r"}}]
-    run.run_fit_score_eval(rows, resume)  # no contexts_for -> default path
-    assert captured["contexts"] == chunk_text(resume)
+    run.run_fit_score_eval(rows, resume)  # no evidence_for -> default path
+    assert captured["resume_text"] == resume
+    assert captured["contexts"] == []


### PR DESCRIPTION
Closes #197. First PR of Phase 3 (epic #152) — make the flagship AI claims true.

## The bug

`evals/retrieval.py` advertised a **downstream retrieval delta**. It measured judge visibility.

`run_fit_score_eval` built every request as `ScoreFitRequest(resume_text=resume_text, ...)`,
and `score_fit` appends `f"Resume:\n{...}"` to the prompt unconditionally. So in **every** mode —
including `off`, documented in `EVALS.md` as *"the JD only (no resume evidence at all)"* — the
generator had the whole résumé. The mode toggle only changed the Ragas judge's `retrieved_contexts`.

The published headline — **"faithfulness 0.25 → 0.83, a ~3× gain"** — was the baseline arm being
blindfolded while the others were not.

**The evidence was already on the page.** `off` scored the *highest* fit-vs-label Spearman
(0.705) of any mode. A résumé-blind model cannot rank candidates against a job description.
Under the corrected harness that arm scores **0.407**.

## The fix

`evals/evidence.py` introduces `Evidence` — the single value describing what one row's generator
may see. The judge's contexts are *derived* from it (`Evidence.judge_contexts`), so the two views
cannot drift. An ablation can now only be run by genuinely withholding evidence from the model.

The sweep gains two production-path reference modes, so the table answers both questions:

| group | modes | question |
| --- | --- | --- |
| Ablation | `off`, `vector`, `hybrid`, `hybrid+rerank` | what does retrieval buy vs. nothing? |
| Reference | `full-resume`, `full-resume+vector` | what does it buy on top of the real prompt? |

## Re-measured results (gpt-4o-mini judge, live DB, n=16, 0 errors)

| mode | Spearman | faithfulness | ans. rel. | ctx recall |
| --- | --- | --- | --- | --- |
| off (truly résumé-blind) | 0.407 | 0.139 | 0.485 | 0.427 |
| vector | 0.721 | 0.824 | 0.212 | 0.479 |
| hybrid | 0.779 | 0.922 | 0.167 | 0.417 |
| hybrid+rerank | 0.704 | 0.777 | 0.225 | 0.427 |
| full-resume | 0.684 | 0.805 | 0.200 | **0.542** |
| full-resume+vector | 0.726 | 0.795 | 0.157 | 0.490 |

### ⚠️ Do not read `hybrid` as beating `vector`

They are **the same experiment**. Verified directly against the database while re-running:

```
JDs whose full-JD tsquery matched >=1 chunk : 0/16
tsquery nodes for JD[0]                     : 98
rows where hybrid retrieved EXACTLY the same chunks as vector : 16/16
```

`websearch_to_tsquery` ANDs its terms, so a JD becomes a 98-node conjunction no chunk can
satisfy. RRF fusing `[dense, []]` is `dense`. That's #198, now confirmed empirically rather
than by inference.

**Unexpected upside — this hands us error bars.** Two provably identical experiments scored
**Δ0.058 Spearman / Δ0.098 faithfulness** apart. That is pure sampling noise (temperature 0.2 +
judge variance), and it means **no difference below ~0.06 Spearman / ~0.10 faithfulness on this
16-row set is interpretable.** Every hybrid/rerank comparison ever published for this gold set
sits inside that band, so they are now marked **unmeasured** rather than measured-and-equal.

### What the numbers honestly support

Feeding the model **four retrieved chunks** (0.721/0.824) matches the **whole-résumé** prompt
(0.684/0.805) within the noise floor, while a résumé-blind model collapses to 0.407/0.139. The
defensible claim is *top-k retrieval recovers full-résumé quality from a fraction of the
context* — RAG here buys context **efficiency**, not accuracy. That's a better story than a
faithfulness ratio, and it survives scrutiny.

## Also in this PR

- **Sweep ingest scoped to an `eval-harness` tenant.** The live DB already held **4 unowned
  (`user_id IS NULL`) rows** of the eval résumé from a previous sweep — precisely what this
  prevents. (Those 4 pre-existing rows are still there; say the word and I'll delete them.)
- **Main eval carries the résumé once**, via `resume_text`, instead of also duplicating it into
  `retrieved_context` — that duplication was never the production prompt. Re-run confirms it
  changed nothing material: Spearman 0.68 → 0.694, faithfulness 0.80 → 0.828, context recall
  0.51 → 0.552. `baseline.json` deliberately left as-is; all metrics are within regression
  tolerance and ratcheting a baseline to one run is bad practice.
- Corrections written into `EVALS.md` (with a dated withdrawal notice), `docs/ROADMAP.md`,
  `docs/IMPLEMENTATION_STATUS.md`, and `docs/AUDIT_REMEDIATION.md`.

## Verification

- **186 agent tests green**, ruff clean.
- 11 new tests in `tests/test_eval_evidence.py`, including a parametrized invariant across all
  four evidence shapes asserting the judge never sees what the generator didn't. **A mock-model
  test asserting the generator's input would have caught this originally** — the old suite only
  ever asserted the judge's side.
- Both eval runs executed against the live database with a real judge; `retrieval_report.json`
  is committed as the auditable artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
