### PR TITLE
ci(security): pip-audit gate for the Python services (#164)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,3 +239,26 @@ jobs:
       # newly-introduced critical fails the build.
       - name: npm audit (critical)
         run: npm audit --audit-level=critical
+
+      # The npm gate above left the Python services (agent + mcp) — which pull in the
+      # largest, most model-sensitive tree (torch, sentence-transformers, langchain) —
+      # completely unscanned. pip-audit closes that gap against the OSV/PyPI advisory DB.
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pip-audit
+        run: pip install pip-audit==2.10.1
+
+      # Strict gate: fail on ANY known vulnerability. Unlike npm, OSV advisories don't
+      # carry a reliable severity threshold to gate on, and the runtime tree is clean
+      # today — so any newly-introduced vuln fails the build while Dependabot still
+      # opens the fix PRs. Audit the *runtime* files only (what ships in the image);
+      # dev/evals tooling isn't deployed. The agent and mcp trees are pinned apart on
+      # purpose (Starlette 1.x vs the MCP SDK), so they must be resolved separately.
+      - name: pip-audit (agent runtime)
+        run: pip-audit -r services/agent/requirements.txt -r services/agent/requirements-rag.txt
+
+      - name: pip-audit (mcp runtime)
+        run: pip-audit -r services/mcp/requirements.txt


### PR DESCRIPTION
## What

Adds a **pip-audit** gate to the `security` CI job. Until now it audited only the npm tree (`npm audit --audit-level=critical`); the **agent** and **mcp** Python services — which carry the largest, most model-sensitive dependency tree (`torch`, `sentence-transformers`, `langchain`, `langgraph`) — were unscanned.

## How

- Scans the **runtime** requirement files only (what actually ships in the image); `-dev`/`-evals` tooling is not deployed.
- **Strict gate — fail on any known vuln.** Unlike npm, OSV/PyPI advisories carry no reliable severity threshold to gate on, and the runtime tree is **clean today** (verified locally across `requirements.txt`, `requirements-rag.txt`, and the mcp file — all `No known vulnerabilities found`). So any *newly-introduced* vuln fails the build, while Dependabot still opens the fix PRs — same philosophy as the npm gate.
- Agent and mcp are pinned apart on purpose (Starlette 1.x vs the MCP SDK), so they're resolved in **separate** invocations.
- `pip-audit` itself is pinned (`==2.10.1`).

## Verification

Ran the exact CI commands locally — all exit 0:
- `pip-audit -r services/agent/requirements.txt -r services/agent/requirements-rag.txt` → clean (torch/sentence-transformers resolved)
- `pip-audit -r services/mcp/requirements.txt` → clean

## Scope

Completes the audit-gate portion of **#164**. Actions were already SHA-pinned across all 9 workflows; `npm audit` already gated. The remaining supply-chain item — reproducible-build **image pinning** (base digest + `torch==` + constraints) — is tracked separately in **#168** and needs a Docker-verified build pass.

Closes #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)