### PR TITLE
docs: refresh the stale remediation journal + status (#152 Phase 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ web e2e job** alongside the agent/MCP pytest. Phase 4's measured retrieval gains
 A subsequent **product overhaul** (epic #124, 6 phases, all merged) ships truthful
 live-data Reports/Dashboard with empty states, in-app job discovery on `/jobs`,
 add-job URL autofill, persistent AI agent outputs, the floating global assistant, and
-Clerk-sourced identity (migrations 008/009). The web + API changes are deployed; the
-live assistant **chat** and **migration 009** await a pending agent-revision
-activation and production migration (tracked in issue #141).
+Clerk-sourced identity (migrations 008/009). It is **fully deployed** — the live
+assistant **chat** serves from the activated agent revision and **migration 009** is
+applied in production (the ops follow-ups #141/#142 are closed).
 
 Phase 6 hosting and data layer are fully live and verified end to end: web, API,
 and the Python agent are deployed, and the cloud Postgres carries the complete

--- a/docs/AUDIT_REMEDIATION.md
+++ b/docs/AUDIT_REMEDIATION.md
@@ -28,24 +28,24 @@ present) the API refuses to boot without `CLERK_SECRET_KEY`, the agent refuses t
 so nothing changes operationally — a future deploy that *loses* one now fails loudly instead of
 silently serving unauthenticated. Local dev and tests are unchanged.
 
-## Phase 2 — Close tenancy & gating holes 🚧 in progress
+## Phase 2 — Close tenancy & gating holes ✅ merged
 
 | Finding | Severity | Issue | PR |
 | --- | --- | --- | --- |
-| Cross-tenant RAG: `retrieve(user_id=None)` searched all tenants → scope to `IS NULL`; require `user_id` on `/rag/search` | High | [#161](https://github.com/Taleef7/jobops-copilot/issues/161) | _this PR_ |
-| Gate merges + deploys on the full CI suite | High | [#162](https://github.com/Taleef7/jobops-copilot/issues/162) | _pending_ |
-| Test the Postgres stores + tenancy SQL against a real DB in CI | Medium | [#163](https://github.com/Taleef7/jobops-copilot/issues/163) | _pending_ |
+| Cross-tenant RAG: `retrieve(user_id=None)` searched all tenants → scope to `IS NULL`; require `user_id` on `/rag/search` | High | [#161](https://github.com/Taleef7/jobops-copilot/issues/161) | [#165](https://github.com/Taleef7/jobops-copilot/pull/165) |
+| Gate merges + deploys on the full CI suite | High | [#162](https://github.com/Taleef7/jobops-copilot/issues/162) | [#166](https://github.com/Taleef7/jobops-copilot/pull/166) |
+| Test the Postgres stores + tenancy SQL against a real DB in CI | Medium | [#163](https://github.com/Taleef7/jobops-copilot/issues/163) | [#169](https://github.com/Taleef7/jobops-copilot/pull/169) |
 | Supply chain: SHA-pin Actions, add `npm`/`pip` audit gates | Medium | [#164](https://github.com/Taleef7/jobops-copilot/issues/164) | [#205](https://github.com/Taleef7/jobops-copilot/pull/205) |
 | Pin the agent Docker image for reproducible builds (base digest + `torch==…+cpu` + `constraints.txt`) | Medium | [#168](https://github.com/Taleef7/jobops-copilot/issues/168) | [#208](https://github.com/Taleef7/jobops-copilot/pull/208) |
 
-## Phase 3 — Make the flagship AI claims true 🚧 in progress
+## Phase 3 — Make the flagship AI claims true ✅ merged
 
 | Finding | Severity | Issue | PR |
 | --- | --- | --- | --- |
-| Eval sweep leaked the résumé to the generator → "~3× faithfulness" withdrawn | High | [#197](https://github.com/Taleef7/jobops-copilot/issues/197) | _this PR_ |
-| Retrieval query is the raw JD: lexical side never fires, dense query truncated | High | [#198](https://github.com/Taleef7/jobops-copilot/issues/198) | _this PR_ |
-| Skip re-embedding unchanged résumés; structured-output retry + clamp | Medium | [#199](https://github.com/Taleef7/jobops-copilot/issues/199) | _pending_ |
-| Trace assistant/chat paths; injection-guard `draft_outreach` | Medium | [#200](https://github.com/Taleef7/jobops-copilot/issues/200) | _pending_ |
+| Eval sweep leaked the résumé to the generator → "~3× faithfulness" withdrawn | High | [#197](https://github.com/Taleef7/jobops-copilot/issues/197) | [#201](https://github.com/Taleef7/jobops-copilot/pull/201) |
+| Retrieval query is the raw JD: lexical side never fires, dense query truncated | High | [#198](https://github.com/Taleef7/jobops-copilot/issues/198) | [#202](https://github.com/Taleef7/jobops-copilot/pull/202) |
+| Skip re-embedding unchanged résumés; structured-output retry + clamp | Medium | [#199](https://github.com/Taleef7/jobops-copilot/issues/199) | [#203](https://github.com/Taleef7/jobops-copilot/pull/203) |
+| Trace assistant/chat paths; injection-guard `draft_outreach` | Medium | [#200](https://github.com/Taleef7/jobops-copilot/issues/200) | [#204](https://github.com/Taleef7/jobops-copilot/pull/204) |
 
 ### What the eval correction found
 
@@ -102,7 +102,17 @@ profile deliberately unchanged — most gold rationales turn on specific technol
   value landed outside five replicates of the same configuration — five replicates bound
   nothing; they estimate.
 
-## Phase 4 — Polish & harden for scale 📋 planned
+## Phase 4 — Polish & harden for scale 🚧 in progress
 
-Assistant a11y/stream fixes; loading/error boundaries; pagination + externalized limiter/cache;
-reconcile the Bicep with live reality; refresh remaining stale docs.
+| Finding | Severity | PR |
+| --- | --- | --- |
+| Assistant a11y/stream fixes (streaming live-region anti-pattern), loading/error boundaries, skip link | High | [#206](https://github.com/Taleef7/jobops-copilot/pull/206) |
+| Reconcile the Bicep with live reality — faithful model, `what-if` verified (0 deletions) | Medium | [#207](https://github.com/Taleef7/jobops-copilot/pull/207) |
+| Pagination + list projections; externalize the limiter/cache before scale-out | Medium | _pending_ |
+| Refresh stale docs (this journal; README/IMPLEMENTATION_STATUS understate live assistant chat + migration 009) | Medium | _this PR_ |
+
+> **Note on the "supply chain" row.** SHA-pinning Actions + the `npm`/`pip` audit gates
+> ([#164](https://github.com/Taleef7/jobops-copilot/pull/205)) and pinning the agent image
+> ([#168](https://github.com/Taleef7/jobops-copilot/pull/208)) landed under Phase 2's table
+> above but completed during Phase 4 — the CI now also audits the pinned image lock, not
+> just the ranged requirements.

--- a/docs/CODEX_NOTES.md
+++ b/docs/CODEX_NOTES.md
@@ -55,11 +55,11 @@ Make companion flows) is built and live with screenshots.
 The **product overhaul** (epic #124) is also complete — all six phases (#118–#123) plus
 cleanup PR #140 merged to `main` on 2026-06-25.
 
-No outstanding implementation task. The only remaining items are two owner-gated deploy
-follow-ups that need production credentials:
+No outstanding implementation task. The two owner-gated deploy follow-ups are now done:
 
-- **#141** — activate the agent Container App revision that includes `/assistant/chat`, and
-  apply migration `009_drop_display_name.sql` to the production DB.
-- **#142** — add cold-start resilience for the streaming endpoints on the scale-to-zero agent.
+- **#141** — ✅ activated the agent Container App revision that includes `/assistant/chat`, and
+  applied migration `009_drop_display_name.sql` to the production DB.
+- **#142** — ✅ added cold-start resilience for the streaming endpoints on the scale-to-zero agent.
 
-Otherwise the focus is maintenance and demos.
+Current focus is the 2026-07 audit-remediation program (epic #152) — see
+[AUDIT_REMEDIATION.md](AUDIT_REMEDIATION.md) — plus maintenance and demos.

--- a/docs/IMPLEMENTATION_CHECKLIST.md
+++ b/docs/IMPLEMENTATION_CHECKLIST.md
@@ -8,8 +8,8 @@ Phase 7 (Zapier/Make companion flows) is now complete as well — both flows are
 built, tested, and live, with screenshots captured.
 
 The **product overhaul** (epic #124) is also complete — all six phases (#118–#123)
-plus cleanup PR #140 merged to `main` on 2026-06-25. Two owner-gated deploy
-follow-ups (#141, #142) remain; see the bottom of this file.
+plus cleanup PR #140 merged to `main` on 2026-06-25. The two owner-gated deploy
+follow-ups (#141, #142) are now done; see the bottom of this file.
 
 ## Phase 4: n8n Integration
 
@@ -104,7 +104,7 @@ follow-ups (#141, #142) remain; see the bottom of this file.
 
 - [x] PR #140: structured assistant stream returns 503 (not 500) when the agent is disabled.
 
-### Open follow-ups (owner-gated, not done)
+### Deploy follow-ups (done, closed)
 
-- [ ] #141: activate the agent Container App revision that includes `/assistant/chat` and apply migration `009` to the prod DB.
-- [ ] #142: cold-start resilience for the streaming endpoints on the scale-to-zero agent.
+- [x] #141: activated the agent Container App revision that includes `/assistant/chat` and applied migration `009` to the prod DB.
+- [x] #142: cold-start resilience for the streaming endpoints on the scale-to-zero agent.

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -18,9 +18,15 @@ intelligence.
 ## Security & audit remediation
 
 A 2026-07 full-stack security + engineering audit (overall grade **B**) is being remediated in
-phases. Phase 1 — fail-closed auth (API + agent), the Next.js middleware-CVE patch, an
-API crash guard, and three resilience fixes — is merged. The running journal, per-finding PR
-log, and behavioral notes live in [AUDIT_REMEDIATION.md](AUDIT_REMEDIATION.md) (epic #152).
+phases. Phases 1–3 are merged: fail-closed auth (API + agent), the Next.js middleware-CVE
+patch, and crash/resilience guards (P1); cross-tenant RAG scoping, full-suite CI gating,
+real-DB tenancy tests, and SHA-pinned Actions + `npm`/`pip` audit gates (P2); and the
+eval-integrity correction that withdrew the inflated faithfulness claim and produced the
+project's first demonstrated hybrid-retrieval win (P3). Phase 4 (polish/scale) is in progress —
+assistant a11y + route boundaries and a `what-if`-verified faithful Bicep reconcile are merged,
+and the agent Docker image is now pinned by digest with its lock audited in CI. The running
+journal, per-finding PR log, and behavioral notes live in
+[AUDIT_REMEDIATION.md](AUDIT_REMEDIATION.md) (epic #152).
 
 ## Verified Milestones
 
@@ -92,7 +98,9 @@ log, and behavioral notes live in [AUDIT_REMEDIATION.md](AUDIT_REMEDIATION.md) (
 - **Phase 6 — profile on Clerk (#123):** migration `009_drop_display_name.sql`; identity via
   `currentUser()`, `profile_text` grounding kept.
 - Plus cleanup PR #140 (the structured assistant stream returns 503, not 500, when the agent is
-  disabled). Two owner-gated deploy follow-ups (#141, #142) remain — see "What Is Still Pending".
+  disabled). The two owner-gated deploy follow-ups are **done and closed**: #141 (activate the
+  agent revision serving `/assistant/chat` + apply migration 009 in prod) and #142 (assistant
+  cold-start resilience for the scale-to-zero agent).
 
 ## What Is Live Now
 
@@ -150,9 +158,13 @@ log, and behavioral notes live in [AUDIT_REMEDIATION.md](AUDIT_REMEDIATION.md) (
   operational hardening; epics #43/#51/#61/#70/#76) all landed and were verified end to end.
 - The **product overhaul** (epic #124) is **complete** — all six phases (#118–#123) plus cleanup
   PR #140 merged to `main` on 2026-06-25.
-- **Product-overhaul deploy follow-ups** (owner-gated, the only items not done): **#141** — activate
-  the agent Container App revision that includes `/assistant/chat` and apply migration `009` to the
-  prod DB; **#142** — cold-start resilience for the streaming endpoints on the scale-to-zero agent.
+- **Product-overhaul deploy follow-ups are done** — **#141** (activated the agent Container App
+  revision serving `/assistant/chat` and applied migration `009` to the prod DB) and **#142**
+  (cold-start resilience for the streaming endpoints on the scale-to-zero agent) are both closed.
+- **Audit remediation (epic #152)** is the active workstream: Phases 1–3 merged; Phase 4
+  (polish/scale) in progress — assistant a11y + boundaries and a faithful Bicep reconcile landed,
+  the agent image is pinned + lock-audited, and pagination + an externalized limiter/cache is the
+  main remaining item. See [AUDIT_REMEDIATION.md](AUDIT_REMEDIATION.md).
 - **Owner-gated optional follow-ups** (by design, not gaps; see `docs/ROADMAP.md`): applying the
   Bicep to a live/greenfield RG, running k6 in CI, and activating the gated e2e CI job (needs
   Clerk repo secrets). Fine-tuning and a larger retrieval gold set remain deferred.

--- a/docs/PROJECT_IMPLEMENTATION_PLAN.md
+++ b/docs/PROJECT_IMPLEMENTATION_PLAN.md
@@ -878,8 +878,9 @@ The system must not:
 > since shipped two follow-on initiatives — the production-grade AI program (epics #43 → #51 → #61 →
 > #70 → #76) and the **product overhaul** (epic #124: truthful data, JobRight-style jobs feed,
 > add-job URL autofill, persistent agent outputs, global assistant widget, Clerk-consolidated
-> profile; all six phases #118–#123 merged). The only remaining items are two owner-gated deploy
-> follow-ups (#141, #142). See `docs/ROADMAP.md` and `docs/IMPLEMENTATION_STATUS.md` for the live
+> profile; all six phases #118–#123 merged). Its two owner-gated deploy follow-ups (#141, #142)
+> are now done. The active workstream is the 2026-07 audit-remediation program (epic #152). See
+> `docs/ROADMAP.md`, `docs/IMPLEMENTATION_STATUS.md`, and `docs/AUDIT_REMEDIATION.md` for the live
 > status of record.
 
 ## Phase 0: Project Foundation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,7 +26,7 @@ See the dedicated section below.
 The **product overhaul** (epic #124, merged to `main` 2026-06-25) is also **complete** — its
 six phases (truthful data, JobRight-style jobs feed, add-job URL autofill, persistent agent
 outputs, global assistant widget, Clerk-consolidated profile) all landed. See the dedicated
-section below; two owner-gated deploy follow-ups (#141, #142) remain.
+section below; the two owner-gated deploy follow-ups (#141, #142) are now done.
 
 ## Phase 0: Project Foundation
 
@@ -277,9 +277,9 @@ on Clerk. Six phases (#118 → #123), **all complete and merged**, plus cleanup 
 - Migration `009_drop_display_name.sql` drops `user_profiles.display_name`; identity (name/avatar/
   email) comes from Clerk via `currentUser()`, while `profile_text` grounding is kept.
 
-### Open follow-ups (owner-gated, not done)
+### Deploy follow-ups (done, closed)
 
-- **#141 — Deploy/activate:** activate the agent Container App revision that includes
-  `/assistant/chat`, and apply migration `009` to the production DB.
-- **#142 — Cold-start resilience:** harden the streaming endpoints against cold starts on the
-  scale-to-zero agent.
+- **#141 — Deploy/activate:** ✅ activated the agent Container App revision that includes
+  `/assistant/chat`, and applied migration `009` to the production DB.
+- **#142 — Cold-start resilience:** ✅ hardened the streaming endpoints against cold starts on
+  the scale-to-zero agent.


### PR DESCRIPTION
Phase 4 lane (epic #152): refresh the docs the audit flagged as stale/understating, and bring the remediation journal current with the merges.

## Changes (docs-only)
- **`docs/AUDIT_REMEDIATION.md` (the journal)** — Phases 2 & 3 were still "🚧 in progress" with `_this PR_` / `_pending_` placeholders even though all eight sub-issues merged. Filled the real PR links (#165/#166/#169 for P2; #201–#204 for P3) and flipped both to ✅. Added a **Phase 4** status table (assistant a11y #206, Bicep reconcile #207 merged; pagination pending; this refresh) and a note that the supply-chain rows (#205/#208) landed during Phase 4 with the new image-lock audit.
- **`README.md`** — the product overhaul is now **fully deployed**: the live assistant **chat** and **migration 009** no longer "await a pending agent-revision activation" (ops issues #141/#142 are closed — #141 *was* that activation + migration).
- **`docs/IMPLEMENTATION_STATUS.md`** — expanded the remediation snapshot from "Phase 1 merged" to **Phases 1–3 merged + Phase 4 in progress**; marked the #141/#142 deploy follow-ups done; surfaced epic #152 as the active workstream with pagination as the main remaining item.

No code changes.

Part of #152 (Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)