### PR TITLE
feat(api): backward-compatible list pagination + reports export N+1 fix (#152 Phase 4)

### DIFF
--- a/apps/api/src/data/job-store.postgres.ts
+++ b/apps/api/src/data/job-store.postgres.ts
@@ -170,7 +170,9 @@ export async function listJobs(userId: string, page?: PageParams): Promise<JobRe
   // Paginate the base jobs query; the analysis/outreach fan-out below then scopes
   // to only the page's job ids, so a page never over-fetches the nested rows.
   const params: unknown[] = [userId];
-  let sql = 'select * from jobs where user_id = $1 order by created_at desc';
+  // `id` tie-breaks equal created_at (concurrent creates) so LIMIT/OFFSET pages are
+  // stable — without it a client can see a job twice or miss one across pages.
+  let sql = 'select * from jobs where user_id = $1 order by created_at desc, id desc';
   if (page?.limit !== undefined) {
     params.push(page.limit);
     sql += ` limit $${params.length}`;

--- a/apps/api/src/data/job-store.postgres.ts
+++ b/apps/api/src/data/job-store.postgres.ts
@@ -9,6 +9,7 @@ import type {
 } from '@/types';
 import { getDefaultAnalysis, validateJobAnalysis } from '@/lib/analysis-core';
 import { getPool } from '@/lib/postgres';
+import type { PageParams } from '@/lib/pagination';
 import { deriveOutreachJobUpdate } from '@/lib/outreach-workflow';
 import { seedJobs } from '@/data/mock-store';
 
@@ -163,13 +164,23 @@ function mapJob(row: JobRow, analysisRow?: JobAnalysisRow, outreachRows: Outreac
   };
 }
 
-export async function listJobs(userId: string): Promise<JobRecord[]> {
+export async function listJobs(userId: string, page?: PageParams): Promise<JobRecord[]> {
   const pool = poolOrThrow();
 
-  const jobsResult = await pool.query<JobRow>(
-    'select * from jobs where user_id = $1 order by created_at desc',
-    [userId],
-  );
+  // Paginate the base jobs query; the analysis/outreach fan-out below then scopes
+  // to only the page's job ids, so a page never over-fetches the nested rows.
+  const params: unknown[] = [userId];
+  let sql = 'select * from jobs where user_id = $1 order by created_at desc';
+  if (page?.limit !== undefined) {
+    params.push(page.limit);
+    sql += ` limit $${params.length}`;
+  }
+  if (page && page.offset > 0) {
+    params.push(page.offset);
+    sql += ` offset $${params.length}`;
+  }
+
+  const jobsResult = await pool.query<JobRow>(sql, params);
   if (jobsResult.rowCount === 0) {
     return [];
   }
@@ -197,6 +208,15 @@ export async function listJobs(userId: string): Promise<JobRecord[]> {
   }
 
   return jobsResult.rows.map((row: JobRow) => mapJob(row, analysisByJobId.get(row.id), outreachByJobId.get(row.id)));
+}
+
+export async function countJobs(userId: string): Promise<number> {
+  const pool = poolOrThrow();
+  const { rows } = await pool.query<{ count: number }>(
+    'select count(*)::int as count from jobs where user_id = $1',
+    [userId],
+  );
+  return rows[0]?.count ?? 0;
 }
 
 export async function getJobById(userId: string, jobId: string): Promise<JobRecord | undefined> {

--- a/apps/api/src/data/job-store.test.ts
+++ b/apps/api/src/data/job-store.test.ts
@@ -5,8 +5,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   appendOutreachDraft,
+  countJobs,
   createJob,
   getJobById,
+  listJobs,
   resetJobStoreForTests,
   updateOutreachDraft,
 } from './job-store';
@@ -81,6 +83,40 @@ test('appendOutreachDraft preserves sent outreach history', async () => {
 
     const sent = fetched?.outreach.find((entry) => entry.id === 'outreach-first');
     assert.equal(sent?.status, 'sent');
+  } finally {
+    process.chdir(originalCwd);
+    resetJobStoreForTests();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('listJobs paginates (opt-in) and stays user-scoped; countJobs reports the total', async () => {
+  const originalCwd = process.cwd();
+  delete process.env.DATABASE_URL; // force the file store
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-jobs-page-'));
+
+  try {
+    process.chdir(tempDir);
+    resetJobStoreForTests();
+
+    for (let i = 0; i < 5; i += 1) {
+      await createJob('user-1', {
+        company: `Acme ${i}`,
+        title: `Engineer ${i}`,
+        descriptionText: 'Build things.',
+      });
+    }
+    await createJob('user-2', { company: 'Other', title: 'Dev', descriptionText: 'x' });
+
+    // No page params → full list (backward-compatible), user-scoped.
+    assert.equal((await listJobs('user-1')).length, 5);
+    assert.equal((await listJobs('user-2')).length, 1);
+    assert.equal(await countJobs('user-1'), 5);
+
+    // Opt-in pagination slices the list without leaking across users.
+    assert.equal((await listJobs('user-1', { limit: 2, offset: 0 })).length, 2);
+    assert.equal((await listJobs('user-1', { limit: 2, offset: 4 })).length, 1);
+    assert.equal((await listJobs('user-1', { limit: 2, offset: 99 })).length, 0);
   } finally {
     process.chdir(originalCwd);
     resetJobStoreForTests();

--- a/apps/api/src/data/job-store.ts
+++ b/apps/api/src/data/job-store.ts
@@ -12,6 +12,7 @@ import type {
 import { validateJobAnalysis } from '@/lib/analysis-core';
 import { deriveOutreachJobUpdate } from '@/lib/outreach-workflow';
 import { hasPostgresConnection } from '@/lib/postgres';
+import { paginateArray, type PageParams } from '@/lib/pagination';
 import * as postgresStore from '@/data/job-store.postgres';
 import { seedJobs } from '@/data/mock-store';
 
@@ -168,13 +169,23 @@ async function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
   }
 }
 
-export async function listJobs(userId: string): Promise<JobRecord[]> {
+export async function listJobs(userId: string, page?: PageParams): Promise<JobRecord[]> {
   if (hasPostgresConnection()) {
-    return postgresStore.listJobs(userId);
+    return postgresStore.listJobs(userId, page);
   }
 
   const jobs = await ensureLoaded();
-  return clone(jobs.filter((entry) => entry.userId === userId));
+  const mine = clone(jobs.filter((entry) => entry.userId === userId));
+  return page ? paginateArray(mine, page) : mine;
+}
+
+export async function countJobs(userId: string): Promise<number> {
+  if (hasPostgresConnection()) {
+    return postgresStore.countJobs(userId);
+  }
+
+  const jobs = await ensureLoaded();
+  return jobs.filter((entry) => entry.userId === userId).length;
 }
 
 export async function getJobById(userId: string, jobId: string): Promise<JobRecord | undefined> {

--- a/apps/api/src/data/report-store.postgres.ts
+++ b/apps/api/src/data/report-store.postgres.ts
@@ -67,8 +67,10 @@ export async function listWeeklyReports(
   const pool = poolOrThrow();
 
   const params: unknown[] = [userId];
+  // `id` is the final tie-breaker so LIMIT/OFFSET pages are stable when rows share
+  // a created_at / week range (otherwise a client can see duplicates or miss a row).
   let sql =
-    'select * from weekly_reports where user_id = $1 order by created_at desc, week_end desc, week_start desc';
+    'select * from weekly_reports where user_id = $1 order by created_at desc, week_end desc, week_start desc, id desc';
   if (page?.limit !== undefined) {
     params.push(page.limit);
     sql += ` limit $${params.length}`;
@@ -97,8 +99,10 @@ export async function getWeeklyReportById(
   reportId: string,
 ): Promise<WeeklyReportRecord | undefined> {
   const pool = poolOrThrow();
+  // Compare id::text so a non-UUID reportId (e.g. a bad export URL) returns "not
+  // found" instead of raising Postgres 22P02 → a 500. Mirrors getJobById.
   const { rows } = await pool.query<WeeklyReportRow>(
-    'select * from weekly_reports where user_id = $1 and id = $2',
+    'select * from weekly_reports where user_id = $1 and id::text = $2',
     [userId, reportId],
   );
   const row = rows[0];

--- a/apps/api/src/data/report-store.postgres.ts
+++ b/apps/api/src/data/report-store.postgres.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import type { WeeklyReportRecord } from '@/types';
 import { getPool } from '@/lib/postgres';
+import type { PageParams } from '@/lib/pagination';
 import { seedWeeklyReports } from '@/data/mock-store';
 
 type WeeklyReportRow = {
@@ -59,15 +60,49 @@ function mapReport(row: WeeklyReportRow): WeeklyReportRecord {
   };
 }
 
-export async function listWeeklyReports(userId: string): Promise<WeeklyReportRecord[]> {
+export async function listWeeklyReports(
+  userId: string,
+  page?: PageParams,
+): Promise<WeeklyReportRecord[]> {
   const pool = poolOrThrow();
 
-  const { rows } = await pool.query<WeeklyReportRow>(
-    'select * from weekly_reports where user_id = $1 order by created_at desc, week_end desc, week_start desc',
-    [userId],
-  );
+  const params: unknown[] = [userId];
+  let sql =
+    'select * from weekly_reports where user_id = $1 order by created_at desc, week_end desc, week_start desc';
+  if (page?.limit !== undefined) {
+    params.push(page.limit);
+    sql += ` limit $${params.length}`;
+  }
+  if (page && page.offset > 0) {
+    params.push(page.offset);
+    sql += ` offset $${params.length}`;
+  }
+
+  const { rows } = await pool.query<WeeklyReportRow>(sql, params);
 
   return rows.map(mapReport);
+}
+
+export async function countWeeklyReports(userId: string): Promise<number> {
+  const pool = poolOrThrow();
+  const { rows } = await pool.query<{ count: number }>(
+    'select count(*)::int as count from weekly_reports where user_id = $1',
+    [userId],
+  );
+  return rows[0]?.count ?? 0;
+}
+
+export async function getWeeklyReportById(
+  userId: string,
+  reportId: string,
+): Promise<WeeklyReportRecord | undefined> {
+  const pool = poolOrThrow();
+  const { rows } = await pool.query<WeeklyReportRow>(
+    'select * from weekly_reports where user_id = $1 and id = $2',
+    [userId, reportId],
+  );
+  const row = rows[0];
+  return row ? mapReport(row) : undefined;
 }
 
 export async function saveWeeklyReport(userId: string, report: WeeklyReportRecord): Promise<WeeklyReportRecord> {

--- a/apps/api/src/data/report-store.test.ts
+++ b/apps/api/src/data/report-store.test.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path';
 import test from 'node:test';
 import type { WeeklyReportRecord } from '@/types';
 import {
+  countWeeklyReports,
+  getWeeklyReportById,
   listWeeklyReports,
   resetWeeklyReportStoreForTests,
   saveWeeklyReport,
@@ -87,6 +89,59 @@ test('upserts reports by week range and keeps the latest version first', async (
     assert.equal(latest.weekStart, updatedSave.weekStart);
     assert.equal(latest.jobsApplied, 2);
     assert.equal(latest.createdAt, '2026-05-24T19:30:00.000Z');
+  } finally {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('list pagination, count, and getById are user-scoped', async () => {
+  const originalCwd = snapshotCwd();
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-weekly-report-'));
+
+  try {
+    process.chdir(tempDir);
+    resetWeeklyReportStoreForTests();
+
+    // Three distinct weeks (upsert is keyed on week range), newest createdAt first.
+    const ids: string[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      const saved = await saveWeeklyReport(
+        USER,
+        makeReport({
+          id: `report-${i}`,
+          weekStart: `2026-05-0${i + 1}`,
+          weekEnd: `2026-05-0${i + 2}`,
+          createdAt: `2026-05-2${i}T18:00:00.000Z`,
+        }),
+      );
+      ids.push(saved.id);
+    }
+    await saveWeeklyReport('user_other', makeReport({ id: 'other', weekStart: '2026-06-01', weekEnd: '2026-06-02' }));
+
+    assert.equal(await countWeeklyReports(USER), 3);
+    assert.equal(await countWeeklyReports('user_other'), 1);
+
+    // Full list (no pagination) is unchanged, newest first.
+    const all = await listWeeklyReports(USER);
+    assert.equal(all.length, 3);
+    assert.equal(all[0]?.createdAt, '2026-05-22T18:00:00.000Z');
+
+    // Page: limit 2, then offset 2 → the tail.
+    const firstPage = await listWeeklyReports(USER, { limit: 2, offset: 0 });
+    assert.deepEqual(
+      firstPage.map((r) => r.createdAt),
+      ['2026-05-22T18:00:00.000Z', '2026-05-21T18:00:00.000Z'],
+    );
+    const secondPage = await listWeeklyReports(USER, { limit: 2, offset: 2 });
+    assert.equal(secondPage.length, 1);
+    assert.equal(secondPage[0]?.createdAt, '2026-05-20T18:00:00.000Z');
+
+    // getById is targeted + user-scoped.
+    const one = await getWeeklyReportById(USER, ids[0]!);
+    assert.equal(one?.id, ids[0]);
+    assert.equal(await getWeeklyReportById('user_other', ids[0]!), undefined);
+    assert.equal(await getWeeklyReportById(USER, 'nope'), undefined);
   } finally {
     process.chdir(originalCwd);
     await rm(tempDir, { recursive: true, force: true });

--- a/apps/api/src/data/report-store.ts
+++ b/apps/api/src/data/report-store.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { WeeklyReportRecord } from '@/types';
 import { hasPostgresConnection } from '@/lib/postgres';
+import { paginateArray, type PageParams } from '@/lib/pagination';
 import * as postgresStore from '@/data/report-store.postgres';
 import { seedWeeklyReports } from '@/data/mock-store';
 
@@ -90,17 +91,43 @@ async function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
   }
 }
 
-export async function listWeeklyReports(userId: string): Promise<WeeklyReportRecord[]> {
+export async function listWeeklyReports(
+  userId: string,
+  page?: PageParams,
+): Promise<WeeklyReportRecord[]> {
   if (hasPostgresConnection()) {
-    return postgresStore.listWeeklyReports(userId);
+    return postgresStore.listWeeklyReports(userId, page);
   }
 
   const reports = await ensureLoaded();
-  return sortReports(clone(reports.filter((entry) => entry.userId === userId)));
+  const mine = sortReports(clone(reports.filter((entry) => entry.userId === userId)));
+  return page ? paginateArray(mine, page) : mine;
+}
+
+export async function countWeeklyReports(userId: string): Promise<number> {
+  if (hasPostgresConnection()) {
+    return postgresStore.countWeeklyReports(userId);
+  }
+
+  const reports = await ensureLoaded();
+  return reports.filter((entry) => entry.userId === userId).length;
+}
+
+export async function getWeeklyReportById(
+  userId: string,
+  reportId: string,
+): Promise<WeeklyReportRecord | undefined> {
+  if (hasPostgresConnection()) {
+    return postgresStore.getWeeklyReportById(userId, reportId);
+  }
+
+  const reports = await ensureLoaded();
+  const found = reports.find((entry) => entry.userId === userId && entry.id === reportId);
+  return found ? clone(found) : undefined;
 }
 
 export async function getLatestWeeklyReport(userId: string): Promise<WeeklyReportRecord | undefined> {
-  const reports = await listWeeklyReports(userId);
+  const reports = await listWeeklyReports(userId, { limit: 1, offset: 0 });
   return reports[0];
 }
 

--- a/apps/api/src/lib/cors.ts
+++ b/apps/api/src/lib/cors.ts
@@ -15,6 +15,10 @@ const DEV_ORIGINS = ['http://localhost:3000', 'http://127.0.0.1:3000'];
 
 const ALLOWED_HEADERS = ['Content-Type', 'X-API-Key', 'Authorization', 'X-N8N-Webhook-Secret'];
 
+// Response headers a browser fetch() is allowed to read cross-origin. The list
+// endpoints set X-Total-Count (the unpaginated total) for paging clients.
+const EXPOSED_HEADERS = ['X-Total-Count'];
+
 export function allowedOrigins(env: NodeJS.ProcessEnv = process.env): string[] {
   const configured = env.CORS_ALLOWED_ORIGINS?.trim();
   if (!configured) return DEV_ORIGINS;
@@ -38,5 +42,7 @@ export function corsOptions(env: NodeJS.ProcessEnv = process.env): CorsOptions {
       callback(null, false);
     },
     allowedHeaders: ALLOWED_HEADERS,
+    // Custom response headers a browser fetch() may read cross-origin.
+    exposedHeaders: EXPOSED_HEADERS,
   };
 }

--- a/apps/api/src/lib/pagination.test.ts
+++ b/apps/api/src/lib/pagination.test.ts
@@ -23,6 +23,12 @@ test('non-positive or malformed values fall back to defaults, never throw', () =
   assert.equal(parsePageParams({ offset: 'nope' }).offset, 0);
 });
 
+test('integer-valued floats beyond the safe range are rejected (no bigint OFFSET overflow)', () => {
+  // Number.isInteger(1e100) is true, but binding it to a Postgres OFFSET overflows.
+  assert.equal(parsePageParams({ offset: '1e100' }).offset, 0);
+  assert.equal(parsePageParams({ limit: '1e100' }).limit, undefined);
+});
+
 test('repeated query params (arrays) take the first value', () => {
   assert.equal(parsePageParams({ limit: ['5', '9'] }).limit, 5);
 });

--- a/apps/api/src/lib/pagination.test.ts
+++ b/apps/api/src/lib/pagination.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { MAX_PAGE_LIMIT, paginateArray, parsePageParams } from './pagination';
+
+test('absent limit means unbounded (backward-compatible)', () => {
+  assert.deepEqual(parsePageParams({}), { limit: undefined, offset: 0 });
+  assert.deepEqual(parsePageParams(undefined), { limit: undefined, offset: 0 });
+});
+
+test('a valid limit + offset are parsed', () => {
+  assert.deepEqual(parsePageParams({ limit: '10', offset: '20' }), { limit: 10, offset: 20 });
+});
+
+test('limit is clamped to the ceiling; offset floored at 0', () => {
+  assert.equal(parsePageParams({ limit: '10000' }).limit, MAX_PAGE_LIMIT);
+  assert.equal(parsePageParams({ offset: '-5' }).offset, 0);
+});
+
+test('non-positive or malformed values fall back to defaults, never throw', () => {
+  assert.equal(parsePageParams({ limit: '0' }).limit, undefined); // unbounded
+  assert.equal(parsePageParams({ limit: 'abc' }).limit, undefined);
+  assert.equal(parsePageParams({ limit: '1.5' }).limit, undefined);
+  assert.equal(parsePageParams({ offset: 'nope' }).offset, 0);
+});
+
+test('repeated query params (arrays) take the first value', () => {
+  assert.equal(parsePageParams({ limit: ['5', '9'] }).limit, 5);
+});
+
+test('paginateArray slices with limit/offset and never over-reads', () => {
+  const items = [1, 2, 3, 4, 5];
+  assert.deepEqual(paginateArray(items, { limit: 2, offset: 1 }), [2, 3]);
+  assert.deepEqual(paginateArray(items, { limit: undefined, offset: 0 }), items);
+  assert.deepEqual(paginateArray(items, { limit: 10, offset: 3 }), [4, 5]); // limit past the end
+  assert.deepEqual(paginateArray(items, { limit: 2, offset: 99 }), []); // offset past the end
+});

--- a/apps/api/src/lib/pagination.ts
+++ b/apps/api/src/lib/pagination.ts
@@ -1,0 +1,58 @@
+/**
+ * Backward-compatible list pagination (Phase 4 scale-prep).
+ *
+ * The list endpoints predate pagination and every client (incl. our own web,
+ * which filters client-side) expects the full array. So pagination is *opt-in*:
+ * no `limit` query param means "return everything", exactly as before. When a
+ * caller does pass `limit`, it is clamped to a sane maximum so an explicit
+ * request can't ask for an unbounded page; `offset` defaults to 0.
+ *
+ * Routes surface the unpaginated total via an `X-Total-Count` header so a client
+ * can page without the JSON response shape having to change.
+ */
+
+/** Hard ceiling on an explicitly-requested page size. */
+export const MAX_PAGE_LIMIT = 200;
+
+export interface PageParams {
+  /** Undefined ⇒ no limit (return all remaining rows). Otherwise 1..MAX_PAGE_LIMIT. */
+  limit: number | undefined;
+  /** Rows to skip; always ≥ 0. */
+  offset: number;
+}
+
+function toPositiveInt(raw: unknown): number | undefined {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) return undefined;
+  return n;
+}
+
+/**
+ * Parse `?limit=&offset=` from an Express `request.query`. Lenient: invalid or
+ * absent values fall back to the defaults (unbounded / 0) rather than erroring,
+ * so a malformed query never turns a working list call into a 400.
+ */
+export function parsePageParams(query: unknown): PageParams {
+  const q = (query ?? {}) as Record<string, unknown>;
+
+  const rawLimit = toPositiveInt(q.limit);
+  // limit <= 0 (or absent/invalid) ⇒ unbounded; otherwise clamp to the ceiling.
+  const limit = rawLimit !== undefined && rawLimit > 0 ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
+
+  const rawOffset = toPositiveInt(q.offset);
+  const offset = rawOffset !== undefined && rawOffset > 0 ? rawOffset : 0;
+
+  return { limit, offset };
+}
+
+/**
+ * Apply pagination to an already-materialized array (the file-mode stores and
+ * any in-memory list). Postgres stores push LIMIT/OFFSET into SQL instead.
+ */
+export function paginateArray<T>(items: readonly T[], { limit, offset }: PageParams): T[] {
+  const start = Math.min(offset, items.length);
+  const end = limit === undefined ? items.length : start + limit;
+  return items.slice(start, end);
+}

--- a/apps/api/src/lib/pagination.ts
+++ b/apps/api/src/lib/pagination.ts
@@ -25,7 +25,9 @@ function toPositiveInt(raw: unknown): number | undefined {
   const value = Array.isArray(raw) ? raw[0] : raw;
   if (typeof value !== 'string' && typeof value !== 'number') return undefined;
   const n = Number(value);
-  if (!Number.isFinite(n) || !Number.isInteger(n)) return undefined;
+  // isSafeInteger (not isInteger): rejects things like `1e100`, which is an
+  // integer-valued float but overflows Postgres' bigint OFFSET → a 500.
+  if (!Number.isSafeInteger(n)) return undefined;
   return n;
 }
 

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -1,11 +1,13 @@
 import { Router } from 'express';
 import {
+  countJobs,
   createJob,
   getJobById,
   listJobs,
   updateJob,
 } from '@/data/job-store';
 import { requireUser } from '@/lib/auth';
+import { parsePageParams } from '@/lib/pagination';
 import type { CreateJobBody, JobPriority, JobStatus, UpdateJobBody } from '@/types';
 
 export const jobsRouter = Router();
@@ -40,9 +42,11 @@ jobsRouter.get('/', async (request, response, next) => {
     const userId = requireUser(request, response);
     if (!userId) return;
 
-    response.json({
-      jobs: await listJobs(userId),
-    });
+    // Opt-in pagination: no ?limit means the full list (the web filters client-side).
+    const page = parsePageParams(request.query);
+    const [jobs, total] = await Promise.all([listJobs(userId, page), countJobs(userId)]);
+    response.set('X-Total-Count', String(total));
+    response.json({ jobs });
   } catch (error) {
     next(error);
   }

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -92,3 +92,49 @@ test('persists generated weekly reports and exposes them through the reports API
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test('reports list paginates via ?limit and reports the unpaginated total header', async () => {
+  const originalCwd = process.cwd();
+  const tempDir = await mkdtemp(join(tmpdir(), 'jobops-weekly-report-page-'));
+
+  try {
+    process.chdir(tempDir);
+    resetWeeklyReportStoreForTests();
+
+    await withServer(async (baseUrl) => {
+      // Generate two reports in distinct weeks.
+      for (const [start, end] of [
+        ['2026-05-11', '2026-05-17'],
+        ['2026-05-18', '2026-05-24'],
+      ]) {
+        const res = await fetch(`${baseUrl}/api/ai/generate-weekly-report`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ week_start: start, week_end: end }),
+        });
+        assert.equal(res.status, 200);
+      }
+
+      // Full list: both, and the total header reflects the unpaginated count.
+      const full = await fetch(`${baseUrl}/api/reports`);
+      assert.equal(full.headers.get('X-Total-Count'), '2');
+      assert.equal(((await full.json()) as { reports: unknown[] }).reports.length, 2);
+
+      // Paginated: one item, but the total header still says 2.
+      const paged = await fetch(`${baseUrl}/api/reports?limit=1`);
+      assert.equal(paged.headers.get('X-Total-Count'), '2');
+      const pagedBody = (await paged.json()) as { reports: Array<{ id: string }> };
+      assert.equal(pagedBody.reports.length, 1);
+
+      // The export uses a targeted lookup: a real id succeeds, a bogus one 404s
+      // (previously it scanned the whole list).
+      const exportOk = await fetch(`${baseUrl}/api/reports/${pagedBody.reports[0]!.id}/export`);
+      assert.equal(exportOk.status, 200);
+      const exportMissing = await fetch(`${baseUrl}/api/reports/does-not-exist/export`);
+      assert.equal(exportMissing.status, 404);
+    });
+  } finally {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,7 +1,13 @@
 import { Router } from 'express';
 import { readFile } from 'node:fs/promises';
-import { getLatestWeeklyReport, listWeeklyReports } from '@/data/report-store';
+import {
+  countWeeklyReports,
+  getLatestWeeklyReport,
+  getWeeklyReportById,
+  listWeeklyReports,
+} from '@/data/report-store';
 import { requireUser } from '@/lib/auth';
+import { parsePageParams } from '@/lib/pagination';
 import {
   buildLocalWeeklyReportExportPath,
   buildWeeklyReportExportFileName,
@@ -14,7 +20,13 @@ reportsRouter.get('/', async (request, response, next) => {
     const userId = requireUser(request, response);
     if (!userId) return;
 
-    const reports = await listWeeklyReports(userId);
+    const page = parsePageParams(request.query);
+    const [reports, total] = await Promise.all([
+      listWeeklyReports(userId, page),
+      countWeeklyReports(userId),
+    ]);
+    // Expose the unpaginated total so a client can page without the JSON shape changing.
+    response.set('X-Total-Count', String(total));
     response.json({ reports });
   } catch (error) {
     next(error);
@@ -44,8 +56,9 @@ reportsRouter.get('/:reportId/export', async (request, response, next) => {
     const userId = requireUser(request, response);
     if (!userId) return;
 
-    const reports = await listWeeklyReports(userId);
-    const report = reports.find((entry) => entry.id === request.params.reportId);
+    // Targeted lookup — previously this loaded the user's entire report history
+    // and scanned it in JS just to render one export.
+    const report = await getWeeklyReportById(userId, request.params.reportId);
 
     if (!report) {
       response.status(404).json({ error: 'Weekly report not found' });

--- a/apps/web/src/app/api/proxy/[...path]/route.ts
+++ b/apps/web/src/app/api/proxy/[...path]/route.ts
@@ -38,7 +38,8 @@ async function handler(request: NextRequest, context: { params: Promise<{ path: 
   });
 
   const responseHeaders = new Headers();
-  for (const key of ['content-type', 'content-disposition']) {
+  // x-total-count carries the unpaginated list total so the client can page.
+  for (const key of ['content-type', 'content-disposition', 'x-total-count']) {
     const value = upstream.headers.get(key);
     if (value) responseHeaders.set(key, value);
   }


### PR DESCRIPTION
Phase 4 lane (epic #152) — the pagination half of the scale-prep work.

## What
- **`lib/pagination.ts`** — opt-in `?limit=&offset=` parsing. **No `limit` = the full list**, exactly as before (our web filters client-side), so nothing breaks. An explicit limit is clamped to a ceiling (200); malformed input falls back to defaults rather than 400-ing. `paginateArray` covers the file-mode stores; the Postgres stores push `LIMIT/OFFSET` into SQL and gain a `count(*)` companion.
- **`GET /api/jobs` and `GET /api/reports`** accept the params and set an **`X-Total-Count`** header — a client can page without the JSON response shape (`{jobs}` / `{reports}`) changing. The jobs base query is paginated and the analysis/outreach fan-out then scopes to only the page's ids.
- **Bug fix:** `GET /api/reports/:id/export` loaded the user's *entire* report history and `.find()`-scanned it in JS to render one export. Replaced with a targeted `getWeeklyReportById`.

## Scope
Paginated the two endpoints that actually grow (jobs, reports). Left `/saved-searches` and `/jobs/:id/agent-outputs` unpaginated **by design** — low-cardinality (a handful of rows per user/job).

Server-side *filtering* (moving the jobs table's client-side filters to the API) and list *projections* (splitting the heavy nested jobs payload) are a larger UX-coupled follow-up; this PR delivers the capability without a web rewrite.

## Verification
- **201 API tests green**, typecheck + lint clean.
- New tests: pagination helper (clamping, malformed-input safety, slicing); file-mode store pagination + count + `getById` for jobs and reports (user-scoped); a route test asserting `?limit` pages while `X-Total-Count` stays the unpaginated total, and the targeted export 404s on a bogus id.

This is PR 1 of 2 for the final Phase 4 lane; PR 2 externalizes the rate-limiter + job-search cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)