### PR TITLE
feat(api): externalize the rate-limiter + job-search cache for scale-out (#152 Phase 4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,9 +46,13 @@ N8N_WEBHOOK_SECRET=
 ADZUNA_APP_ID=
 ADZUNA_APP_KEY=
 ADZUNA_COUNTRY=us
-# Cache identical job searches in-process to cut redundant (rate-limited) Adzuna
-# calls. Milliseconds; default 300000 (5 min). Set to 0 to disable caching.
+# Cache identical job searches to cut redundant (rate-limited) Adzuna calls.
+# Milliseconds; default 300000 (5 min). Set to 0 to disable caching.
 JOB_SEARCH_CACHE_TTL_MS=300000
+# Cache backing store. Default in-memory (per-instance). Set to 'postgres' on a
+# multi-instance deployment so instances share cache hits (needs DATABASE_URL +
+# migration 010). Anything else = in-memory.
+JOB_SEARCH_CACHE_STORE=memory
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:4000
 # Optional shared secret for mutating API calls; set the same value in both variables.
 API_SHARED_SECRET=
@@ -64,6 +68,10 @@ MCP_SERVER_API_KEY=
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX=120
 RATE_LIMIT_AI_MAX=20
+# Rate-limit counter store. Default in-memory (per-instance — fine for a single
+# instance). Set to 'postgres' before scaling out so the limit holds across instances
+# (needs DATABASE_URL + migration 010); otherwise the effective limit is max × instances.
+RATE_LIMIT_STORE=memory
 # Per-user daily AI spend ceiling (USD). The /api/ai routes 429 once a user reaches it.
 # Defaults to 1.00 when unset or malformed (it fails safe to the cap, never off).
 AI_DAILY_BUDGET_USD=1.00

--- a/apps/api/src/lib/cache.postgres.pgtest.ts
+++ b/apps/api/src/lib/cache.postgres.pgtest.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import { getPool } from './postgres';
+import { PostgresTtlCache } from './cache.postgres';
+
+// Real-Postgres only (see rate-limit-store.pgtest.ts). Proves the shared cache backing
+// matches the in-memory TtlCache semantics (serve-on-hit, TTL, never cache a failure).
+const DB = process.env.DATABASE_URL?.trim();
+
+test(
+  'PostgresTtlCache: serves hits, honors TTL, and never caches a failed compute',
+  { skip: DB ? false : 'DATABASE_URL not set — Postgres integration test skipped' },
+  async (t) => {
+    const pool = getPool();
+    assert.ok(pool, 'expected a live pool');
+    const ns = `t-${randomUUID().slice(0, 8)}`;
+
+    await t.test('caches a computed value and serves it without recomputing', async () => {
+      const cache = new PostgresTtlCache<number[]>(pool, { ttlMs: 60_000, namespace: ns });
+      let calls = 0;
+      const compute = async () => {
+        calls += 1;
+        return [calls];
+      };
+      assert.deepEqual(await cache.getOrCompute('k', compute), [1]);
+      assert.deepEqual(await cache.getOrCompute('k', compute), [1]); // from cache
+      assert.equal(calls, 1);
+      await cache.clear();
+    });
+
+    await t.test('ttlMs <= 0 disables caching (always recompute)', async () => {
+      const cache = new PostgresTtlCache<number[]>(pool, { ttlMs: 0, namespace: ns });
+      let calls = 0;
+      const compute = async () => {
+        calls += 1;
+        return [calls];
+      };
+      await cache.getOrCompute('k', compute);
+      await cache.getOrCompute('k', compute);
+      assert.equal(calls, 2);
+    });
+
+    await t.test('a failed compute is not cached — the next call retries', async () => {
+      const cache = new PostgresTtlCache<number[]>(pool, { ttlMs: 60_000, namespace: ns });
+      await assert.rejects(
+        cache.getOrCompute('boom', async () => {
+          throw new Error('nope');
+        }),
+      );
+      assert.deepEqual(await cache.getOrCompute('boom', async () => [42]), [42]);
+      await cache.clear();
+    });
+
+    await t.test('expired entries are not served', async () => {
+      const cache = new PostgresTtlCache<number[]>(pool, { ttlMs: 1, namespace: ns }); // 1ms
+      let calls = 0;
+      const compute = async () => {
+        calls += 1;
+        return [calls];
+      };
+      await cache.getOrCompute('exp', compute);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await cache.getOrCompute('exp', compute);
+      assert.equal(calls, 2);
+      await cache.clear();
+    });
+  },
+);

--- a/apps/api/src/lib/cache.postgres.pgtest.ts
+++ b/apps/api/src/lib/cache.postgres.pgtest.ts
@@ -65,5 +65,24 @@ test(
       assert.equal(calls, 2);
       await cache.clear();
     });
+
+    await t.test('a write purges the namespace’s expired rows (bounded growth)', async () => {
+      const purgeNs = `${ns}-purge`;
+      const shortLived = new PostgresTtlCache<number[]>(pool, { ttlMs: 1, namespace: purgeNs });
+      await shortLived.getOrCompute('stale', async () => [1]); // expires ~immediately
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      // A fresh write in the same namespace triggers the expired-row purge.
+      const longLived = new PostgresTtlCache<number[]>(pool, { ttlMs: 60_000, namespace: purgeNs });
+      await longLived.getOrCompute('fresh', async () => [2]);
+
+      const { rows } = await pool.query<{ count: number }>(
+        'select count(*)::int as count from cache_entries where key like $1',
+        [`${purgeNs}:%`],
+      );
+      // Only the fresh row remains; the stale one was purged on write.
+      assert.equal(rows[0]?.count, 1);
+      await longLived.clear();
+    });
   },
 );

--- a/apps/api/src/lib/cache.postgres.test.ts
+++ b/apps/api/src/lib/cache.postgres.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { Pool } from 'pg';
+import { PostgresTtlCache } from './cache.postgres';
+
+// Resilience unit tests — no real DB. A cache is optional, so a DB failure must degrade
+// to a direct compute, never turn a cache outage into a job-search outage (#211 review).
+
+function rejectingPool(): Pool {
+  return { query: async () => Promise.reject(new Error('db down')) } as unknown as Pool;
+}
+
+test('a failed cache READ degrades to a direct compute (does not throw)', async () => {
+  const cache = new PostgresTtlCache<number[]>(rejectingPool(), { ttlMs: 60_000, namespace: 'x' });
+  let calls = 0;
+  const value = await cache.getOrCompute('k', async () => {
+    calls += 1;
+    return [calls];
+  });
+  assert.deepEqual(value, [1]);
+  assert.equal(calls, 1);
+});
+
+test('a failed cache WRITE still returns the computed value', async () => {
+  // Read resolves empty (miss), write rejects — the value must still come back.
+  let call = 0;
+  const pool = {
+    query: async () => {
+      call += 1;
+      if (call === 1) return { rows: [] }; // the SELECT: a miss
+      throw new Error('write failed'); // the INSERT
+    },
+  } as unknown as Pool;
+  const cache = new PostgresTtlCache<number[]>(pool, { ttlMs: 60_000, namespace: 'x' });
+  const value = await cache.getOrCompute('k', async () => [7]);
+  assert.deepEqual(value, [7]);
+});
+
+test('ttlMs <= 0 computes directly without touching the DB', async () => {
+  const cache = new PostgresTtlCache<number[]>(rejectingPool(), { ttlMs: 0, namespace: 'x' });
+  assert.deepEqual(await cache.getOrCompute('k', async () => [9]), [9]);
+});

--- a/apps/api/src/lib/cache.postgres.ts
+++ b/apps/api/src/lib/cache.postgres.ts
@@ -40,21 +40,39 @@ export class PostgresTtlCache<T> implements AsyncTtlCache<T> {
     if (this.ttlMs <= 0) return compute();
 
     const namespaced = this.keyFor(key);
-    const hit = await this.pool.query<{ value: T }>(
-      'select value from cache_entries where key = $1 and expires_at > now()',
-      [namespaced],
-    );
-    if (hit.rows[0]) return hit.rows[0].value; // jsonb → already-parsed value
+
+    try {
+      const hit = await this.pool.query<{ value: T }>(
+        'select value from cache_entries where key = $1 and expires_at > now()',
+        [namespaced],
+      );
+      if (hit.rows[0]) return hit.rows[0].value; // jsonb → already-parsed value
+    } catch {
+      // A cache-read failure (DB hiccup) must not become a job-search outage — the whole
+      // point of a cache is to be optional. Degrade to a direct compute, uncached.
+      return compute();
+    }
 
     const value = await compute(); // errors propagate uncached, exactly like TtlCache
-    await this.pool.query(
-      `
-        insert into cache_entries (key, value, expires_at)
-        values ($1, $2::jsonb, now() + make_interval(secs => $3::double precision / 1000))
-        on conflict (key) do update set value = excluded.value, expires_at = excluded.expires_at
-      `,
-      [namespaced, JSON.stringify(value), this.ttlMs],
-    );
+    try {
+      await this.pool.query(
+        `
+          insert into cache_entries (key, value, expires_at)
+          values ($1, $2::jsonb, now() + make_interval(secs => $3::double precision / 1000))
+          on conflict (key) do update set value = excluded.value, expires_at = excluded.expires_at
+        `,
+        [namespaced, JSON.stringify(value), this.ttlMs],
+      );
+      // Bound the table: novel search keys would otherwise accumulate forever (the
+      // in-memory cache had a 500-entry cap). Purge this namespace's expired rows on
+      // write — infrequent (only on a miss) and index-backed on expires_at.
+      await this.pool.query(
+        'delete from cache_entries where key like $1 and expires_at <= now()',
+        [`${this.namespace}:%`],
+      );
+    } catch {
+      // Write/cleanup failed — still return the computed value, just uncached.
+    }
     return value;
   }
 

--- a/apps/api/src/lib/cache.postgres.ts
+++ b/apps/api/src/lib/cache.postgres.ts
@@ -1,0 +1,64 @@
+/**
+ * A Postgres-backed TTL cache (Phase 4 scale-prep).
+ *
+ * The in-memory `TtlCache` is process-local, so on a multi-instance deployment each
+ * instance keeps its own copy and cache hits don't share. This backs the same
+ * `AsyncTtlCache` seam with a shared `cache_entries` table. Opt-in via
+ * `JOB_SEARCH_CACHE_STORE=postgres`; the in-memory default is untouched.
+ *
+ * Matches the in-memory semantics: a non-positive `ttlMs` disables caching, and a
+ * failed `compute()` is never cached (the error propagates so the next call retries).
+ */
+
+import type { Pool } from 'pg';
+import type { AsyncTtlCache } from './cache';
+
+export interface PostgresTtlCacheOptions {
+  /** Entry lifetime in ms. `<= 0` disables caching (every lookup recomputes). */
+  ttlMs: number;
+  /** Key namespace so different cache users can't collide in the shared table. */
+  namespace: string;
+}
+
+export class PostgresTtlCache<T> implements AsyncTtlCache<T> {
+  private readonly ttlMs: number;
+  private readonly namespace: string;
+
+  constructor(
+    private readonly pool: Pool,
+    options: PostgresTtlCacheOptions,
+  ) {
+    this.ttlMs = options.ttlMs;
+    this.namespace = options.namespace;
+  }
+
+  private keyFor(key: string): string {
+    return `${this.namespace}:${key}`;
+  }
+
+  async getOrCompute(key: string, compute: () => Promise<T>): Promise<T> {
+    if (this.ttlMs <= 0) return compute();
+
+    const namespaced = this.keyFor(key);
+    const hit = await this.pool.query<{ value: T }>(
+      'select value from cache_entries where key = $1 and expires_at > now()',
+      [namespaced],
+    );
+    if (hit.rows[0]) return hit.rows[0].value; // jsonb → already-parsed value
+
+    const value = await compute(); // errors propagate uncached, exactly like TtlCache
+    await this.pool.query(
+      `
+        insert into cache_entries (key, value, expires_at)
+        values ($1, $2::jsonb, now() + make_interval(secs => $3::double precision / 1000))
+        on conflict (key) do update set value = excluded.value, expires_at = excluded.expires_at
+      `,
+      [namespaced, JSON.stringify(value), this.ttlMs],
+    );
+    return value;
+  }
+
+  async clear(): Promise<void> {
+    await this.pool.query('delete from cache_entries where key like $1', [`${this.namespace}:%`]);
+  }
+}

--- a/apps/api/src/lib/cache.ts
+++ b/apps/api/src/lib/cache.ts
@@ -8,6 +8,16 @@
  * Degrades safely: a non-positive `ttlMs` disables caching (every lookup misses),
  * and a failed `getOrCompute` is never cached so the next call retries.
  */
+/**
+ * The cache seam the job-search path depends on. Both the in-memory `TtlCache`
+ * and the Postgres-backed `PostgresTtlCache` satisfy it, so the store is a config
+ * choice (`JOB_SEARCH_CACHE_STORE`) rather than a code change.
+ */
+export interface AsyncTtlCache<T> {
+  getOrCompute(key: string, compute: () => Promise<T>): Promise<T>;
+  clear(): Promise<void> | void;
+}
+
 export interface TtlCacheOptions {
   /** Entry lifetime in ms. `<= 0` disables caching entirely. */
   ttlMs: number;
@@ -22,7 +32,7 @@ interface Entry<T> {
   expires: number;
 }
 
-export class TtlCache<T> {
+export class TtlCache<T> implements AsyncTtlCache<T> {
   private readonly store = new Map<string, Entry<T>>();
   private readonly ttlMs: number;
   private readonly maxEntries: number;

--- a/apps/api/src/lib/job-sources/index.ts
+++ b/apps/api/src/lib/job-sources/index.ts
@@ -1,4 +1,6 @@
-import { TtlCache } from '../cache';
+import { TtlCache, type AsyncTtlCache } from '../cache';
+import { PostgresTtlCache } from '../cache.postgres';
+import { getPool } from '../postgres';
 import { createAdzunaSource } from './adzuna';
 import { createRemotiveSource } from './remotive';
 import type { SourcedJob } from './normalize';
@@ -23,11 +25,26 @@ function jobSearchCacheTtlMs(): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-const jobSearchCache = new TtlCache<SourcedJob[]>({ ttlMs: jobSearchCacheTtlMs() });
+/**
+ * Build the job-search cache. `JOB_SEARCH_CACHE_STORE=postgres` (with a live pool)
+ * shares hits across instances via `cache_entries`; otherwise the process-local
+ * in-memory cache (correct for a single instance, and the safe fallback if the flag
+ * is set but the DB is unavailable).
+ */
+function createJobSearchCache(): AsyncTtlCache<SourcedJob[]> {
+  const ttlMs = jobSearchCacheTtlMs();
+  if (process.env.JOB_SEARCH_CACHE_STORE === 'postgres') {
+    const pool = getPool();
+    if (pool) return new PostgresTtlCache<SourcedJob[]>(pool, { ttlMs, namespace: 'jobsearch' });
+  }
+  return new TtlCache<SourcedJob[]>({ ttlMs });
+}
+
+const jobSearchCache = createJobSearchCache();
 
 /** Clear the shared job-search cache (used in tests; safe to call anytime). */
-export function clearJobSearchCache(): void {
-  jobSearchCache.clear();
+export async function clearJobSearchCache(): Promise<void> {
+  await jobSearchCache.clear();
 }
 
 /** Stable cache key for a search. Country matters because Adzuna is region-scoped. */
@@ -52,7 +69,7 @@ export function jobSearchCacheKey(
  */
 export function withCachedSearch(
   source: JobSource,
-  cache: TtlCache<SourcedJob[]>,
+  cache: AsyncTtlCache<SourcedJob[]>,
   country: () => string,
 ): JobSource {
   return {

--- a/apps/api/src/lib/rate-limit-store.pgtest.ts
+++ b/apps/api/src/lib/rate-limit-store.pgtest.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import type { Options } from 'express-rate-limit';
+import { getPool } from './postgres';
+import { PostgresRateLimitStore } from './rate-limit-store.postgres';
+
+// Real-Postgres only (named *.pgtest.ts so `npm test` skips it; run via `npm run test:pg`).
+// Proves the shared cross-instance counter — the whole point of externalizing the limiter.
+const DB = process.env.DATABASE_URL?.trim();
+
+test(
+  'PostgresRateLimitStore: shared window counter, expiry reset, and prefix isolation',
+  { skip: DB ? false : 'DATABASE_URL not set — Postgres integration test skipped' },
+  async (t) => {
+    const pool = getPool();
+    assert.ok(pool, 'expected a live pool');
+
+    const store = new PostgresRateLimitStore(pool);
+    store.prefix = `t:${randomUUID().slice(0, 8)}:`;
+    store.init({ windowMs: 60_000 } as Options);
+
+    await t.test('increments accumulate within the window', async () => {
+      const first = await store.increment('user-A');
+      const second = await store.increment('user-A');
+      assert.equal(first.totalHits, 1);
+      assert.equal(second.totalHits, 2);
+      assert.ok(second.resetTime instanceof Date);
+    });
+
+    await t.test('get reflects the live counter, decrement/resetKey adjust it', async () => {
+      assert.equal((await store.get('user-A'))?.totalHits, 2);
+      await store.decrement('user-A');
+      assert.equal((await store.get('user-A'))?.totalHits, 1);
+      await store.resetKey('user-A');
+      assert.equal(await store.get('user-A'), undefined);
+    });
+
+    await t.test('an elapsed window resets to a fresh 1 on the next hit', async () => {
+      const expired = new PostgresRateLimitStore(pool);
+      expired.prefix = store.prefix;
+      expired.init({ windowMs: 0 } as Options); // each hit's window has already ended
+      assert.equal((await expired.increment('user-B')).totalHits, 1);
+      assert.equal((await expired.increment('user-B')).totalHits, 1);
+    });
+
+    await t.test('a different prefix is a different counter (limiters share one table)', async () => {
+      const other = new PostgresRateLimitStore(pool);
+      other.prefix = `t:other:${randomUUID().slice(0, 8)}:`;
+      other.init({ windowMs: 60_000 } as Options);
+      await store.increment('shared');
+      assert.equal(await other.get('shared'), undefined);
+    });
+
+    await store.resetAll();
+  },
+);

--- a/apps/api/src/lib/rate-limit-store.postgres.ts
+++ b/apps/api/src/lib/rate-limit-store.postgres.ts
@@ -1,0 +1,93 @@
+/**
+ * A Postgres-backed `express-rate-limit` store (Phase 4 scale-prep).
+ *
+ * The default MemoryStore counts requests per *process*, so on a multi-instance
+ * App Service the effective limit is `configured × instanceCount` — the ceiling
+ * stops meaning anything. This store keeps the fixed-window counter in a shared
+ * table so the limit holds across instances. Opt-in via `RATE_LIMIT_STORE=postgres`;
+ * the in-memory default is untouched for the current single-instance deployment.
+ *
+ * Each limiter (global vs strict) gets its own store instance with a distinct
+ * `prefix` so their counters don't collide in the shared table.
+ */
+
+import type { Pool } from 'pg';
+import type {
+  ClientRateLimitInfo,
+  IncrementResponse,
+  Options,
+  Store,
+} from 'express-rate-limit';
+
+interface HitRow {
+  hits: number;
+  expires_at: string;
+}
+
+export class PostgresRateLimitStore implements Store {
+  /** express-rate-limit sets this per limiter; namespaces keys in the shared table. */
+  prefix = '';
+  /** Counters live in Postgres, not this process, so hits are NOT local. */
+  localKeys = false as const;
+
+  private windowMs = 60_000;
+
+  constructor(private readonly pool: Pool) {}
+
+  init(options: Options): void {
+    this.windowMs = options.windowMs;
+  }
+
+  private keyFor(key: string): string {
+    return `${this.prefix}${key}`;
+  }
+
+  async increment(key: string): Promise<IncrementResponse> {
+    // Atomic upsert: a live window increments; an expired/absent one starts a
+    // fresh window at 1. The whole check-and-set is one statement, so concurrent
+    // requests (even across instances) can't race the counter.
+    const { rows } = await this.pool.query<HitRow>(
+      `
+        insert into rate_limit_hits (key, hits, expires_at)
+        values ($1, 1, now() + make_interval(secs => $2::double precision / 1000))
+        on conflict (key) do update set
+          hits = case
+            when rate_limit_hits.expires_at <= now() then 1
+            else rate_limit_hits.hits + 1
+          end,
+          expires_at = case
+            when rate_limit_hits.expires_at <= now()
+              then now() + make_interval(secs => $2::double precision / 1000)
+            else rate_limit_hits.expires_at
+          end
+        returning hits, expires_at
+      `,
+      [this.keyFor(key), this.windowMs],
+    );
+    const row = rows[0]!;
+    return { totalHits: row.hits, resetTime: new Date(row.expires_at) };
+  }
+
+  async decrement(key: string): Promise<void> {
+    await this.pool.query('update rate_limit_hits set hits = greatest(hits - 1, 0) where key = $1', [
+      this.keyFor(key),
+    ]);
+  }
+
+  async resetKey(key: string): Promise<void> {
+    await this.pool.query('delete from rate_limit_hits where key = $1', [this.keyFor(key)]);
+  }
+
+  async resetAll(): Promise<void> {
+    await this.pool.query('delete from rate_limit_hits where key like $1', [`${this.prefix}%`]);
+  }
+
+  async get(key: string): Promise<ClientRateLimitInfo | undefined> {
+    const { rows } = await this.pool.query<HitRow>(
+      'select hits, expires_at from rate_limit_hits where key = $1 and expires_at > now()',
+      [this.keyFor(key)],
+    );
+    const row = rows[0];
+    return row ? { totalHits: row.hits, resetTime: new Date(row.expires_at) } : undefined;
+  }
+}

--- a/apps/api/src/lib/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit.test.ts
@@ -15,7 +15,7 @@ test('keyForRequest falls back to the client IP when unauthenticated', () => {
 
 test('createRateLimiter returns 429 once the limit is exceeded in a window', async () => {
   const app = express();
-  app.use(createRateLimiter(2));
+  app.use(createRateLimiter(2, 'test'));
   app.get('/ping', (_request, response) => response.json({ ok: true }));
 
   const server = http.createServer(app);

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -10,7 +10,9 @@
  */
 
 import type { Request } from 'express';
-import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator, type Store } from 'express-rate-limit';
+import { getPool } from './postgres';
+import { PostgresRateLimitStore } from './rate-limit-store.postgres';
 
 const windowMs = Number(process.env.RATE_LIMIT_WINDOW_MS ?? 60_000);
 const globalMax = Number(process.env.RATE_LIMIT_MAX ?? 120);
@@ -21,8 +23,28 @@ export function keyForRequest(request: Pick<Request, 'userId' | 'ip'>): string {
   return request.userId ?? ipKeyGenerator(request.ip ?? '0.0.0.0', 56);
 }
 
-/** Build a limiter with an explicit per-window request `limit`. */
-export function createRateLimiter(limit: number) {
+/**
+ * Pick the counter store. `RATE_LIMIT_STORE=postgres` (with a live pool) shares the
+ * counter across instances so the limit holds under scale-out; otherwise we fall back
+ * to express-rate-limit's per-process MemoryStore (correct for a single instance, and
+ * a safe fail-open if the flag is set but the DB is unavailable). `prefix` namespaces
+ * each limiter's keys in the shared table.
+ */
+function makeStore(prefix: string): Store | undefined {
+  if (process.env.RATE_LIMIT_STORE === 'postgres') {
+    const pool = getPool();
+    if (pool) {
+      const store = new PostgresRateLimitStore(pool);
+      store.prefix = prefix;
+      return store;
+    }
+  }
+  return undefined; // default MemoryStore
+}
+
+/** Build a limiter with an explicit per-window request `limit` and a store namespace. */
+export function createRateLimiter(limit: number, namespace: string) {
+  const store = makeStore(`${namespace}:`);
   return rateLimit({
     windowMs,
     limit,
@@ -30,9 +52,10 @@ export function createRateLimiter(limit: number) {
     legacyHeaders: false,
     keyGenerator: (request: Request) => keyForRequest(request),
     message: { error: 'Too many requests, slow down.' },
+    ...(store ? { store } : {}),
   });
 }
 
 /** Lenient limiter for all routes; strict limiter for the expensive AI/discovery routes. */
-export const globalLimiter = createRateLimiter(globalMax);
-export const strictLimiter = createRateLimiter(aiMax);
+export const globalLimiter = createRateLimiter(globalMax, 'global');
+export const strictLimiter = createRateLimiter(aiMax, 'strict');

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -52,7 +52,10 @@ export function createRateLimiter(limit: number, namespace: string) {
     legacyHeaders: false,
     keyGenerator: (request: Request) => keyForRequest(request),
     message: { error: 'Too many requests, slow down.' },
-    ...(store ? { store } : {}),
+    // With the shared Postgres store, a DB outage must not 500 every request (that would
+    // take down DB-independent routes too). passOnStoreError lets the request through —
+    // fail-open on availability, matching the budget guard. MemoryStore never errors.
+    ...(store ? { store, passOnStoreError: true } : {}),
   });
 }
 

--- a/db/migrations/010_scale_stores.sql
+++ b/db/migrations/010_scale_stores.sql
@@ -1,0 +1,23 @@
+-- Phase 4 scale-prep — shared, cross-instance stores for the rate-limiter and the
+-- job-search cache. Both are OPT-IN (RATE_LIMIT_STORE / JOB_SEARCH_CACHE_STORE =
+-- 'postgres'); the in-memory defaults are unchanged for the current single-instance
+-- deployment. On a scaled-out (multi-instance) App Service these tables let every
+-- instance share one rate-limit counter and one cache, instead of each keeping its own.
+
+-- Fixed-window request counters for express-rate-limit. `key` is the limiter prefix +
+-- the per-request bucket (user id or IPv6 /56 subnet); `expires_at` is the window end.
+create table if not exists rate_limit_hits (
+  key text primary key,
+  hits integer not null default 0,
+  expires_at timestamptz not null
+);
+create index if not exists rate_limit_hits_expires_idx on rate_limit_hits (expires_at);
+
+-- Generic TTL key/value cache (currently the Adzuna job-search results). `value` is the
+-- cached payload; a row is live only while `expires_at > now()`.
+create table if not exists cache_entries (
+  key text primary key,
+  value jsonb not null,
+  expires_at timestamptz not null
+);
+create index if not exists cache_entries_expires_idx on cache_entries (expires_at);


### PR DESCRIPTION
Phase 4 lane (epic #152) — the externalization half. PR 2 of 2 (pagination was #210).

## Why
Both were **process-local**, so scaling the API past one instance breaks them:
- **Rate limiter** (express-rate-limit MemoryStore): each instance counts separately, so the effective ceiling becomes `max × instanceCount` — the limit stops meaning anything.
- **Job-search cache** (in-memory `TtlCache`): each instance keeps its own, so hits don't share.

The per-user **daily budget** reservation is already a Postgres-atomic upsert (multi-instance-safe) — left untouched.

## What
- **Migration 010** — `rate_limit_hits` (fixed-window counters) + `cache_entries` (TTL key/value), both indexed on expiry.
- **`PostgresRateLimitStore`** — implements the express-rate-limit `Store` with an atomic check-and-increment upsert (concurrent requests across instances can't race). Each limiter gets a distinct `prefix` so global vs strict don't collide in the shared table.
- **`PostgresTtlCache`** — backs the existing cache path, now behind an `AsyncTtlCache` seam; matches the in-memory semantics (serve-on-hit, TTL, **never cache a failed compute**).
- **Opt-in**: `RATE_LIMIT_STORE=postgres` / `JOB_SEARCH_CACHE_STORE=postgres`. In-memory defaults are unchanged for the current single instance, and a set-but-DB-unavailable flag **falls back to in-memory** rather than failing.

## Verification
- **Verified against a real Postgres** (Docker `pgvector:pg16`, migration 010 applied): **13 integration tests green** — shared window counter, elapsed-window reset, prefix isolation; cache serve/TTL/expired-not-served/failure-not-cached. These run in CI's `db` job.
- 202 file-mode tests + typecheck + lint clean.

With this + #210, the epic's Phase 4 (polish & scale) is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)