### PR TITLE
chore(deps): align langgraph + azure-monitor floors to the pinned lock

### DIFF
--- a/services/agent/requirements.txt
+++ b/services/agent/requirements.txt
@@ -15,7 +15,7 @@ langchain-openai>=1.0,<2
 langchain-google-genai>=4.3.1,<5
 
 # LangGraph application-assistant orchestration (Phase 3 · Workstream K).
-langgraph>=1.0,<2
+langgraph>=1.2.9,<2
 
 # Agent-as-MCP-client: load external MCP tools into the research agent (Phase 3 · N).
 langchain-mcp-adapters>=0.3,<1
@@ -28,7 +28,7 @@ pandas>=2.2,<3
 numpy>=1.26,<3
 
 # Observability (App Insights via OpenTelemetry)
-azure-monitor-opentelemetry>=1.6,<2
+azure-monitor-opentelemetry>=1.8.9,<2
 
 # LLM tracing/observability (Phase 1 LLMOps). No-op when unconfigured.
 langfuse>=4.14.1,<5


### PR DESCRIPTION
Finishes the safe Dependabot tier. #187 (langgraph) and #186 (azure-monitor) were auto-closed in a merge race; both are no-op floor alignments — the pinned image `constraints.txt` already ships `langgraph==1.2.9` and `azure-monitor-opentelemetry==1.8.9`. This raises the range floors to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)