### PR TITLE
chore(ci): require Node 22 (drop Node 20) — unblocks undici 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Node 22 only: undici 8 requires node >=22.19.0, and we deploy on the App
+        # Service NODE|22-lts runtime — testing Node 20 would test a version we can't run.
         node-version:
-          - 20.x
           - 22.x
 
     steps:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,6 +2,9 @@
   "name": "@jobops/api",
   "private": true,
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "db:init": "tsx scripts/db-init.ts",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "jobops-copilot",
   "private": true,
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "workspaces": [
     "apps/*"
   ],


### PR DESCRIPTION
undici 8 declares `engines.node >=22.19.0`, so CI's Node 20.x leg fails at import (`webidl.util.markAsUncloneable is not a function`). We deploy on the App Service `NODE|22-lts` runtime, so the Node 20 matrix leg was testing a version we can't run. Drops Node 20 from the `verify` matrix and declares `engines.node >=22.19.0` on the root + api packages. Prereq for merging #193 (undici 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)