### PR TITLE
fix(analysis): stop publishing fit scores the app hasn't earned

### DIFF
--- a/apps/api/src/lib/discovery.test.ts
+++ b/apps/api/src/lib/discovery.test.ts
@@ -145,7 +145,9 @@ test('propagates non-duplicate insert errors', async () => {
 
 test('pre-ranks each inserted job with a local-prerank analysis', async () => {
   const { deps, analyses } = makeDeps(
-    [sourced('https://x/1', { descriptionText: 'We use TypeScript and React.' })],
+    // Three recognised skills clears the local-fit evidence floor, so this
+    // posting gets a real estimated number.
+    [sourced('https://x/1', { descriptionText: 'We use TypeScript, React, and Node.js.' })],
     [],
   );
 
@@ -156,6 +158,22 @@ test('pre-ranks each inserted job with a local-prerank analysis', async () => {
   assert.equal(analyses[0]?.jobId, 'job-1');
   assert.equal(analyses[0]?.modelUsed, 'local-prerank');
   assert.equal(typeof analyses[0]?.fitScore, 'number');
+});
+
+test('pre-ranks a thin job-board snippet without inventing a score', async () => {
+  // Adzuna returns 500-char snippets that typically parse to 0–1 skills. The
+  // job is still ingested and analysed; only the fit number is withheld, so the
+  // list renders "not scored" instead of a confident 0 or 100.
+  const { deps, analyses } = makeDeps(
+    [sourced('https://x/1', { descriptionText: 'Exciting AI Engineer role using LLM tooling.' })],
+    [],
+  );
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 1);
+  assert.equal(analyses[0]?.modelUsed, 'local-prerank');
+  assert.equal(analyses[0]?.fitScore, null);
 });
 
 test('still counts an inserted job when pre-rank persistence fails (best-effort)', async () => {

--- a/apps/api/src/lib/local-fit.test.ts
+++ b/apps/api/src/lib/local-fit.test.ts
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { PRERANK_MODEL, computeLocalFit, prerankAnalysis } from './local-fit';
+import { MIN_EVIDENCE_SKILLS, PRERANK_MODEL, computeLocalFit, prerankAnalysis } from './local-fit';
 
 test('scores the overlap of resume skills against job skills', () => {
-  // Description mentions TypeScript, React, Node.js (3 catalog skills).
-  // Resume covers TypeScript + React (2 of 3) → round(2/3*100) = 67.
+  // Description mentions TypeScript, React, Node.js (3 catalog skills = the
+  // evidence floor). Resume covers TypeScript + React (2 of 3) → round(2/3*100) = 67.
   const description = 'We use TypeScript, React, and Node.js daily.';
   const resume = 'Senior engineer fluent in TypeScript and React.';
 
@@ -14,21 +14,44 @@ test('scores the overlap of resume skills against job skills', () => {
   assert.deepEqual(matchedSkills.sort(), ['React', 'TypeScript']);
 });
 
-test('returns 0 with no resume', () => {
-  const result = computeLocalFit('We use TypeScript and React.', '');
-  assert.equal(result.score, 0);
-  assert.deepEqual(result.matchedSkills, []);
-});
-
-test('returns 0 when the description has no recognised skills', () => {
-  const result = computeLocalFit('A friendly team that loves coffee.', 'TypeScript React');
-  assert.equal(result.score, 0);
-  assert.deepEqual(result.matchedSkills, []);
-});
-
 test('scores 100 when the resume covers every job skill', () => {
-  const result = computeLocalFit('TypeScript and React.', 'TypeScript, React, and more.');
+  const result = computeLocalFit(
+    'TypeScript, React, and Node.js.',
+    'TypeScript, React, Node.js, and more.',
+  );
   assert.equal(result.score, 100);
+});
+
+test('scores 0 when a well-described job shares nothing with the resume', () => {
+  // Enough skills to divide by, genuinely no overlap → 0 is a real verdict here.
+  const result = computeLocalFit('We use Python, SQL, and n8n.', 'TypeScript React');
+  assert.equal(result.score, 0);
+  assert.deepEqual(result.matchedSkills, []);
+});
+
+test('returns null (not 0) with no resume to compare against', () => {
+  const result = computeLocalFit('We use TypeScript, React, and Node.js.', '   ');
+  assert.equal(result.score, null);
+  assert.deepEqual(result.matchedSkills, []);
+});
+
+test('returns null when the description has no recognised skills', () => {
+  // "unknown", not "terrible match" — 0 would render as a scored red ring.
+  const result = computeLocalFit('A friendly team that loves coffee.', 'TypeScript React');
+  assert.equal(result.score, null);
+});
+
+test('returns null below the evidence floor, even on a full match', () => {
+  // One recognised skill can only yield 0 or 100. A lone keyword hit must not
+  // publish "100" — this is the shape job-board snippets actually arrive in.
+  const result = computeLocalFit('Experience with TypeScript required.', 'I know TypeScript.');
+  assert.equal(result.score, null);
+  // The observation itself is still reported; only the verdict is withheld.
+  assert.deepEqual(result.matchedSkills, ['TypeScript']);
+});
+
+test('the evidence floor is the documented minimum', () => {
+  assert.equal(MIN_EVIDENCE_SKILLS, 3);
 });
 
 test('prerankAnalysis builds an estimated analysis tagged local-prerank', () => {
@@ -49,4 +72,16 @@ test('prerankAnalysis builds an estimated analysis tagged local-prerank', () => 
   // A matched skill must never also appear as missing.
   const overlap = analysis.missingSkills.filter((skill) => analysis.matchedSkills.includes(skill));
   assert.deepEqual(overlap, []);
+});
+
+test('prerankAnalysis leaves the score unset when evidence is thin', () => {
+  const { fitScore, analysis } = prerankAnalysis(
+    'Experience with TypeScript required.',
+    'I know TypeScript.',
+  );
+
+  assert.equal(fitScore, null);
+  // Still a usable analysis — just without a fabricated number attached.
+  assert.equal(analysis.modelUsed, PRERANK_MODEL);
+  assert.deepEqual(analysis.matchedSkills, ['TypeScript']);
 });

--- a/apps/api/src/lib/local-fit.ts
+++ b/apps/api/src/lib/local-fit.ts
@@ -2,21 +2,45 @@ import { analysisFromParsed, extractKeywords, parseJobDescription } from '@/lib/
 import type { JobAnalysis } from '@/types';
 
 /**
+ * Fewest recognised job skills we will divide by before publishing an estimate.
+ *
+ * The estimate is a ratio, so a tiny denominator can only land on a handful of
+ * values: 1 skill yields 0 or 100, 2 skills yield 0/50/100. Those read as
+ * confident verdicts ("perfect fit!") while carrying almost no information.
+ * Job-board search results make this the common case, not the edge case —
+ * Adzuna returns 500-character description snippets, which typically parse to
+ * 0–2 recognised skills. Below this floor we report "unknown" instead.
+ */
+export const MIN_EVIDENCE_SKILLS = 3;
+
+/**
  * Free, deterministic fit estimate: the share of a job's recognised skills that
  * also appear in the user's resume. No LLM, no I/O. Used to pre-rank discovered
  * postings on ingest before the (paid) LLM score runs on first open.
+ *
+ * Returns `score: null` when there isn't enough evidence to estimate — no
+ * resume to compare against, or too few recognised skills in the description.
+ * `null` means "not scored yet" (the UI renders an empty ring); it must not be
+ * collapsed to 0, which means "scored, and a bad match". Matched skills are
+ * still returned when known, since those are observations rather than a verdict.
  */
 export function computeLocalFit(
   descriptionText: string,
   resumeText: string,
-): { score: number; matchedSkills: string[] } {
+): { score: number | null; matchedSkills: string[] } {
   const jobSkills = extractKeywords(descriptionText);
-  if (jobSkills.length === 0) {
-    return { score: 0, matchedSkills: [] };
+  const resumeLower = resumeText.trim().toLowerCase();
+
+  if (!resumeLower) {
+    return { score: null, matchedSkills: [] };
   }
 
-  const resumeLower = resumeText.toLowerCase();
   const matchedSkills = jobSkills.filter((skill) => resumeLower.includes(skill.toLowerCase()));
+
+  if (jobSkills.length < MIN_EVIDENCE_SKILLS) {
+    return { score: null, matchedSkills };
+  }
+
   const score = Math.round((matchedSkills.length / jobSkills.length) * 100);
 
   return { score, matchedSkills };
@@ -34,7 +58,7 @@ export const PRERANK_MODEL = 'local-prerank';
 export function prerankAnalysis(
   descriptionText: string,
   resumeText: string,
-): { fitScore: number; analysis: JobAnalysis } {
+): { fitScore: number | null; analysis: JobAnalysis } {
   const { score, matchedSkills } = computeLocalFit(descriptionText, resumeText);
   const base = analysisFromParsed(parseJobDescription(descriptionText));
   const matched = new Set(matchedSkills);

--- a/apps/api/src/lib/weekly-report.ts
+++ b/apps/api/src/lib/weekly-report.ts
@@ -57,6 +57,25 @@ function countSkills(jobs: JobRecord[]) {
     .map(([skill]) => skill);
 }
 
+/**
+ * Shorten a model-authored missing-skill string for use inside a sentence.
+ *
+ * The scorer returns free-form justifications, not tokens, so interpolating one
+ * raw produced recommendations like: `Add one truthful proof point for
+ * "Intelligent automation platforms" (automation is implied via agent
+ * workflows, but the job's wording is not explicitly evidenced) to reduce
+ * repeated screening friction.` Prefer a leading quoted phrase, else drop the
+ * parenthetical aside, else clip.
+ */
+function skillPhrase(raw: string): string {
+  const text = raw.trim();
+  const quoted = text.match(/^["“”']([^"“”']{2,})["“”']/);
+  const base = quoted?.[1]?.trim() || text.replace(/\s*\([^)]*\)\s*$/, '').trim();
+  const firstClause = base.split(/(?<=[.;])\s+/)[0]?.trim() || base;
+  const cleaned = firstClause.replace(/[.;,]+$/, '').trim();
+  return cleaned.length > 60 ? `${cleaned.slice(0, 59).trimEnd()}…` : cleaned;
+}
+
 function buildRecommendations(metrics: WeeklyReportMetrics, commonMissingSkills: string[]) {
   if (
     metrics.jobs_discovered === 0 &&
@@ -82,7 +101,7 @@ function buildRecommendations(metrics: WeeklyReportMetrics, commonMissingSkills:
       ? 'Review the drafted outreach and send or archive the items that are still waiting.'
       : 'Keep outreach drafts aligned to the most promising roles and contacts.',
     commonMissingSkills[0]
-      ? `Add one truthful proof point for ${commonMissingSkills[0]} to reduce repeated screening friction.`
+      ? `Add one truthful proof point for ${skillPhrase(commonMissingSkills[0])} to reduce repeated screening friction.`
       : 'Capture one new proof point from this week so the next report has a stronger story to tell.',
   ];
 

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { LoadSampleDataButton } from '@/components/load-sample-data-button';
 import { SectionCard } from '@/components/section-card';
 import { StatTile } from '@/components/stat-tile';
 import { StatusPill } from '@/components/status-pill';
+import { isSkillLabelTruncated, skillLabel } from '@/lib/analysis-display';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { getDashboardSummary } from '@/lib/dashboard';
@@ -90,7 +91,16 @@ export default async function DashboardPage() {
       {/* KPI tiles — real values only (no fabricated trend/sparkline history). */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatTile label="Jobs tracked" value={summary.totalJobs} icon={Briefcase} />
-        <StatTile label="Avg fit score" value={summary.averageFitScore} icon={Target} />
+        <StatTile
+          label="Avg fit score"
+          value={summary.averageFitScore ?? '—'}
+          hint={
+            summary.averageFitScore == null
+              ? 'No jobs scored yet'
+              : `Across ${summary.scoredJobCount} scored job${summary.scoredJobCount === 1 ? '' : 's'}`
+          }
+          icon={Target}
+        />
         <StatTile label="Outreach drafts" value={summary.outreachDrafts} icon={Send} />
         <StatTile label="Follow-ups due" value={summary.followUpsDue} icon={TimerReset} />
       </div>
@@ -158,9 +168,11 @@ export default async function DashboardPage() {
           <div className="space-y-3">
             {summary.topMissingSkills.map((skill) => (
               <div key={skill.skill} className="space-y-1">
-                <div className="flex items-center justify-between text-sm">
-                  <span>{skill.skill}</span>
-                  <span className="text-muted-foreground tabular-nums">{skill.count}</span>
+                <div className="flex items-start justify-between gap-3 text-sm">
+                  <span title={isSkillLabelTruncated(skill.skill) ? skill.skill : undefined}>
+                    {skillLabel(skill.skill)}
+                  </span>
+                  <span className="text-muted-foreground shrink-0 tabular-nums">{skill.count}</span>
                 </div>
                 <div className="bg-muted h-2 overflow-hidden rounded-full">
                   <div

--- a/apps/web/src/app/(app)/reports/page.tsx
+++ b/apps/web/src/app/(app)/reports/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { CircleCheck, Download, Send, Target, Briefcase, CalendarCheck } from 'lucide-react';
 import { EmptyState } from '@/components/empty-state';
+import { isSkillLabelTruncated, skillLabel } from '@/lib/analysis-display';
 import { SectionCard } from '@/components/section-card';
 import { StatTile } from '@/components/stat-tile';
 import { Card } from '@/components/ui/card';
@@ -43,7 +44,6 @@ export default async function ReportsPage() {
   }
 
   const topSkills = snapshot.commonMissingSkills.slice(0, 6);
-  const maxSkill = Math.max(1, topSkills.length);
 
   return (
     <div className="space-y-6">
@@ -85,23 +85,27 @@ export default async function ReportsPage() {
           )}
         </SectionCard>
 
-        <SectionCard title="Recurring missing skills" description="Repeated gaps across your targets.">
+        <SectionCard
+          title="Recurring missing skills"
+          description="Repeated gaps across your targets, most frequent first."
+        >
           {topSkills.length > 0 ? (
-            <div className="space-y-3">
+            // Deliberately a ranked list, not a bar chart: the report carries no
+            // per-skill counts (`commonMissingSkills` is a plain string[]), so any
+            // bar length would be invented. This previously drew bars from the
+            // array index, which looked like data and was not.
+            <ol className="space-y-2.5">
               {topSkills.map((skill, index) => (
-                <div key={skill} className="space-y-1">
-                  <div className="flex items-center justify-between text-sm">
-                    <span>{skill}</span>
-                  </div>
-                  <div className="bg-muted h-2 overflow-hidden rounded-full">
-                    <div
-                      className="bg-primary h-full rounded-full"
-                      style={{ width: `${100 - (index / maxSkill) * 60}%` }}
-                    />
-                  </div>
-                </div>
+                <li key={skill} className="flex items-start gap-3 text-sm">
+                  <span className="bg-muted text-muted-foreground mt-px flex size-5 shrink-0 items-center justify-center rounded-md text-xs font-medium tabular-nums">
+                    {index + 1}
+                  </span>
+                  <span title={isSkillLabelTruncated(skill) ? skill : undefined}>
+                    {skillLabel(skill)}
+                  </span>
+                </li>
               ))}
-            </div>
+            </ol>
           ) : (
             <p className="text-muted-foreground text-sm">No repeated skill gaps yet.</p>
           )}

--- a/apps/web/src/components/job-analysis-actions.tsx
+++ b/apps/web/src/components/job-analysis-actions.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { ApiRequestError, scoreFit } from '@/lib/api';
+import { isHeuristicAnalysis } from '@/lib/analysis-display';
 
 type JobAnalysisActionsProps = {
   jobId: string;
@@ -29,7 +30,18 @@ export function JobAnalysisActions({ jobId, autoScore = false }: JobAnalysisActi
     setIsScoring(true);
     try {
       const scored = await scoreFit({ jobId });
-      if (!silent) toast.success(`Fit score saved: ${scored.fit_score}/100`);
+      // /score-fit answers 200 whether the agent scored the job or the request
+      // fell through to the rule-based heuristic (agent-client.ts falls back on
+      // any agent failure — a cold start on the scale-to-zero container is the
+      // common case). Without this the two are indistinguishable to the user,
+      // who sees a confident number and no hint that the AI never ran.
+      if (isHeuristicAnalysis(scored.model_used)) {
+        toast.warning(`Estimated fit: ${scored.fit_score}/100`, {
+          description: 'The AI scorer was unavailable, so this is a rule-based estimate. Try again in a moment for a full analysis.',
+        });
+      } else if (!silent) {
+        toast.success(`Fit score saved: ${scored.fit_score}/100`);
+      }
       // Always refresh so the upgraded score is reflected in the UI, even silently.
       router.refresh();
     } catch (error) {

--- a/apps/web/src/components/stat-tile.tsx
+++ b/apps/web/src/components/stat-tile.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils';
 export function StatTile({
   label,
   value,
+  hint,
   trend,
   trendLabel,
   spark,
@@ -14,6 +15,8 @@ export function StatTile({
 }: {
   label: string;
   value: string | number;
+  /** Small caption under the value — e.g. what the number is measured over. */
+  hint?: string;
   trend?: number;
   trendLabel?: string;
   spark?: number[];
@@ -36,6 +39,7 @@ export function StatTile({
           <Sparkline values={spark} variant={sparkVariant} width={64} height={28} />
         ) : null}
       </div>
+      {hint ? <p className="text-muted-foreground text-xs">{hint}</p> : null}
       {trend != null ? (
         <p
           className={cn(

--- a/apps/web/src/lib/analysis-display.test.ts
+++ b/apps/web/src/lib/analysis-display.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { PRERANK_MODEL, isHeuristicAnalysis, isPrerankAnalysis } from './analysis-display';
+import {
+  PRERANK_MODEL,
+  isHeuristicAnalysis,
+  isPrerankAnalysis,
+  isSkillLabelTruncated,
+  skillLabel,
+} from './analysis-display';
 
 describe('isHeuristicAnalysis (QA·B heuristic banner)', () => {
   it('flags only the unambiguous fit-scorer fallback marker', () => {
@@ -28,5 +34,49 @@ describe('isPrerankAnalysis', () => {
 
   it('does not classify the pre-rank sentinel as a heuristic fit', () => {
     expect(isHeuristicAnalysis('local-prerank')).toBe(false);
+  });
+});
+
+describe('skillLabel', () => {
+  // The strings below are verbatim `missing_skills` entries from the live
+  // scorer (gpt-5.4-nano): reasoning, not skill tokens. Rendering them raw
+  // turned the dashboard and weekly report into walls of model commentary.
+
+  it('prefers a leading quoted phrase over the surrounding justification', () => {
+    expect(
+      skillLabel(
+        '"Intelligent automation platforms" (automation is implied via agent workflows, but the job\'s wording is not explicitly evidenced)',
+      ),
+    ).toBe('Intelligent automation platforms');
+  });
+
+  it('handles curly quotes and trailing commentary', () => {
+    expect(
+      skillLabel('“Large Language Models” phrasing is present, but no specific details follow'),
+    ).toBe('Large Language Models');
+  });
+
+  it('drops a trailing parenthetical aside when there is no quoted phrase', () => {
+    expect(
+      skillLabel('LangGraph tool integrations (explicit tool experience not mentioned)'),
+    ).toBe('LangGraph tool integrations');
+  });
+
+  it('elides an over-long label', () => {
+    const label = skillLabel(
+      'Explicit experience with deployment of LLM/GAI solutions to meet business stakeholder requirements',
+    );
+    expect(label.length).toBeLessThanOrEqual(48);
+    expect(label.endsWith('…')).toBe(true);
+  });
+
+  it('leaves an ordinary skill token untouched', () => {
+    expect(skillLabel('Kubernetes')).toBe('Kubernetes');
+    expect(skillLabel('  TypeScript  ')).toBe('TypeScript');
+    expect(isSkillLabelTruncated('Kubernetes')).toBe(false);
+  });
+
+  it('reports truncation so callers can expose the original', () => {
+    expect(isSkillLabelTruncated('"Intelligent automation platforms" (implied)')).toBe(true);
   });
 });

--- a/apps/web/src/lib/analysis-display.ts
+++ b/apps/web/src/lib/analysis-display.ts
@@ -22,3 +22,46 @@ export const PRERANK_MODEL = 'local-prerank';
 export function isPrerankAnalysis(modelUsed: string | null | undefined): boolean {
   return modelUsed === PRERANK_MODEL;
 }
+
+/** Longest skill label we render inline before eliding. */
+const MAX_SKILL_LABEL = 48;
+
+/**
+ * Reduce a model-authored "missing skill" to something that reads as a skill.
+ *
+ * The scorer is free-form, so `missing_skills` regularly arrives as reasoning
+ * prose rather than a token, e.g.
+ *
+ *   `"Intelligent automation platforms" (automation is implied via agent
+ *    workflows, but the job's wording is not explicitly evidenced)`
+ *
+ * Rendering that verbatim in a chip list turns the dashboard and the weekly
+ * report into walls of model commentary. Prefer a leading quoted phrase, then
+ * drop any parenthetical justification, then elide. Callers should keep the raw
+ * string as a `title` so the full rationale is still reachable on hover.
+ */
+export function skillLabel(raw: string): string {
+  const text = raw.trim();
+
+  // `"Large Language Models" phrasing is present, but …` → `Large Language Models`
+  const quoted = text.match(/^["“”']([^"“”']{2,})["“”']/);
+  if (quoted?.[1]) {
+    const inner = quoted[1].trim();
+    if (inner.length <= MAX_SKILL_LABEL) return inner;
+    return `${inner.slice(0, MAX_SKILL_LABEL - 1).trimEnd()}…`;
+  }
+
+  // Drop a trailing parenthetical justification, then any clause after the
+  // first sentence break.
+  const withoutAside = text.replace(/\s*\([^)]*\)\s*$/, '').trim();
+  const firstSentence = withoutAside.split(/(?<=[.;])\s+/)[0]?.trim() || withoutAside;
+  const cleaned = (firstSentence || text).replace(/[.;,]+$/, '').trim();
+
+  if (cleaned.length <= MAX_SKILL_LABEL) return cleaned;
+  return `${cleaned.slice(0, MAX_SKILL_LABEL - 1).trimEnd()}…`;
+}
+
+/** True when the label was shortened, so the caller should expose the original. */
+export function isSkillLabelTruncated(raw: string): boolean {
+  return skillLabel(raw) !== raw.trim();
+}

--- a/apps/web/src/lib/dashboard.ts
+++ b/apps/web/src/lib/dashboard.ts
@@ -15,11 +15,17 @@ const statusBuckets: JobStatus[] = [
 ];
 
 export function getDashboardSummary(jobs: Job[]) {
-  const averageFitScore = jobs.length
-    ? Math.round(
-        jobs.reduce((total, job) => total + (job.fitScore ?? 0), 0) / jobs.length,
-      )
-    : 0;
+  // Average only the jobs that actually carry a score. Counting an unscored job
+  // as 0 dragged the headline number toward zero as soon as discovery pulled in
+  // a batch — it reported "avg fit 32" for a pipeline whose scored jobs averaged
+  // in the 80s. `null` means "not scored yet", never "scored zero".
+  const scoredJobs = jobs.filter(
+    (job): job is Job & { fitScore: number } => typeof job.fitScore === 'number',
+  );
+  const averageFitScore = scoredJobs.length
+    ? Math.round(scoredJobs.reduce((total, job) => total + job.fitScore, 0) / scoredJobs.length)
+    : null;
+  const scoredJobCount = scoredJobs.length;
 
   const statusCounts = Object.fromEntries(
     statusBuckets.map((status) => [status, jobs.filter((job) => job.status === status).length]),
@@ -44,6 +50,7 @@ export function getDashboardSummary(jobs: Job[]) {
   return {
     totalJobs: jobs.length,
     averageFitScore,
+    scoredJobCount,
     statusCounts,
     followUpsDue,
     outreachDrafts,


### PR DESCRIPTION
Found while driving the live app end to end as a new user.

## What the live app was showing

Discovery pulled 20 real Adzuna postings. Every one was scored **exactly 0 (×15) or 100 (×5)** — no value in between:

```
scoreDistribution: { "0": 15, "100": 5 }
descLengths:       [500, 500, 500, 500, 500]
```

A job detail page rendered a confident green **100** ring beside `Confidence 48`, `Parsed 1 keywords from the job description`, `Missing skills: None missing.` — and the row text *"Run fit scoring to analyze this role."*

<img width="600" alt="fit score 100, confidence 48, one parsed keyword" src="https://github.com/user-attachments/assets/placeholder" />

The landing page promises fit scores "grounded in real evidence — no hallucinated matches."

## Root cause

`computeLocalFit` publishes `matched / jobSkills * 100`. Adzuna truncates descriptions to **500 characters** and the keyword catalog is **20 terms**, so a posting parses to 0–2 recognised skills — and a 1-skill denominator can only ever return 0 or 100.

It also returned `score: 0` when the description parsed to *nothing*, reporting **unknown** as **terrible match**, indistinguishable from a real zero.

## Changes

| Area | Fix |
|---|---|
| `local-fit.ts` | Return `score: null` below an evidence floor of 3 recognised skills, and when there's no résumé. Matched skills still returned — those are observations; only the verdict is withheld. |
| `dashboard.ts` | Average only *scored* jobs. Counting unscored as 0 reported **"Avg fit score 32"** for a pipeline whose scored jobs averaged in the 80s. |
| `reports/page.tsx` | The "Recurring missing skills" bars were `width: 100 - (index / list.length) * 60` — **bar length was a pure function of array position** and encoded no data, since the report has no per-skill counts. Replaced with a ranked list. |
| `analysis-display.ts` | `skillLabel()` — the scorer returns *reasoning*, not tokens. Entries like `"Intelligent automation platforms" (automation is implied via agent workflows, but the job's wording is not explicitly evidenced)` were rendered verbatim as skill chips. Normalised for display, full text kept in `title`. |
| `job-analysis-actions.tsx` | `/score-fit` answers **200** whether the agent scored the job or it fell through to the `mock-fit-scorer-v1` heuristic. The response already carried `model_used` and the UI ignored it — now warns the score is a rule-based estimate. |

`FitScoreRing` already renders `null` as an empty `—` ring labelled "Not scored yet", so no UI change was needed for the core fix.

## Note

The reports bar-chart issue is the exact defect the 2026-07 audit logged as *"reports skill-bars fabricate magnitude"* — it was recorded as remediated but had never actually been fixed.

## Tests

**210 API + 89 web green.** New cases pin null-vs-zero, the evidence floor, thin-snippet discovery, and `skillLabel` against verbatim live scorer output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXTucjdN6LqHQezv8B5aKY