### PR TITLE
fix(a11y): one main landmark, links that announce as links, touch-sized targets

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -33,7 +33,15 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         <Suspense fallback={<div className="h-16 border-b" />}>
           <AppHeader />
         </Suspense>
-        <main id="main-content" tabIndex={-1} className="flex-1 p-4 outline-none md:p-6 lg:p-8">
+        {/* Reserve the strip the fixed assistant FAB occupies (bottom-4 +
+            size-12, bottom-6 from sm) so the end of a page can always be
+            scrolled clear of it. Previously the last row's controls stayed
+            pinned underneath the button with nothing left to scroll. */}
+        <main
+          id="main-content"
+          tabIndex={-1}
+          className="flex-1 p-4 pb-24 outline-none md:p-6 md:pb-24 lg:p-8 lg:pb-28"
+        >
           {children}
         </main>
       </SidebarInset>

--- a/apps/web/src/components/mode-toggle.tsx
+++ b/apps/web/src/components/mode-toggle.tsx
@@ -4,19 +4,45 @@ import { Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { Button } from '@/components/ui/button';
 
+/**
+ * Theme switch.
+ *
+ * Deliberately renders one button per theme and lets CSS pick which is visible,
+ * rather than deriving a label from `resolvedTheme`. `resolvedTheme` is
+ * undefined during SSR and the first client render, so the label was computed
+ * as "Switch to dark mode" and shipped that way *while already in dark mode* —
+ * the wrong action, announced to assistive tech for the whole session, and it
+ * never corrected itself because nothing re-rendered until the user clicked.
+ *
+ * next-themes sets `class="dark"` on <html> in a blocking script before paint,
+ * so the correct button is visible on first paint with no flash, and `hidden`
+ * keeps the inactive one out of both the tab order and the accessibility tree.
+ */
 export function ModeToggle() {
-  const { setTheme, resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
+  const { setTheme } = useTheme();
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-      onClick={() => setTheme(isDark ? 'light' : 'dark')}
-    >
-      <Sun className="size-5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-      <Moon className="absolute size-5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
-    </Button>
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="dark:hidden"
+        aria-label="Switch to dark mode"
+        title="Switch to dark mode"
+        onClick={() => setTheme('dark')}
+      >
+        <Sun className="size-5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="hidden dark:inline-flex"
+        aria-label="Switch to light mode"
+        title="Switch to light mode"
+        onClick={() => setTheme('light')}
+      >
+        <Moon className="size-5" />
+      </Button>
+    </>
   );
 }

--- a/apps/web/src/components/ui/button.test.tsx
+++ b/apps/web/src/components/ui/button.test.tsx
@@ -1,0 +1,67 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Button } from './button';
+
+describe('Button', () => {
+  it('renders a native button by default', () => {
+    render(<Button>Save changes</Button>);
+    const button = screen.getByRole('button', { name: 'Save changes' });
+    expect(button.tagName).toBe('BUTTON');
+  });
+
+  describe('rendered as a link', () => {
+    // Base UI's Button applies role="button" to whatever it renders once
+    // nativeButton={false}. That made every `<Button render={<Link/>}>` in the
+    // app announce as a button: the "this navigates" affordance was lost, the
+    // control dropped out of the screen reader's links list, and it advertised
+    // Space-key activation that an anchor does not provide. Verified live on the
+    // marketing nav: <a href="/architecture" role="button">.
+    it('stays a link in the accessibility tree', () => {
+      render(<Button render={<a href="/architecture" />}>Architecture</Button>);
+
+      const link = screen.getByRole('link', { name: 'Architecture' });
+      expect(link).toHaveAttribute('href', '/architecture');
+      expect(link).not.toHaveAttribute('role');
+      expect(screen.queryByRole('button')).toBeNull();
+    });
+
+    it('still carries the button styling and slot', () => {
+      render(
+        <Button render={<a href="/jobs/new" />} variant="outline" size="sm">
+          Add job
+        </Button>,
+      );
+
+      const link = screen.getByRole('link', { name: 'Add job' });
+      expect(link).toHaveAttribute('data-slot', 'button');
+      // cva output for variant/size lands on the anchor itself.
+      expect(link.className).toContain('border-border');
+      expect(link.className).toContain('h-7');
+    });
+
+    it('preserves className already on the render target', () => {
+      render(
+        <Button render={<a href="/reports" className="custom-anchor" />}>Reports</Button>,
+      );
+
+      const link = screen.getByRole('link', { name: 'Reports' });
+      expect(link).toHaveClass('custom-anchor');
+      expect(link.className).toContain('inline-flex');
+    });
+  });
+
+  it('gives a non-button, non-link render target button semantics', () => {
+    // A <div> genuinely needs Base UI to supply role + keyboard handling.
+    render(<Button render={<div />}>Run</Button>);
+    expect(screen.getByRole('button', { name: 'Run' })).toBeInTheDocument();
+  });
+
+  it('grows touch targets on a coarse pointer', () => {
+    // Audited at 390px: every control sat between 28px and 32px tall, under the
+    // 44/48px platform guidance for touch.
+    render(<Button>Discover now</Button>);
+    expect(screen.getByRole('button').className).toContain('pointer-coarse:h-11');
+  });
+});

--- a/apps/web/src/components/ui/button.test.tsx
+++ b/apps/web/src/components/ui/button.test.tsx
@@ -1,3 +1,7 @@
+// These tests render plain <a> elements on purpose: the point is to assert what
+// `Button` does to whatever `render` target it receives, independent of
+// next/link. Callers in the app still pass <Link />.
+/* eslint-disable @next/next/no-html-link-for-pages */
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,3 +1,4 @@
+import * as React from "react"
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -19,18 +20,22 @@ const buttonVariants = cva(
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",
       },
+      // Heights are deliberately dense for pointer devices. On a touch primary
+      // pointer they grow to ~44px: an audit at 390px found every control
+      // between 28px and 32px tall, well under the 44/48px platform guidance
+      // (and the icon buttons were near WCAG 2.2 AA 2.5.8's 24px floor).
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        icon: "size-8",
+          "h-8 pointer-coarse:h-11 gap-1.5 px-2.5 pointer-coarse:px-4 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 pointer-coarse:h-9 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 pointer-coarse:h-10 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 pointer-coarse:px-3.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 pointer-coarse:h-12 gap-1.5 px-2.5 pointer-coarse:px-5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        icon: "size-8 pointer-coarse:size-11",
         "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+          "size-6 pointer-coarse:size-9 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
         "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
+          "size-7 pointer-coarse:size-10 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9 pointer-coarse:size-12",
       },
     },
     defaultVariants: {
@@ -40,6 +45,18 @@ const buttonVariants = cva(
   }
 )
 
+/** A `render` target carrying an href is navigation, not an action. */
+function isLinkElement(
+  render: unknown,
+): render is React.ReactElement<{ className?: string }> {
+  return (
+    React.isValidElement(render) &&
+    typeof render.props === "object" &&
+    render.props !== null &&
+    "href" in render.props
+  )
+}
+
 function Button({
   className,
   variant = "default",
@@ -47,14 +64,30 @@ function Button({
   render,
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  const classes = cn(buttonVariants({ variant, size, className }))
+
+  // Base UI's Button stamps role="button" on whatever it renders once
+  // nativeButton={false}, so every `<Button render={<Link/>}>` in the app was
+  // announced as a button rather than a link — losing the "this navigates"
+  // affordance, dropping the control out of the screen reader's links list, and
+  // promising Space-key activation that an anchor does not provide.
+  // Style the anchor directly instead; it is already interactive.
+  if (isLinkElement(render)) {
+    return React.cloneElement(render, {
+      ...props,
+      "data-slot": "button",
+      className: cn(classes, render.props.className),
+    } as React.HTMLAttributes<HTMLElement>)
+  }
+
   return (
     <ButtonPrimitive
       data-slot="button"
-      // When rendered as a non-button element (e.g. a link via `render`), tell
-      // Base UI it is not a native button so it applies correct a11y semantics.
+      // A non-button, non-link render target (e.g. a <div>) still needs Base UI
+      // to supply button semantics and keyboard handling.
       nativeButton={render ? false : undefined}
       render={render}
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={classes}
       {...props}
     />
   )

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -302,9 +302,14 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   )
 }
 
-function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+// Upstream shadcn renders this as <main>. It wraps the app header *and* the
+// page content, and the app layout already marks the content region as
+// <main id="main-content"> (the skip-link target) — which produced two main
+// landmarks, nested, on every authenticated page. A document may have only one
+// `main`, so this wrapper is a plain <div> and the inner region stays the main.
+function SidebarInset({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <main
+    <div
       data-slot="sidebar-inset"
       className={cn(
         "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",


### PR DESCRIPTION
Four defects found auditing the live app with a screen-reader-shaped lens.

### 1. Two `<main>` landmarks, nested

shadcn's `SidebarInset` renders `<main>`; the skip-link work added `<main id="main-content">` **inside** it. Verified live:

```json
[ { "id": "",             "nestedMain": true  },
  { "id": "main-content", "parentTag": "MAIN" } ]
```

A document may have exactly one `main`. `SidebarInset` wraps the header *and* the content, so it becomes a `<div>` and the inner content region stays the `main` — which is also the correct skip-link target, since skipping to a region that contains the header skips nothing.

### 2. Every button-styled link announced as a button

`ui/button.tsx` set `nativeButton={false}` whenever `render` was passed, and Base UI then stamps `role="button"` on the rendered element. Verified live:

```html
<a href="/architecture" role="button">Architecture</a>
<a href="/#features"    role="button">Features</a>
```

This hits every `<Button render={<Link/>}>` in the app — marketing nav, "Add job", "Reports", "View all". Consequences: the "this navigates" affordance is lost, the control drops out of the screen reader's links list, and it advertises Space-key activation that an anchor doesn't provide.

A render target carrying an `href` is now styled directly and left a link. A non-button, non-link target (e.g. `<div>`) still gets Base UI's button semantics. **6 new tests** pin both paths.

### 3. Theme toggle labelled with the wrong action

`resolvedTheme` is `undefined` during SSR and the first client render, so the label computed to "Switch to dark mode" and shipped that way **while already in dark mode**:

```json
{ "htmlClass": "dark", "localStorageTheme": "dark",
  "toggleLabel": "Switch to dark mode" }     // unchanged 2.5s after load
```

It only corrected after the first click, so a screen-reader user is told the wrong action for the whole session.

Replaced with one button per theme, chosen by CSS. next-themes sets `class="dark"` in a blocking script before paint, so the correct button is visible with no flash and `hidden` keeps the other out of the tab order and the a11y tree. No state, so nothing can go stale.

### 4. Touch targets under the minimum

At 390px every control measured 28–32px tall — "Toggle Sidebar" 28×28, "Discover now" and "Add" 28px. Sizes now grow to ~44px under `pointer-coarse`, so pointer devices keep the dense layout unchanged.

Also reserves the strip the fixed assistant FAB occupies, so the end of a page can be scrolled clear of it.

## Tests
95 web tests green (6 new `Button` cases), typecheck + production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXTucjdN6LqHQezv8B5aKY