### PR TITLE
feat(ui): replace every native select with the design-system Select

### DIFF
--- a/apps/web/src/components/job-create-form.tsx
+++ b/apps/web/src/components/job-create-form.tsx
@@ -8,15 +8,20 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { OptionSelect } from '@/components/ui/option-select';
 import { Textarea } from '@/components/ui/textarea';
 import { ApiRequestError, createJob, extractJobFromUrl } from '@/lib/api';
 import type { Job } from '@/types/job';
 
-const workplaceTypeOptions: Array<Job['workplaceType']> = ['remote', 'hybrid', 'onsite', 'flexible'];
-const priorityOptions: Array<Job['priority']> = ['high', 'medium', 'low'];
+const capitalise = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
 
-const selectClass =
-  'border-input bg-card h-9 w-full rounded-md border px-2.5 text-sm capitalize shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none';
+const workplaceTypeOptions = (
+  ['remote', 'hybrid', 'onsite', 'flexible'] as const satisfies readonly Job['workplaceType'][]
+).map((value) => ({ value, label: capitalise(value) }));
+
+const priorityOptions = (
+  ['high', 'medium', 'low'] as const satisfies readonly Job['priority'][]
+).map((value) => ({ value, label: capitalise(value) }));
 
 function isHttpUrl(value: string): boolean {
   try {
@@ -296,36 +301,22 @@ export function JobCreateForm() {
         </div>
         <div className="space-y-1.5">
           <Label htmlFor="workplace">Workplace</Label>
-          <select
+          <OptionSelect
             id="workplace"
-            className={selectClass}
             value={form.workplaceType}
-            onChange={(event) =>
-              updateField('workplaceType', event.target.value as Job['workplaceType'])
-            }
+            onValueChange={(value) => updateField('workplaceType', value)}
+            options={workplaceTypeOptions}
             disabled={isExtracting}
-          >
-            {workplaceTypeOptions.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
-          </select>
+          />
         </div>
         <div className="space-y-1.5">
           <Label htmlFor="priority">Priority</Label>
-          <select
+          <OptionSelect
             id="priority"
-            className={selectClass}
             value={form.priority}
-            onChange={(event) => updateField('priority', event.target.value as Job['priority'])}
-          >
-            {priorityOptions.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
-          </select>
+            onValueChange={(value) => updateField('priority', value)}
+            options={priorityOptions}
+          />
         </div>
       </div>
 

--- a/apps/web/src/components/job-edit-panel.tsx
+++ b/apps/web/src/components/job-edit-panel.tsx
@@ -5,30 +5,40 @@ import type { FormEvent } from 'react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { OptionSelect } from '@/components/ui/option-select';
 import { Textarea } from '@/components/ui/textarea';
 import { ApiRequestError, updateJob } from '@/lib/api';
 import { fromDatetimeLocalValue, toDatetimeLocalValue } from '@/lib/format';
 import type { Job } from '@/types/job';
 
-const statusOptions: Job['status'][] = [
-  'discovered',
-  'shortlisted',
-  'applied',
-  'outreach_drafted',
-  'outreach_sent',
-  'referral_requested',
-  'follow_up_due',
-  'interview',
-  'rejected',
-  'offer',
-  'archived',
-];
+const capitalise = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
 
-const priorityOptions: Job['priority'][] = ['high', 'medium', 'low'];
+/** `outreach_drafted` -> `Outreach drafted`. */
+function formatStatus(status: Job['status']) {
+  return capitalise(status.replaceAll('_', ' '));
+}
 
-const selectClass =
-  'border-input bg-card h-9 w-full rounded-md border px-2.5 text-sm capitalize shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none';
+const statusOptions = (
+  [
+    'discovered',
+    'shortlisted',
+    'applied',
+    'outreach_drafted',
+    'outreach_sent',
+    'referral_requested',
+    'follow_up_due',
+    'interview',
+    'rejected',
+    'offer',
+    'archived',
+  ] as const satisfies readonly Job['status'][]
+).map((value) => ({ value, label: formatStatus(value) }));
+
+const priorityOptions = (['high', 'medium', 'low'] as const satisfies readonly Job['priority'][]).map(
+  (value) => ({ value, label: capitalise(value) }),
+);
 
 type FormState = {
   status: Job['status'];
@@ -88,33 +98,21 @@ export function JobEditPanel({ job }: { job: Job }) {
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
           <Label htmlFor="job-status">Status</Label>
-          <select
+          <OptionSelect
             id="job-status"
-            className={selectClass}
             value={form.status}
-            onChange={(event) => updateField('status', event.target.value as Job['status'])}
-          >
-            {statusOptions.map((option) => (
-              <option key={option} value={option}>
-                {option.replaceAll('_', ' ')}
-              </option>
-            ))}
-          </select>
+            onValueChange={(value) => updateField('status', value)}
+            options={statusOptions}
+          />
         </div>
         <div className="space-y-1.5">
           <Label htmlFor="job-priority">Priority</Label>
-          <select
+          <OptionSelect
             id="job-priority"
-            className={selectClass}
             value={form.priority}
-            onChange={(event) => updateField('priority', event.target.value as Job['priority'])}
-          >
-            {priorityOptions.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
-          </select>
+            onValueChange={(value) => updateField('priority', value)}
+            options={priorityOptions}
+          />
         </div>
       </div>
 
@@ -141,10 +139,9 @@ export function JobEditPanel({ job }: { job: Job }) {
 
       <div className="space-y-1.5">
         <Label htmlFor="job-followup">Follow-up due</Label>
-        <input
+        <Input
           id="job-followup"
           type="datetime-local"
-          className={selectClass}
           value={form.nextActionDue}
           onChange={(event) => updateField('nextActionDue', event.target.value)}
         />

--- a/apps/web/src/components/job-outreach-actions.tsx
+++ b/apps/web/src/components/job-outreach-actions.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { OptionSelect } from '@/components/ui/option-select';
 import { ApiRequestError, draftOutreach } from '@/lib/api';
 import type { OutreachMessageType } from '@/types/job';
 
@@ -20,9 +21,6 @@ const messageTypeOptions: { label: string; value: OutreachMessageType }[] = [
   { label: 'Follow-up', value: 'follow_up' },
   { label: 'Thank you', value: 'thank_you' },
 ];
-
-const selectClass =
-  'border-input bg-card h-9 w-full rounded-md border px-2.5 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none disabled:opacity-50';
 
 type FormState = {
   messageType: OutreachMessageType;
@@ -121,21 +119,13 @@ export function JobOutreachActions({
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="space-y-1.5">
           <Label htmlFor="msg-type">Message type</Label>
-          <select
+          <OptionSelect
             id="msg-type"
-            className={selectClass}
             value={form.messageType}
-            onChange={(event) =>
-              updateField('messageType', event.target.value as OutreachMessageType)
-            }
+            onValueChange={(value) => updateField('messageType', value)}
+            options={messageTypeOptions}
             disabled={busy}
-          >
-            {messageTypeOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+          />
         </div>
         <div className="space-y-1.5">
           <Label htmlFor="contact-name">Contact name</Label>

--- a/apps/web/src/components/jobs-table-empty-states.test.tsx
+++ b/apps/web/src/components/jobs-table-empty-states.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect, it } from 'vitest';
 import type { Job } from '@/types/job';
+import { chooseOption } from '@/test/select';
 import { JobsTable } from './jobs-table';
 
 function makeJob(overrides: Partial<Job>): Job {
@@ -62,7 +63,7 @@ it('reaches "No matching jobs" via the status filter, not only via search', asyn
   const user = userEvent.setup();
   render(<JobsTable jobs={[makeJob({ company: 'Northwind', status: 'discovered' })]} />);
 
-  await user.selectOptions(screen.getByRole('combobox', { name: /filter by status/i }), 'offer');
+  await chooseOption(user, /filter by status/i, /^offer$/i);
 
   expect(screen.getByText('No matching jobs')).toBeInTheDocument();
 });

--- a/apps/web/src/components/jobs-table.test.tsx
+++ b/apps/web/src/components/jobs-table.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect, it } from 'vitest';
 import type { Job } from '@/types/job';
+import { chooseOption } from '@/test/select';
 import { JobsTable } from './jobs-table';
 
 function makeJob(overrides: Partial<Job>): Job {
@@ -76,7 +77,7 @@ it('filters by recency on datePosted (falling back to discoveredAt)', async () =
   expect(screen.getByText('Fresh Role')).toBeInTheDocument();
   expect(screen.getByText('Old Role')).toBeInTheDocument();
 
-  await user.selectOptions(screen.getByLabelText(/filter by recency/i), '24h');
+  await chooseOption(user, /filter by recency/i, /last 24h/i);
 
   expect(screen.getByText('Fresh Role')).toBeInTheDocument();
   expect(screen.queryByText('Old Role')).not.toBeInTheDocument();

--- a/apps/web/src/components/jobs-table.tsx
+++ b/apps/web/src/components/jobs-table.tsx
@@ -118,7 +118,11 @@ export function JobsTable({ jobs, initialQuery = '' }: { jobs: Job[]; initialQue
             value={status}
             onValueChange={setStatus}
             options={statusOptions}
-            className="w-auto min-w-36"
+            // The popup takes the trigger's width, and each item reserves 32px
+            // on the right for the selected-check. At 9rem the longest label
+            // ("Referral requested") ran under that check. Sized for the
+            // longest option instead.
+            className="w-auto min-w-46"
           />
           <OptionSelect
             aria-label="Filter by priority"

--- a/apps/web/src/components/jobs-table.tsx
+++ b/apps/web/src/components/jobs-table.tsx
@@ -4,6 +4,7 @@ import { Search } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { EmptyState } from '@/components/empty-state';
+import { OptionSelect } from '@/components/ui/option-select';
 import { FitScoreRing } from '@/components/fit-score-ring';
 import { StatusPill } from '@/components/status-pill';
 import { Badge } from '@/components/ui/badge';
@@ -22,31 +23,38 @@ import { isWithinRecency, RECENCY_OPTIONS, recencyDate, type RecencyWindow } fro
 import { cn } from '@/lib/utils';
 import type { Job, JobPriority, JobStatus } from '@/types/job';
 
-const statusOptions: Array<JobStatus | 'all'> = [
-  'all',
-  'discovered',
-  'shortlisted',
-  'outreach_drafted',
-  'outreach_sent',
-  'referral_requested',
-  'follow_up_due',
-  'applied',
-  'interview',
-  'offer',
-  'rejected',
-  'archived',
-];
+/** `outreach_drafted` -> `Outreach drafted`. */
+function titleCase(value: string) {
+  const words = value.replaceAll('_', ' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
 
-const priorityOptions: Array<JobPriority | 'all'> = ['all', 'high', 'medium', 'low'];
+const statusOptions = (
+  [
+    'all',
+    'discovered',
+    'shortlisted',
+    'outreach_drafted',
+    'outreach_sent',
+    'referral_requested',
+    'follow_up_due',
+    'applied',
+    'interview',
+    'offer',
+    'rejected',
+    'archived',
+  ] as const satisfies readonly (JobStatus | 'all')[]
+).map((value) => ({ value, label: value === 'all' ? 'All statuses' : titleCase(value) }));
+
+const priorityOptions = (
+  ['all', 'high', 'medium', 'low'] as const satisfies readonly (JobPriority | 'all')[]
+).map((value) => ({ value, label: value === 'all' ? 'All priorities' : titleCase(value) }));
 
 const priorityTone: Record<JobPriority, string> = {
   high: 'bg-rose-500',
   medium: 'bg-amber-500',
   low: 'bg-slate-400',
 };
-
-const selectClass =
-  'border-input bg-card h-9 rounded-md border px-2.5 text-sm capitalize shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none';
 
 export function JobsTable({ jobs, initialQuery = '' }: { jobs: Job[]; initialQuery?: string }) {
   const [query, setQuery] = useState(initialQuery);
@@ -105,42 +113,27 @@ export function JobsTable({ jobs, initialQuery = '' }: { jobs: Job[]; initialQue
               className="bg-card pl-8"
             />
           </div>
-          <select
+          <OptionSelect
             aria-label="Filter by status"
-            className={selectClass}
             value={status}
-            onChange={(event) => setStatus(event.target.value as JobStatus | 'all')}
-          >
-            {statusOptions.map((option) => (
-              <option key={option} value={option}>
-                {option === 'all' ? 'All statuses' : option.replaceAll('_', ' ')}
-              </option>
-            ))}
-          </select>
-          <select
+            onValueChange={setStatus}
+            options={statusOptions}
+            className="w-auto min-w-36"
+          />
+          <OptionSelect
             aria-label="Filter by priority"
-            className={selectClass}
             value={priority}
-            onChange={(event) => setPriority(event.target.value as JobPriority | 'all')}
-          >
-            {priorityOptions.map((option) => (
-              <option key={option} value={option}>
-                {option === 'all' ? 'All priorities' : option}
-              </option>
-            ))}
-          </select>
-          <select
+            onValueChange={setPriority}
+            options={priorityOptions}
+            className="w-auto min-w-36"
+          />
+          <OptionSelect
             aria-label="Filter by recency"
-            className={selectClass}
             value={recency}
-            onChange={(event) => setRecency(event.target.value as RecencyWindow)}
-          >
-            {RECENCY_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+            onValueChange={setRecency}
+            options={RECENCY_OPTIONS}
+            className="w-auto min-w-32"
+          />
         </div>
       ) : null}
 

--- a/apps/web/src/components/ui/option-select.tsx
+++ b/apps/web/src/components/ui/option-select.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+
+export type SelectOption<T extends string> = { value: T; label: string };
+
+/**
+ * A labelled dropdown built on the design-system `Select`.
+ *
+ * Exists so the app stops reaching for a native `<select>`. Every dropdown in
+ * the product — job status and priority, outreach message type, the jobs
+ * filters — was a bare `<select>` styled with a border, so they rendered with
+ * OS-native chrome (and an OS-native popup) inside an otherwise custom UI,
+ * while `components/ui/select.tsx` sat unused. This keeps the one-line
+ * ergonomics of a native select at the call site.
+ */
+export function OptionSelect<T extends string>({
+  id,
+  value,
+  onValueChange,
+  options,
+  className,
+  size = 'default',
+  placeholder,
+  'aria-label': ariaLabel,
+  disabled,
+}: {
+  id?: string;
+  value: T;
+  onValueChange: (value: T) => void;
+  options: readonly SelectOption<T>[];
+  className?: string;
+  size?: 'sm' | 'default';
+  placeholder?: string;
+  'aria-label'?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <Select
+      // `items` lets SelectValue render the option's label rather than the raw
+      // value, so "outreach_drafted" shows as "Outreach drafted".
+      items={[...options]}
+      value={value}
+      onValueChange={(next) => onValueChange(next as T)}
+      disabled={disabled}
+    >
+      <SelectTrigger
+        id={id}
+        size={size}
+        aria-label={ariaLabel}
+        className={cn('w-full', className)}
+      >
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/src/test/select.ts
+++ b/apps/web/src/test/select.ts
@@ -1,0 +1,17 @@
+import { screen, within } from '@testing-library/react';
+import type { UserEvent } from '@testing-library/user-event';
+
+/**
+ * Pick an option from a design-system `OptionSelect`.
+ *
+ * The filters and form dropdowns used to be native `<select>` elements, which
+ * tests drove with `user.selectOptions`. They are Base UI comboboxes now — a
+ * button that opens a listbox popup — so `selectOptions` no longer applies.
+ * This drives the control the way a user does: open the trigger, click the
+ * option by its visible label.
+ */
+export async function chooseOption(user: UserEvent, filterName: RegExp, optionLabel: RegExp) {
+  await user.click(screen.getByRole('combobox', { name: filterName }));
+  const listbox = await screen.findByRole('listbox');
+  await user.click(within(listbox).getByRole('option', { name: optionLabel }));
+}


### PR DESCRIPTION
## The problem

The app shipped **eight bare `<select>` elements** — job status, priority, outreach message type, workplace type, and the three jobs-table filters — each styled with a border class. Browsers render those with OS-native chrome and an OS-native popup, so the most-used controls in the product looked nothing like the rest of it and differed per platform.

Meanwhile `components/ui/select.tsx` existed in the design system and was **used nowhere**.

## The change

Adds `ui/option-select.tsx`, a thin labelled wrapper over the design-system Select that keeps native-select ergonomics at the call site (`value`, `onValueChange`, `options`) — so this is a small diff instead of 40 lines of Trigger/Value/Content/Item per dropdown.

Option labels are now title-cased properly: the status filter reads **"Outreach drafted"** rather than the raw `outreach_drafted` the old `replaceAll('_', ' ')` produced. Base UI's `items` prop renders the label for the selected value, so the trigger matches the list.

Also swaps the follow-up `<input type="datetime-local">` for the design-system `Input`, so its border, height and focus ring match the fields around it. The date spinner itself is still browser-native — styling that away needs a real date-picker component, which is out of scope here.

## Verified in a browser, not just unit tests

Ran the app locally against the **live API** and drove it:

- 0 native selects remain; triggers expose `role="combobox"`
- status popup lists correctly-cased labels and shows the check on the current value
- selecting "Shortlisted" updates the trigger
- **Save changes persists** — refetching the job returns `status: "shortlisted"`
- the jobs filters narrow the table 20 → 1 row

## Test change

The two jobs-table tests drove `user.selectOptions`, which only works on a native `<select>`. They now go through a `chooseOption` helper that opens the trigger and clicks the option by its visible label — closer to what a user actually does.

**83 web tests green**, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXTucjdN6LqHQezv8B5aKY