### PR TITLE
feat(onboarding): make the first run recoverable

### DIFF
--- a/apps/web/src/app/onboarding/onboarding-page.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-page.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { fireEvent } from '@testing-library/react';
 import { afterEach, expect, it, vi } from 'vitest';
 
 const { push, refresh } = vi.hoisted(() => ({ push: vi.fn(), refresh: vi.fn() }));
@@ -13,6 +14,10 @@ const { saveResumeText, uploadResumeFile, createSavedSearch, runDiscovery } = vi
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push, refresh }) }));
 vi.mock('@/lib/api', () => ({ saveResumeText, uploadResumeFile, createSavedSearch, runDiscovery }));
+// The step-1 escape hatch renders a real Clerk button, which needs a provider.
+vi.mock('@clerk/nextjs', () => ({
+  SignOutButton: ({ children }: { children: React.ReactNode }) => children,
+}));
 
 import OnboardingPage from './page';
 
@@ -101,4 +106,60 @@ it('lets the user skip discovery and go to the dashboard', async () => {
 
   expect(createSavedSearch).not.toHaveBeenCalled();
   await waitFor(() => expect(push).toHaveBeenCalledWith('/dashboard'));
+});
+
+
+// --- step 1: file intake -----------------------------------------------------
+
+function dropFile(file: File) {
+  const dropzone = screen.getByText(/drop or choose your resume pdf/i).closest('label');
+  if (!dropzone) throw new Error('dropzone not found');
+  // jsdom has no DataTransfer, so hand fireEvent the shape the handler reads.
+  fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+}
+
+function pdfFile(name = 'resume.pdf', size = 1024) {
+  const file = new File(['%PDF-1.4'], name, { type: 'application/pdf' });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+}
+
+it('tells the user which step of the flow they are on', () => {
+  render(<OnboardingPage />);
+  expect(screen.getByText('Step 1 of 2')).toBeInTheDocument();
+});
+
+it('offers a way out instead of trapping the user on step 1', () => {
+  // A resume is required to pass this step and the app redirects here until a
+  // profile exists, so without an escape a PDF that will not parse locks
+  // someone out of the product entirely.
+  render(<OnboardingPage />);
+  expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument();
+});
+
+it('accepts a dropped PDF', () => {
+  // The copy promised "Drop or choose your resume PDF" but the label carried no
+  // drag handlers, so dropping a file made the browser navigate away to render
+  // the PDF and the half-finished onboarding was lost.
+  render(<OnboardingPage />);
+  dropFile(pdfFile('ava-resume.pdf'));
+  expect(screen.getByText('ava-resume.pdf')).toBeInTheDocument();
+});
+
+it('rejects a dropped non-PDF and says what to do instead', () => {
+  render(<OnboardingPage />);
+  dropFile(new File(['x'], 'notes.docx', { type: 'application/msword' }));
+
+  const alert = screen.getByRole('alert');
+  expect(alert).toHaveTextContent('notes.docx');
+  expect(alert).toHaveTextContent(/paste text/i);
+});
+
+it('rejects a file over the 5 MB API limit and reports the actual size', () => {
+  render(<OnboardingPage />);
+  dropFile(pdfFile('huge.pdf', 6 * 1024 * 1024));
+
+  const alert = screen.getByRole('alert');
+  expect(alert).toHaveTextContent('6.0 MB');
+  expect(alert).toHaveTextContent(/limit is 5 MB/i);
 });

--- a/apps/web/src/app/onboarding/onboarding-page.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-page.test.tsx
@@ -163,3 +163,24 @@ it('rejects a file over the 5 MB API limit and reports the actual size', () => {
   expect(alert).toHaveTextContent('6.0 MB');
   expect(alert).toHaveTextContent(/limit is 5 MB/i);
 });
+
+it('lets a user recover by pasting after a PDF upload fails', async () => {
+  // The failure message tells the user to switch to "Paste text". That advice
+  // was previously a dead end: `pendingFile` stayed set, so saveResume kept
+  // preferring uploadResumeFile and retried the same broken PDF forever.
+  uploadResumeFile.mockRejectedValueOnce(new Error('unparseable pdf'));
+  const user = userEvent.setup();
+  render(<OnboardingPage />);
+
+  dropFile(pdfFile('broken.pdf'));
+  await user.click(screen.getByRole('button', { name: /continue/i }));
+  expect(await screen.findByRole('alert')).toHaveTextContent(/paste text/i);
+
+  await user.click(screen.getByRole('tab', { name: /paste text/i }));
+  await user.type(screen.getByPlaceholderText(/paste your resume text/i), 'Ava Tester — AI engineer');
+  await user.click(screen.getByRole('button', { name: /continue/i }));
+
+  await waitFor(() => expect(saveResumeText).toHaveBeenCalledWith('Ava Tester — AI engineer'));
+  // and crucially: the broken file was not retried
+  expect(uploadResumeFile).toHaveBeenCalledTimes(1);
+});

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState } from 'react';
+import type { DragEvent } from 'react';
 import { useRouter } from 'next/navigation';
-import { FileText, Loader2, Sparkles, Upload } from 'lucide-react';
+import { SignOutButton } from '@clerk/nextjs';
+import { ArrowLeft, FileText, Loader2, Sparkles, Upload } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
@@ -12,10 +14,20 @@ import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { saveResumeText, uploadResumeFile, createSavedSearch, runDiscovery } from '@/lib/api';
+import { cn } from '@/lib/utils';
 
 // Mirrors the Adzuna source: these "locations" aren't geographic, so they're
 // ignored as a `where` filter — we treat them as a remote-only signal instead.
 const NON_GEOGRAPHIC_LOCATIONS = new Set(['remote', 'anywhere', 'worldwide', 'global']);
+
+/** Matches the API's multer limit. Checked here so the failure is specific. */
+const MAX_RESUME_BYTES = 5 * 1024 * 1024;
+
+const TOTAL_STEPS = 2;
+
+function isPdf(file: File) {
+  return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+}
 
 export default function OnboardingPage() {
   const router = useRouter();
@@ -25,6 +37,7 @@ export default function OnboardingPage() {
   const [resumeText, setResumeText] = useState('');
   const [fileName, setFileName] = useState<string | null>(null);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -32,6 +45,48 @@ export default function OnboardingPage() {
   const [query, setQuery] = useState('');
   const [location, setLocation] = useState('');
   const [remoteOnly, setRemoteOnly] = useState(false);
+
+  /**
+   * Shared by the file picker and the drop target so both paths get the same
+   * validation. Previously nothing was checked here, so a 40 MB file or a .docx
+   * only failed server-side and surfaced as a generic "Could not save your
+   * resume", with no hint what was wrong.
+   */
+  function acceptFile(file: File | null) {
+    if (!file) return;
+
+    if (!isPdf(file)) {
+      const message = `“${file.name}” isn’t a PDF. Upload a PDF, or switch to “Paste text”.`;
+      setError(message);
+      toast.error(message);
+      return;
+    }
+    if (file.size > MAX_RESUME_BYTES) {
+      const megabytes = (file.size / (1024 * 1024)).toFixed(1);
+      const message = `“${file.name}” is ${megabytes} MB — the limit is 5 MB.`;
+      setError(message);
+      toast.error(message);
+      return;
+    }
+
+    setPendingFile(file);
+    setFileName(file.name);
+    setError(null);
+  }
+
+  // The drop zone advertised "Drop or choose your resume PDF" but had no drag
+  // handlers at all, so dropping a file made the browser navigate away from the
+  // app to render the PDF — losing the half-finished onboarding.
+  function handleDrop(event: DragEvent<HTMLLabelElement>) {
+    event.preventDefault();
+    setIsDraggingOver(false);
+    acceptFile(event.dataTransfer.files?.[0] ?? null);
+  }
+
+  function handleDragOver(event: DragEvent<HTMLLabelElement>) {
+    event.preventDefault();
+    setIsDraggingOver(true);
+  }
 
   async function saveResume() {
     setSaving(true);
@@ -49,7 +104,13 @@ export default function OnboardingPage() {
       }
       setStep(2);
     } catch {
-      toast.error('Could not save your resume. Please try again.');
+      // Name the fallback explicitly: a PDF that fails to parse is the most
+      // likely failure here, and without this the user has no way forward.
+      const message = pendingFile
+        ? "We couldn't read that PDF. Try another file, or paste the text instead."
+        : 'Could not save your resume. Please try again.';
+      setError(message);
+      toast.error(message);
     } finally {
       setSaving(false);
     }
@@ -99,12 +160,35 @@ export default function OnboardingPage() {
     <main className="bg-background flex min-h-svh items-center justify-center p-4">
       <Card className="w-full max-w-xl">
         <CardHeader>
-          <div className="bg-primary/10 text-primary mb-2 flex size-11 items-center justify-center rounded-xl">
-            <Sparkles className="size-5" />
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <div className="bg-primary/10 text-primary flex size-11 items-center justify-center rounded-xl">
+              <Sparkles className="size-5" />
+            </div>
+            {/* The flow always had two steps but never said so. */}
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-xs font-medium tabular-nums">
+                Step {step} of {TOTAL_STEPS}
+              </span>
+              <span className="flex gap-1" aria-hidden>
+                {Array.from({ length: TOTAL_STEPS }, (_, index) => (
+                  <span
+                    key={index}
+                    className={cn(
+                      // shrink-0: these are empty flex children, so without it
+                      // they collapse to zero width and the indicator vanishes.
+                      'h-1 w-6 shrink-0 rounded-full transition-colors',
+                      index < step ? 'bg-primary' : 'bg-muted',
+                    )}
+                  />
+                ))}
+              </span>
+            </div>
           </div>
           {step === 1 ? (
             <>
-              <h1 className="font-heading text-2xl font-medium leading-snug">Welcome to JobOps Copilot</h1>
+              <h1 className="font-heading text-2xl font-medium leading-snug">
+                Welcome to JobOps Copilot
+              </h1>
               <CardDescription>
                 Add your resume so the AI can score job fit and draft outreach grounded in your real
                 experience. Nothing is sent anywhere without your review.
@@ -112,7 +196,9 @@ export default function OnboardingPage() {
             </>
           ) : (
             <>
-              <h1 className="font-heading text-2xl font-medium leading-snug">What roles are you targeting?</h1>
+              <h1 className="font-heading text-2xl font-medium leading-snug">
+                What roles are you targeting?
+              </h1>
               <CardDescription>
                 We&apos;ll pull matching postings into your feed, already scored against your resume.
               </CardDescription>
@@ -135,18 +221,36 @@ export default function OnboardingPage() {
               <TabsContent value="upload" className="pt-4">
                 <label
                   htmlFor="resume-file"
-                  className="border-border hover:border-primary/50 hover:bg-accent/40 flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-dashed p-8 text-center transition-colors"
+                  onDragOver={handleDragOver}
+                  onDragEnter={handleDragOver}
+                  onDragLeave={() => setIsDraggingOver(false)}
+                  onDrop={handleDrop}
+                  className={cn(
+                    'flex cursor-pointer flex-col items-center gap-2 rounded-xl border border-dashed p-8 text-center transition-colors',
+                    isDraggingOver
+                      ? 'border-primary bg-primary/5'
+                      : 'border-border hover:border-primary/50 hover:bg-accent/40',
+                  )}
                 >
                   {fileName ? (
                     <>
                       <FileText className="text-primary size-6" />
                       <span className="text-sm font-medium">{fileName}</span>
-                      <span className="text-muted-foreground text-xs">Click to choose a different file</span>
+                      <span className="text-muted-foreground text-xs">
+                        Click to choose a different file
+                      </span>
                     </>
                   ) : (
                     <>
-                      <Upload className="text-muted-foreground size-6" />
-                      <span className="text-sm font-medium">Drop or choose your resume PDF</span>
+                      <Upload
+                        className={cn(
+                          'size-6 transition-colors',
+                          isDraggingOver ? 'text-primary' : 'text-muted-foreground',
+                        )}
+                      />
+                      <span className="text-sm font-medium">
+                        {isDraggingOver ? 'Drop to upload' : 'Drop or choose your resume PDF'}
+                      </span>
                       <span className="text-muted-foreground text-xs">PDF, up to 5&nbsp;MB</span>
                     </>
                   )}
@@ -155,12 +259,7 @@ export default function OnboardingPage() {
                     type="file"
                     accept="application/pdf"
                     className="sr-only"
-                    onChange={(event) => {
-                      const file = event.target.files?.[0] ?? null;
-                      setPendingFile(file);
-                      setFileName(file?.name ?? null);
-                      if (file) setError(null);
-                    }}
+                    onChange={(event) => acceptFile(event.target.files?.[0] ?? null)}
                   />
                 </label>
               </TabsContent>
@@ -184,10 +283,24 @@ export default function OnboardingPage() {
               </p>
             ) : null}
 
-            <Button onClick={saveResume} disabled={saving} className="w-full">
+            <Button onClick={saveResume} disabled={saving} aria-busy={saving} className="w-full">
               {saving ? <Loader2 className="size-4 animate-spin" /> : null}
               Continue
             </Button>
+
+            {/* A resume is genuinely required — every downstream feature is
+                grounded on it, and the app redirects here until a profile
+                exists. Say why, and leave a way out instead of trapping
+                someone whose PDF will not parse. */}
+            <p className="text-muted-foreground text-center text-xs">
+              Your resume grounds every fit score and draft.{' '}
+              <SignOutButton>
+                <button type="button" className="hover:text-foreground underline underline-offset-2">
+                  Sign out
+                </button>
+              </SignOutButton>{' '}
+              if you&apos;d rather come back later.
+            </p>
           </CardContent>
         ) : (
           <CardContent className="space-y-5">
@@ -226,7 +339,12 @@ export default function OnboardingPage() {
             ) : null}
 
             <div className="flex items-center gap-3">
-              <Button onClick={discover} disabled={saving} className="flex-1">
+              <Button
+                onClick={discover}
+                disabled={saving}
+                aria-busy={saving}
+                className="flex-1"
+              >
                 {saving ? <Loader2 className="size-4 animate-spin" /> : null}
                 Find matching jobs
               </Button>
@@ -241,6 +359,21 @@ export default function OnboardingPage() {
                 Skip for now
               </Button>
             </div>
+
+            {/* Step 2 was a one-way door: the resume was already saved, but
+                there was no way back to review or replace it. */}
+            <button
+              type="button"
+              onClick={() => {
+                setError(null);
+                setStep(1);
+              }}
+              disabled={saving}
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs disabled:opacity-50"
+            >
+              <ArrowLeft className="size-3.5" />
+              Back to your resume
+            </button>
           </CardContent>
         )}
       </Card>

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -38,6 +38,11 @@ export default function OnboardingPage() {
   const [fileName, setFileName] = useState<string | null>(null);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
+  // Which input the user is actually working in. Without this, a PDF that
+  // failed to upload stayed in `pendingFile` and kept winning over pasted
+  // text, so following the error's own advice ("switch to Paste text") just
+  // retried the same broken file.
+  const [inputMode, setInputMode] = useState<'upload' | 'paste'>('upload');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -91,13 +96,19 @@ export default function OnboardingPage() {
   async function saveResume() {
     setSaving(true);
     setError(null);
+    // Submit whichever input the user is looking at, so a previously-chosen
+    // file can't silently override text typed on the other tab.
+    const usingFile = inputMode === 'upload' && pendingFile !== null;
     try {
-      if (pendingFile) {
+      if (usingFile) {
         await uploadResumeFile(pendingFile);
-      } else if (resumeText.trim()) {
+      } else if (inputMode === 'paste' && resumeText.trim()) {
         await saveResumeText(resumeText.trim());
       } else {
-        const message = 'Add your resume to continue — upload a PDF or paste the text.';
+        const message =
+          inputMode === 'upload'
+            ? 'Add your resume to continue — choose a PDF, or switch to “Paste text”.'
+            : 'Add your resume to continue — paste the text, or switch to “Upload PDF”.';
         setError(message);
         toast.error(message);
         return;
@@ -106,8 +117,8 @@ export default function OnboardingPage() {
     } catch {
       // Name the fallback explicitly: a PDF that fails to parse is the most
       // likely failure here, and without this the user has no way forward.
-      const message = pendingFile
-        ? "We couldn't read that PDF. Try another file, or paste the text instead."
+      const message = usingFile
+        ? "We couldn't read that PDF. Try another file, or switch to “Paste text”."
         : 'Could not save your resume. Please try again.';
       setError(message);
       toast.error(message);
@@ -208,7 +219,13 @@ export default function OnboardingPage() {
 
         {step === 1 ? (
           <CardContent className="space-y-5">
-            <Tabs defaultValue="upload">
+            <Tabs
+              value={inputMode}
+              onValueChange={(value) => {
+                setInputMode(value as 'upload' | 'paste');
+                setError(null);
+              }}
+            >
               <TabsList className="w-full">
                 <TabsTrigger value="upload" className="flex-1">
                   Upload PDF


### PR DESCRIPTION
Three problems, all found walking the flow as a brand-new user.

## 1. The drop zone was a lie

The label read **"Drop or choose your resume PDF"** but carried no `onDrop`/`onDragOver` handlers at all. Dropping a file did what the browser does by default — navigated away from the app to render the PDF, losing the half-finished onboarding.

It now accepts drops, with a hover state and a "Drop to upload" label while a file is over it.

## 2. Files were never validated client-side

`accept="application/pdf"` only filters the picker dialog. A `.docx`, or a 40 MB file, still went to the server and came back as a generic *"Could not save your resume."*

Both paths (picker and drop) now run the same check and name the problem:

```
“notes.docx” isn’t a PDF. Upload a PDF, or switch to “Paste text”.
“huge.pdf” is 6.0 MB — the limit is 5 MB.
```

A failed upload also suggests the paste-text path rather than repeating "try again" — an unparseable PDF will fail every retry.

## 3. Step 1 was a dead end

The component has always had `step: 1 | 2` but never said so. Step 2 had "Skip for now"; step 1 had nothing, and there was no way back from step 2 to review the resume.

Adds a **"Step N of 2"** indicator and a **"Back to your resume"** control on step 2.

A resume genuinely *is* required — every downstream feature is grounded on it, and `(app)/layout.tsx` redirects here until a profile exists, so a "skip" would just loop. Instead this explains why it's needed and adds a **sign-out escape**, so a resume that won't parse no longer locks someone out of the product entirely.

## Verification

Ran locally against the live API and drove it in a browser:

| Check | Result |
|---|---|
| Drop a real PDF | filename appears, file accepted |
| Mid-drag label | "Drop or choose…" → **"Drop to upload"** |
| Drop a `.docx` | specific rejection naming the file |
| Drop a 6 MB PDF | reports actual size vs. the 5 MB limit |

One bug caught only by measuring the rendered element: the progress dashes needed `shrink-0` — as empty flex children they collapsed to **0px wide** and the indicator was invisible despite being in the DOM.

**88 web tests green** (5 new onboarding cases), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXTucjdN6LqHQezv8B5aKY