### PR TITLE
fix(assistant): use the resume already on file

### DIFF
--- a/apps/api/src/routes/assistant.test.ts
+++ b/apps/api/src/routes/assistant.test.ts
@@ -110,3 +110,79 @@ test('returns 503 (not 500) when the agent service is disabled', async () => {
     assert.equal(res.status, 503);
   });
 });
+
+test('falls back to the saved resume when the client sends none', async () => {
+  // The /assistant page labels its resume field optional, so this is the normal
+  // path. Passing an empty resume through meant the graph scored the role
+  // against nothing, failed its fit gate, and reported "Your profile didn't
+  // score high enough" — blaming the user for an input we already had.
+  let sent: Record<string, unknown> | undefined;
+  const router = createAssistantStreamRouter({
+    openUpstream: async (payload) => {
+      sent = payload as Record<string, unknown>;
+      return { ok: true, status: 200, body: sseStream(['event: status\ndata: {"node":"parse"}\n\n']) };
+    },
+    loadProfile: async () => ({ resumeText: 'Ava Tester — 8 years of RAG work', profileText: 'Senior AI Engineer' }),
+  });
+
+  await withServer(router, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-User-Id': 'user_1' },
+      body: JSON.stringify({ description_text: 'Senior AI Engineer, RAG + LangGraph' }),
+    });
+    await response.text();
+    assert.equal(response.status, 200);
+  });
+
+  assert.equal(sent?.resume_text, 'Ava Tester — 8 years of RAG work');
+  assert.equal(sent?.profile_text, 'Senior AI Engineer');
+});
+
+test('an explicitly pasted resume overrides the saved one', async () => {
+  let sent: Record<string, unknown> | undefined;
+  const router = createAssistantStreamRouter({
+    openUpstream: async (payload) => {
+      sent = payload as Record<string, unknown>;
+      return { ok: true, status: 200, body: sseStream(['event: status\ndata: {"node":"parse"}\n\n']) };
+    },
+    loadProfile: async () => ({ resumeText: 'saved resume' }),
+  });
+
+  await withServer(router, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-User-Id': 'user_1' },
+      body: JSON.stringify({ description_text: 'A role', resume_text: 'pasted override' }),
+    });
+    await response.text();
+  });
+
+  assert.equal(sent?.resume_text, 'pasted override');
+});
+
+test('a profile lookup failure does not break the run', async () => {
+  // The resume is an enhancement here, not a preconditionfor streaming.
+  let sent: Record<string, unknown> | undefined;
+  const router = createAssistantStreamRouter({
+    openUpstream: async (payload) => {
+      sent = payload as Record<string, unknown>;
+      return { ok: true, status: 200, body: sseStream(['event: status\ndata: {"node":"parse"}\n\n']) };
+    },
+    loadProfile: async () => {
+      throw new Error('db down');
+    },
+  });
+
+  await withServer(router, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-User-Id': 'user_1' },
+      body: JSON.stringify({ description_text: 'A role' }),
+    });
+    assert.equal(response.status, 200);
+    await response.text();
+  });
+
+  assert.equal(sent?.resume_text, undefined);
+});

--- a/apps/api/src/routes/assistant.ts
+++ b/apps/api/src/routes/assistant.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { requireUser } from '@/lib/auth';
 import { AgentDisabledError, streamAssistantUpstream } from '@/lib/agent-client';
+import { getUserProfile } from '@/data/profile-store';
 
 const AGENT_DISABLED_MESSAGE =
   'The AI agent service is not configured. Set AGENT_SERVICE_URL and a provider key to enable the assistant.';
@@ -14,6 +15,8 @@ export interface UpstreamStream {
 
 export interface AssistantStreamDeps {
   openUpstream: (payload: unknown) => Promise<UpstreamStream>;
+  /** Reads the caller's saved resume so the client needn't resend it. */
+  loadProfile?: (userId: string) => Promise<{ resumeText?: string; profileText?: string } | undefined>;
 }
 
 /**
@@ -24,7 +27,7 @@ export interface AssistantStreamDeps {
  * (before the AI router) so it doesn't double-apply the AI guards to run/resume.
  */
 export function createAssistantStreamRouter(
-  deps: AssistantStreamDeps = { openUpstream: streamAssistantUpstream },
+  deps: AssistantStreamDeps = { openUpstream: streamAssistantUpstream, loadProfile: getUserProfile },
 ) {
   const router = Router();
 
@@ -38,12 +41,22 @@ export function createAssistantStreamRouter(
       return;
     }
 
+    // Fall back to the saved resume, the way /score-fit already does. Without
+    // this the run scored a job description against nothing, failed the graph's
+    // fit gate, and told the user "Your profile didn't score high enough for
+    // this role" — blaming their profile for an input the client never sent.
+    // The resume field on /assistant is labelled optional, so this was the
+    // default path.
+    const profile = await deps.loadProfile?.(userId).catch(() => undefined);
+    const resumeText = body.resume_text?.trim() || profile?.resumeText;
+    const profileText = body.profile_text?.trim() || profile?.profileText || resumeText;
+
     let upstream: UpstreamStream;
     try {
       upstream = await deps.openUpstream({
         description_text: body.description_text,
-        resume_text: body.resume_text,
-        profile_text: body.profile_text,
+        resume_text: resumeText,
+        profile_text: profileText,
         user_id: userId,
       });
     } catch (error) {

--- a/apps/web/src/app/(app)/assistant/page.tsx
+++ b/apps/web/src/app/(app)/assistant/page.tsx
@@ -16,7 +16,7 @@ export default function AssistantPage() {
       </div>
       <SectionCard
         title="Run the assistant"
-        description="Paste a job description (and optionally your resume) to start a streamed, human-in-the-loop run."
+        description="Paste a job description to start a streamed, human-in-the-loop run. It scores against the resume on file."
       >
         <AssistantPanel />
       </SectionCard>

--- a/apps/web/src/components/assistant-panel.tsx
+++ b/apps/web/src/components/assistant-panel.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import { Check, Loader2, Sparkles, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 
 interface Step {
   node: string;
@@ -126,18 +128,32 @@ export function AssistantPanel() {
   return (
     <div className="space-y-4">
       <div className="grid gap-3 sm:grid-cols-2">
-        <textarea
-          className="border-input bg-background min-h-32 rounded-lg border p-3 text-sm"
-          placeholder="Paste a job description…"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-        />
-        <textarea
-          className="border-input bg-background min-h-32 rounded-lg border p-3 text-sm"
-          placeholder="Paste your resume (optional)…"
-          value={resume}
-          onChange={(e) => setResume(e.target.value)}
-        />
+        <div className="space-y-1.5">
+          <Label htmlFor="assistant-jd">Job description</Label>
+          <Textarea
+            id="assistant-jd"
+            className="min-h-32"
+            placeholder="Paste a job description…"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="assistant-resume">Resume</Label>
+          <Textarea
+            id="assistant-resume"
+            className="min-h-32"
+            placeholder="Leave blank to use your saved resume…"
+            value={resume}
+            onChange={(e) => setResume(e.target.value)}
+          />
+          {/* The old placeholder said "(optional)" while the API sent whatever
+              was typed straight through — so leaving it blank scored the role
+              against nothing and always failed the fit gate. */}
+          <p className="text-muted-foreground text-xs">
+            Optional — the run uses the resume on file unless you paste an override.
+          </p>
+        </div>
       </div>
 
       <Button onClick={run} disabled={running} aria-busy={running}>
@@ -167,9 +183,10 @@ export function AssistantPanel() {
             <div role="status" className="bg-muted mt-3 rounded-md px-3 py-2 text-sm">
               <p className="font-medium">Below the fit threshold</p>
               <p className="text-muted-foreground mt-1">
-                Your profile didn&apos;t score high enough for this role. Common next steps: strengthen
-                your resume for the required skills, or use the <strong>Score fit</strong> button on the
-                job detail page to see exactly what&apos;s missing.
+                This role scored below the bar against your resume, so the run stopped before
+                drafting. Use <strong>Score fit</strong> on the job detail page to see exactly which
+                requirements are missing, or check that the resume on file in{' '}
+                <strong>Settings</strong> is current.
               </p>
             </div>
           ) : null}


### PR DESCRIPTION
## The bug

The `/assistant` resume field is labelled **optional**, and leaving it blank is the obvious thing to do — the app already holds your resume from onboarding, and Settings displays it.

Doing that broke the feature.

`createAssistantStreamRouter` passed `resume_text` straight through to the agent with **no fallback**, so the graph scored the job description against nothing, failed its fit gate (threshold 60), and reported:

> **Your profile didn't score high enough for this role.**

## Confirmed live, both directions

Same job description, matching the test resume almost exactly (RAG, pgvector, LangGraph, Python, TypeScript, Docker, Azure, evaluation harnesses):

| Resume box | Result |
|---|---|
| *(blank — the labelled-optional path)* | `Parsing → Scoring → ` **Below the fit bar — stopping** |
| resume pasted | `Parsing → Scoring → Researching → ` **Approve drafting?** → drafted |

So the error blamed the user's profile for an input the client never sent.

## The fix

`/api/ai/score-fit` has always resolved `body.resume_text?.trim() || profile?.resumeText`. The assistant stream now does the same, via an injected `loadProfile` dep so it stays testable.

- a pasted resume still wins
- a profile lookup failure degrades to the previous behaviour rather than blocking the run — the resume enriches the run, it isn't a precondition for streaming

## UI

The two bare `<textarea>` elements become labelled design-system `Textarea`s ("Job description" / "Resume") with an honest hint: *"the run uses the resume on file unless you paste an override."*

The below-threshold copy no longer blames the profile — it points at **Score fit** for the specific gaps and at **Settings** to check the resume is current.

## Tests

3 new cases pin the fallback, the override precedence, and that a profile read failure can't break the stream. **208 API + 83 web green.**

## Still open

`/assistant` can't pick a job from the pipeline — you paste a description by hand even for a job the CRM already holds. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXTucjdN6LqHQezv8B5aKY