### PR TITLE
fix(db): unblock migrations on a database that reached multi-tenancy

### DIFF
--- a/db/migrations/002_weekly_report_storage.sql
+++ b/db/migrations/002_weekly_report_storage.sql
@@ -30,8 +30,29 @@ begin
   end if;
 end $$;
 
-create unique index if not exists weekly_reports_week_range_unique_idx
-  on weekly_reports (week_start, week_end);
+-- This global (week_start, week_end) uniqueness predates multi-tenancy, and 004
+-- replaces it with a per-user index precisely because two accounts may each
+-- hold a report for the same week. Creating it on a database that has already
+-- reached 004 therefore fails on data that is legitimately duplicated — which
+-- is exactly what happened to production: its tracker recorded only 001 and
+-- 002_outreach, while the schema had advanced well past 004, so every run of
+-- `db:init` died here and NO migration from 003 onward could ever be applied.
+--
+-- Skip it when the per-user index already exists. A fresh database is
+-- unaffected (that index does not exist yet at this point, so the global index
+-- is created and 004 drops it as before) and the end state is identical.
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_indexes
+    where schemaname = 'public'
+      and indexname = 'weekly_reports_user_week_range_unique_idx'
+  ) then
+    create unique index if not exists weekly_reports_week_range_unique_idx
+      on weekly_reports (week_start, week_end);
+  end if;
+end $$;
 
 create index if not exists weekly_reports_created_at_idx
   on weekly_reports (created_at desc);


### PR DESCRIPTION
## Production cannot apply *any* migration

Found trying to ship #221's backfill. `db:init` against the live database dies on:

```
error: could not create unique index "weekly_reports_week_range_unique_idx"
```

and has done for a long time. Its tracker records only:

```
001_core_tables.sql
002_outreach_gmail_draft_id.sql
```

…while the schema has advanced well past 004 (the per-user weekly-report index and `saved_searches` are both present). Every run re-attempts `002_weekly_report_storage` and stops there.

**Nothing from 003 onward has ever been applied through the normal path.** `agent_outputs` (008) and the `rate_limit_hits` / `cache_entries` tables (010) are simply **absent from production** — and #221 couldn't land either.

## It's an ordering artifact, not bad data

002 creates a **global** unique index on `(week_start, week_end)`. 004 drops it and replaces it with a **per-user** index — precisely because two accounts may each hold a report for the same week.

Production has exactly that: two users, week `2026-05-11 → 05-17`. That data is correct; the obsolete global index just can't tolerate it.

So 002 now skips that index when the per-user index already exists. A fresh database is unaffected — at 002 the per-user index doesn't exist yet, the global index is created, and 004 drops it as before. Identical end state.

## Verified by reproducing production exactly

On a real pgvector Postgres: schema advanced past 004, two users sharing a week, tracker rolled back to two entries.

| | result |
|---|---|
| without this change | `could not create unique index …` — **production's exact error** |
| with this change | `Bootstrap complete: 10 applied, 2 skipped` |
| fresh database | `Bootstrap complete: 12 applied, 0 skipped` |

The 14 Postgres store tests pass against the resulting schema.

## Note

Applying this to production is a **manual step** — no workflow runs `db:init` against the live database. That gap is arguably the deeper issue and worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXTucjdN6LqHQezv8B5aKY