### PR TITLE
fix(db): apply migrations at boot so production cannot silently drift

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -3,15 +3,26 @@
 # Why this exists: apps/api is an npm workspace whose dependencies are hoisted to
 # the repo-root node_modules. Deploying the workspace folder directly ships no
 # node_modules, so the app crashes with "Cannot find module '@clerk/express'".
-# This workflow assembles a SELF-CONTAINED package (dist + package.json + the
-# production dependency tree copied out of the install this run already tested)
-# and deploys that, then verifies the live app is healthy.
+# This workflow assembles a SELF-CONTAINED package (dist + db/migrations +
+# package.json + the production dependency tree copied out of the install this
+# run already tested) and deploys that, then verifies the live app is healthy.
+#
+# Migrations ship IN the package and the API applies them at boot
+# (src/lib/migrate-on-boot.ts). There is deliberately no migrate step here: a
+# GitHub runner can only reach the database by opening a Postgres firewall rule
+# for an ephemeral IP on every deploy and closing it after — and it would need
+# a production DATABASE_URL in GitHub Secrets. The App Service is already
+# inside the firewall and already holds the credential, so the schema and the
+# code that expects it travel together and cannot drift. The readiness gate
+# below asserts that.
 #
 # Preconditions (already configured on the jobops-api App Service):
 #   - App setting WEBSITE_RUN_FROM_PACKAGE=1        (package mounted read-only;
 #     avoids the B1 big-node_modules extraction hang)
 #   - App setting SCM_DO_BUILD_DURING_DEPLOYMENT=false  (no Oryx rebuild)
 #   - DB / Clerk / App Insights secrets (or Key Vault references) set
+#   - Recovery lever: app setting RUN_MIGRATIONS_ON_BOOT=false + restart boots
+#     the API without migrating, if a bad migration ever wedges startup.
 # Repo config:
 #   - Variable AZURE_WEBAPP_NAME_API
 #   - Secret   AZURE_WEBAPP_PUBLISH_PROFILE_API
@@ -23,6 +34,9 @@ on:
     paths:
       - 'apps/api/**'
       - '.github/workflows/deploy-api.yml'
+      # A new migration must be able to reach production on its own — the API
+      # applies migrations at boot, so shipping one IS the deploy.
+      - 'db/migrations/**'
       # The deploy assembles its package via scripts/ci/write-deploy-package.mjs,
       # so a fix to that helper must be able to trigger a deploy on its own —
       # otherwise the old packaging stays live until an unrelated API change.
@@ -84,8 +98,14 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf apps/api/.deploy
-          mkdir -p apps/api/.deploy/dist
+          mkdir -p apps/api/.deploy/dist apps/api/.deploy/db/migrations
           cp -r apps/api/dist/. apps/api/.deploy/dist/
+          # The API applies these at boot, so they must travel with the build.
+          # findMigrationDir() walks up from dist/lib and expects them here.
+          cp db/migrations/*.sql apps/api/.deploy/db/migrations/
+          test "$(ls -1 apps/api/.deploy/db/migrations/*.sql | wc -l)" \
+             = "$(ls -1 db/migrations/*.sql | wc -l)" \
+            || { echo "Migration files did not all land in the package." >&2; exit 1; }
           # Build the package from the dependency tree `npm ci` just installed —
           # the same one `npm test` exercised — instead of resolving a second one.
           #
@@ -112,7 +132,7 @@ jobs:
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_API }}
           package: apps/api/.deploy
 
-      - name: Health check (readiness — proves DB connectivity)
+      - name: Health check (readiness — proves DB connectivity and schema)
         env:
           API_NAME: ${{ vars.AZURE_WEBAPP_NAME_API }}
         run: |
@@ -120,16 +140,25 @@ jobs:
           # /api/health/ready runs a real "SELECT 1", so it only reports db:ok when
           # Postgres is actually reachable — a broken data path fails this gate
           # instead of going green on a mode flag that only checks DATABASE_URL.
+          #
+          # It also compares the migrations in THIS package against
+          # schema_migrations. db:ok alone is not enough: production once ran
+          # nine migrations behind with five tables missing, and every probe
+          # stayed green because reads against a missing table fail open with an
+          # empty result. Requiring migrations:"ok" is what closes that.
           url="https://${API_NAME}.azurewebsites.net/api/health/ready"
           echo "Polling $url"
           for i in $(seq 1 12); do
             body="$(curl -fsS --max-time 10 "$url" || true)"
             echo "attempt $i: $body"
-            if printf '%s' "$body" | grep -Eq '"db"[[:space:]]*:[[:space:]]*"ok"'; then
-              echo "API ready (database reachable)."
+            if printf '%s' "$body" | grep -Eq '"db"[[:space:]]*:[[:space:]]*"ok"' \
+               && printf '%s' "$body" | grep -Eq '"migrations"[[:space:]]*:[[:space:]]*"ok"'; then
+              echo "API ready (database reachable, schema up to date)."
               exit 0
             fi
             sleep 15
           done
-          echo "API did not report a reachable database (/api/health/ready db:ok) in time." >&2
+          echo "API did not report db:ok AND migrations:ok on /api/health/ready in time." >&2
+          echo "migrations:pending means the schema is behind this build; check the App Service log" >&2
+          echo "stream for the migration that failed, or RUN_MIGRATIONS_ON_BOOT=false to recover." >&2
           exit 1

--- a/apps/api/scripts/db-init.ts
+++ b/apps/api/scripts/db-init.ts
@@ -2,12 +2,7 @@ import 'dotenv/config';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Pool } from 'pg';
-import {
-  applyMigration,
-  bootstrapIfNeeded,
-  ensureTrackingTable,
-  listMigrationFiles,
-} from './db-migrations';
+import { runMigrations } from '../src/lib/migrations';
 
 const databaseUrl = process.env.DATABASE_URL?.trim();
 if (!databaseUrl) {
@@ -38,18 +33,9 @@ async function main() {
     console.log(`Connecting to ${describeTarget(databaseUrl)}`);
     await pool.query('SELECT 1');
 
-    await ensureTrackingTable(pool);
-
-    const migrationFiles = await listMigrationFiles(migrationDir);
-    await bootstrapIfNeeded(pool, migrationFiles);
-
-    let applied = 0;
-    let skipped = 0;
-    for (const filePath of migrationFiles) {
-      const wasApplied = await applyMigration(pool, filePath);
-      if (wasApplied) applied++;
-      else skipped++;
-    }
+    // Same runner the API uses at boot (src/lib/migrations), so a manual
+    // bootstrap and a deploy can never disagree about what "applied" means.
+    const { applied, skipped } = await runMigrations(pool, migrationDir);
 
     console.log(`Bootstrap complete: ${applied} applied, ${skipped} skipped.`);
   } finally {

--- a/apps/api/src/lib/migrate-on-boot.ts
+++ b/apps/api/src/lib/migrate-on-boot.ts
@@ -1,0 +1,112 @@
+/**
+ * Apply pending database migrations when the API starts, and expose the
+ * result so a readiness probe can report drift.
+ *
+ * Why boot and not CI: production sat NINE migrations behind for weeks —
+ * `agent_outputs`, `ai_usage`, `embeddings`, `rate_limit_hits` and
+ * `cache_entries` simply did not exist, and the code that read them failed
+ * open with an empty result instead of an error. Nothing ran `db:init`
+ * against production, because nothing could: a GitHub runner reaches the
+ * database only by opening a firewall rule for an ephemeral IP on every
+ * deploy and closing it after (one such delete has already been observed to
+ * silently no-op, which would leave the database open), and it would need a
+ * production DATABASE_URL stored in GitHub Secrets.
+ *
+ * The App Service is already inside the firewall and already holds the
+ * credential, and the migrations ship in the same package as the code that
+ * expects them — so applying them here makes schema drift structurally
+ * impossible rather than merely monitored.
+ *
+ * Escape hatch: set the app setting RUN_MIGRATIONS_ON_BOOT=false and restart
+ * to bring the API back up without migrating (for example if a bad migration
+ * is wedging startup). Readiness then reports the pending migrations instead
+ * of pretending the schema is current.
+ */
+import { findMigrationDir, listMigrationFiles, pendingMigrations, runMigrations } from '@/lib/migrations';
+import { getPool, hasPostgresConnection } from '@/lib/postgres';
+
+/**
+ * `db/migrations` relative to this module. Resolved by walking up, because the
+ * depth differs between the repo (apps/api/src/lib) and the deploy package
+ * (.deploy/dist/lib). CommonJS build — `__dirname` is available.
+ */
+function migrationDir(): string | null {
+  return findMigrationDir(__dirname);
+}
+
+export function migrationsOnBootEnabled(): boolean {
+  return process.env.RUN_MIGRATIONS_ON_BOOT?.trim().toLowerCase() !== 'false';
+}
+
+/**
+ * Run pending migrations. Throws on failure so the caller can refuse to boot —
+ * serving requests against a schema the code does not match is what produced
+ * the silent empty results in the first place.
+ */
+export async function migrateOnBoot(): Promise<void> {
+  if (!hasPostgresConnection()) {
+    console.log('No DATABASE_URL — skipping migrations (file-backed mode).');
+    return;
+  }
+
+  if (!migrationsOnBootEnabled()) {
+    console.warn(
+      'RUN_MIGRATIONS_ON_BOOT=false — starting without applying migrations. ' +
+        'Readiness will report any pending migration until this is unset.',
+    );
+    return;
+  }
+
+  const dir = migrationDir();
+  if (!dir) {
+    throw new Error(
+      'Could not locate db/migrations next to the running build. ' +
+        'The deploy package must ship db/migrations alongside dist/.',
+    );
+  }
+
+  const pool = getPool();
+  if (!pool) throw new Error('DATABASE_URL is set but no connection pool was created.');
+
+  const { applied, skipped } = await runMigrations(pool, dir);
+  console.log(`Migrations up to date: ${applied} applied, ${skipped} already present.`);
+}
+
+export type MigrationStatus =
+  | { state: 'skipped' }
+  | { state: 'ok' }
+  | { state: 'pending'; pending: string[] }
+  | { state: 'unknown'; reason: string };
+
+/**
+ * Compare the migrations shipped in this build against schema_migrations.
+ *
+ * Cheap enough for a probe: the on-disk list cannot change while the process
+ * runs, so it is read once, leaving a single query per call.
+ */
+let cachedFiles: Promise<string[]> | null = null;
+
+export async function getMigrationStatus(): Promise<MigrationStatus> {
+  if (!hasPostgresConnection()) return { state: 'skipped' };
+
+  const dir = migrationDir();
+  if (!dir) return { state: 'unknown', reason: 'db/migrations not found next to the build' };
+
+  const pool = getPool();
+  if (!pool) return { state: 'unknown', reason: 'no connection pool' };
+
+  try {
+    cachedFiles ??= listMigrationFiles(dir);
+    const pending = await pendingMigrations(pool, await cachedFiles);
+    return pending.length === 0 ? { state: 'ok' } : { state: 'pending', pending };
+  } catch (error) {
+    cachedFiles = null;
+    console.error('Could not read migration state:', error);
+    return { state: 'unknown', reason: 'schema_migrations unreadable' };
+  }
+}
+
+/** Test seam: drop the memoised on-disk migration list. */
+export function resetMigrationStatusCache(): void {
+  cachedFiles = null;
+}

--- a/apps/api/src/lib/migrations.test.ts
+++ b/apps/api/src/lib/migrations.test.ts
@@ -1,16 +1,23 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import test from 'node:test';
 import type { Pool } from 'pg';
-import { applyMigration, bootstrapIfNeeded } from './db-migrations';
+import {
+  applyMigration,
+  bootstrapIfNeeded,
+  findMigrationDir,
+  pendingMigrations,
+  runMigrations,
+} from './migrations';
+
+type MockResult = { rows: Record<string, unknown>[]; rowCount?: number };
+type MockHandler = (sql: string, params?: unknown[]) => MockResult | Promise<MockResult>;
 
 // Pool whose query() routes through a single handler.
 // Only use when pool.connect() is never called by the function under test.
-function poolQueryOnly(
-  handler: (sql: string, params?: unknown[]) => { rows: Record<string, unknown>[] },
-): Pool {
+function poolQueryOnly(handler: MockHandler): Pool {
   return {
     query: async (sql: string, params?: unknown[]) => handler(sql, params),
     connect: async () => {
@@ -21,10 +28,7 @@ function poolQueryOnly(
 
 // Pool with separate handlers for pool.query (used for the "already recorded?" check)
 // and for each client.query call (BEGIN / SQL / INSERT / COMMIT).
-function poolWithClient(
-  poolHandler: (sql: string, params?: unknown[]) => { rows: Record<string, unknown>[] },
-  clientHandler: (sql: string, params?: unknown[]) => { rows: Record<string, unknown>[] },
-): Pool {
+function poolWithClient(poolHandler: MockHandler, clientHandler: MockHandler): Pool {
   return {
     query: async (sql: string, params?: unknown[]) => poolHandler(sql, params),
     connect: async () => ({
@@ -202,4 +206,154 @@ test('bootstrapIfNeeded does not pre-seed when jobs exists but agent_outputs is 
   });
   await bootstrapIfNeeded(pool, ['/m/001.sql', '/m/008.sql']);
   assert.equal(inserted.length, 0, 'should not pre-seed when schema is only partially initialised');
+});
+
+// ─── findMigrationDir ─────────────────────────────────────────────────────────
+
+test('findMigrationDir walks up to db/migrations from a nested build directory', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'jobops-'));
+  try {
+    // Mirrors the deploy package: .deploy/db/migrations next to .deploy/dist/lib.
+    await mkdir(join(root, 'db', 'migrations'), { recursive: true });
+    await writeFile(join(root, 'db', 'migrations', '001_core.sql'), 'SELECT 1;');
+    await mkdir(join(root, 'dist', 'lib'), { recursive: true });
+
+    assert.equal(findMigrationDir(join(root, 'dist', 'lib')), join(root, 'db', 'migrations'));
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test('findMigrationDir ignores a db/migrations directory that holds no .sql files', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'jobops-'));
+  try {
+    // A same-named but empty directory must not shadow the real one further up.
+    await mkdir(join(root, 'db', 'migrations'), { recursive: true });
+    await writeFile(join(root, 'db', 'migrations', '001_core.sql'), 'SELECT 1;');
+    await mkdir(join(root, 'pkg', 'db', 'migrations'), { recursive: true });
+
+    assert.equal(findMigrationDir(join(root, 'pkg')), join(root, 'db', 'migrations'));
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test('findMigrationDir returns null when nothing above holds migrations', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'jobops-'));
+  try {
+    assert.equal(findMigrationDir(root), null);
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+// ─── pendingMigrations ────────────────────────────────────────────────────────
+
+test('pendingMigrations reports files on disk that schema_migrations never recorded', async () => {
+  // Exactly the production state that went unnoticed: the tracker stuck at 002
+  // while the schema had advanced, so everything after it was silently pending.
+  const pool = poolQueryOnly(() => ({
+    rows: [{ filename: '001_core_tables.sql' }, { filename: '002_outreach_gmail_draft_id.sql' }],
+  }));
+
+  const pending = await pendingMigrations(pool, [
+    '/db/migrations/001_core_tables.sql',
+    '/db/migrations/002_outreach_gmail_draft_id.sql',
+    '/db/migrations/003_vector_store.sql',
+    '/db/migrations/008_agent_outputs.sql',
+  ]);
+
+  assert.deepEqual(pending, ['003_vector_store.sql', '008_agent_outputs.sql']);
+});
+
+test('pendingMigrations is empty when every shipped migration is recorded', async () => {
+  const pool = poolQueryOnly(() => ({ rows: [{ filename: '001_core_tables.sql' }] }));
+  const pending = await pendingMigrations(pool, ['/db/migrations/001_core_tables.sql']);
+  assert.deepEqual(pending, []);
+});
+
+// ─── runMigrations ────────────────────────────────────────────────────────────
+
+/** Pool that records every statement, on the pool and on checked-out clients. */
+function recordingPool(alreadyApplied: Set<string>) {
+  const statements: string[] = [];
+  const respond = (sql: string, params?: unknown[]) => {
+    statements.push(sql.trim().split('\n')[0]!.trim());
+    if (sql.includes('WHERE filename')) {
+      return { rows: alreadyApplied.has(String(params?.[0] ?? '')) ? [{ ok: 1 }] : [], rowCount: 0 };
+    }
+    if (sql.includes('count(*)')) return { rows: [{ n: '1' }], rowCount: 1 };
+    if (sql.includes('INSERT INTO schema_migrations')) return { rows: [], rowCount: 1 };
+    return { rows: [], rowCount: 0 };
+  };
+
+  const pool = {
+    query: async (sql: string, params?: unknown[]) => respond(sql, params),
+    connect: async () => ({
+      query: async (sql: string, params?: unknown[]) => respond(sql, params),
+      release: () => {},
+    }),
+  } as unknown as Pool;
+
+  return { pool, statements };
+}
+
+test('runMigrations takes the advisory lock, applies pending files, and releases it', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'jobops-'));
+  try {
+    await writeFile(join(dir, '001_first.sql'), 'SELECT 1;');
+    await writeFile(join(dir, '002_second.sql'), 'SELECT 2;');
+
+    const { pool, statements } = recordingPool(new Set(['001_first.sql']));
+    const result = await runMigrations(pool, dir);
+
+    assert.deepEqual(result, { applied: 1, skipped: 1 }, '001 already recorded, 002 applied');
+
+    const lockAt = statements.findIndex((s) => s.includes('pg_advisory_lock'));
+    const unlockAt = statements.findIndex((s) => s.includes('pg_advisory_unlock'));
+    const insertAt = statements.findIndex((s) => s.includes('INSERT INTO schema_migrations'));
+
+    assert.ok(lockAt >= 0, 'should acquire the advisory lock');
+    assert.ok(unlockAt >= 0, 'should release the advisory lock');
+    assert.ok(
+      statements.some((s) => s.includes('lock_timeout')),
+      'should bound the wait so a wedged peer fails the boot instead of hanging it',
+    );
+    assert.ok(lockAt < insertAt, 'lock must be held before any migration is written');
+    assert.ok(insertAt < unlockAt, 'lock must be held until the last migration is written');
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+});
+
+test('runMigrations releases the advisory lock when a migration throws', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'jobops-'));
+  try {
+    await writeFile(join(dir, '001_boom.sql'), 'SELECT 1;');
+
+    const statements: string[] = [];
+    const pool = {
+      query: async (sql: string) => {
+        statements.push(sql.trim().split('\n')[0]!.trim());
+        if (sql.includes('count(*)')) return { rows: [{ n: '1' }] };
+        return { rows: [] };
+      },
+      connect: async () => ({
+        query: async (sql: string) => {
+          statements.push(sql.trim().split('\n')[0]!.trim());
+          if (sql.includes('SELECT 1;')) throw new Error('syntax error at or near');
+          return { rows: [], rowCount: 1 };
+        },
+        release: () => {},
+      }),
+    } as unknown as Pool;
+
+    await assert.rejects(() => runMigrations(pool, dir), /syntax error/);
+    assert.ok(
+      statements.some((s) => s.includes('pg_advisory_unlock')),
+      'a failed migration must not strand the lock and block every future boot',
+    );
+  } finally {
+    await rm(dir, { recursive: true });
+  }
 });

--- a/apps/api/src/lib/migrations.ts
+++ b/apps/api/src/lib/migrations.ts
@@ -1,6 +1,7 @@
+import { existsSync, readdirSync } from 'node:fs';
 import { readFile, readdir } from 'node:fs/promises';
-import { basename, join } from 'node:path';
-import type { Pool } from 'pg';
+import { basename, dirname, join } from 'node:path';
+import type { Pool, PoolClient } from 'pg';
 
 export async function listMigrationFiles(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -8,6 +9,35 @@ export async function listMigrationFiles(dir: string): Promise<string[]> {
     .filter((e) => e.isFile() && e.name.endsWith('.sql'))
     .map((e) => join(dir, e.name))
     .sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Locate `db/migrations` by walking up from `startDir`, so the same code works
+ * from the repo (`apps/api/src/lib` -> `<repo>/db/migrations`) and from the
+ * deploy package (`.deploy/dist/lib` -> `.deploy/db/migrations`), which has a
+ * different depth. A candidate only counts if it actually holds .sql files —
+ * an empty directory of the right name must not shadow the real one.
+ */
+export function findMigrationDir(startDir: string): string | null {
+  let dir = startDir;
+
+  for (let hop = 0; hop < 8; hop += 1) {
+    const candidate = join(dir, 'db', 'migrations');
+    if (
+      existsSync(candidate) &&
+      readdirSync(candidate, { withFileTypes: true }).some(
+        (e) => e.isFile() && e.name.endsWith('.sql'),
+      )
+    ) {
+      return candidate;
+    }
+
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return null;
 }
 
 export async function ensureTrackingTable(pool: Pool): Promise<void> {
@@ -42,7 +72,7 @@ const BOOTSTRAP_SENTINEL_FILE = '008_agent_outputs.sql';
 
 export async function bootstrapIfNeeded(pool: Pool, migrationFiles: string[]): Promise<void> {
   const { rows } = await pool.query<{ n: string }>('SELECT count(*) AS n FROM schema_migrations');
-  if (Number(rows[0].n) > 0) return;
+  if (Number(rows[0]?.n ?? 0) > 0) return;
 
   const { rows: tableRows } = await pool.query<{ table_name: string }>(
     `SELECT table_name FROM information_schema.tables
@@ -82,7 +112,9 @@ export async function bootstrapIfNeeded(pool: Pool, migrationFiles: string[]): P
 export async function applyMigration(pool: Pool, filePath: string): Promise<boolean> {
   const filename = basename(filePath);
 
-  const { rows } = await pool.query('SELECT 1 FROM schema_migrations WHERE filename = $1', [filename]);
+  const { rows } = await pool.query('SELECT 1 FROM schema_migrations WHERE filename = $1', [
+    filename,
+  ]);
   if (rows.length > 0) {
     console.log(`Skipping already-applied migration ${filename}`);
     return false;
@@ -115,4 +147,81 @@ export async function applyMigration(pool: Pool, filePath: string): Promise<bool
   } finally {
     client.release();
   }
+}
+
+/**
+ * Migration filenames that exist on disk but are absent from schema_migrations.
+ *
+ * This is the drift signal. Production sat nine migrations behind for weeks
+ * because nothing compared these two sets — `fetchAgentOutputs` just returned
+ * `[]` against a table that did not exist. Surfaced on /health/ready so the
+ * gap fails a probe instead of hiding behind an empty result.
+ */
+export async function pendingMigrations(pool: Pool, migrationFiles: string[]): Promise<string[]> {
+  const { rows } = await pool.query<{ filename: string }>('SELECT filename FROM schema_migrations');
+  const applied = new Set(rows.map((r) => r.filename));
+  return migrationFiles.map((f) => basename(f)).filter((name) => !applied.has(name));
+}
+
+/**
+ * Advisory-lock key serialising migration runs across instances. Arbitrary but
+ * fixed: any two runners must pick the same number to exclude each other.
+ */
+const MIGRATION_LOCK_KEY = 4159821;
+
+/** How long a runner waits for another instance's migration before giving up. */
+const LOCK_TIMEOUT = '60s';
+
+/**
+ * Hold the migration advisory lock for the duration of `run`.
+ *
+ * The lock is session-scoped, so it needs its own client — `applyMigration`
+ * checks out separate clients for the migrations themselves. `lock_timeout`
+ * bounds the wait: a wedged peer surfaces as a boot failure rather than an
+ * App Service that hangs forever with no listener.
+ */
+async function withMigrationLock<T>(pool: Pool, run: () => Promise<T>): Promise<T> {
+  const client: PoolClient = await pool.connect();
+  let locked = false;
+  try {
+    await client.query(`SET lock_timeout = '${LOCK_TIMEOUT}'`);
+    await client.query('SELECT pg_advisory_lock($1)', [MIGRATION_LOCK_KEY]);
+    locked = true;
+    return await run();
+  } finally {
+    if (locked) {
+      try {
+        await client.query('SELECT pg_advisory_unlock($1)', [MIGRATION_LOCK_KEY]);
+      } catch (error) {
+        // Releasing the client drops the session and the lock with it, so a
+        // failed unlock is not a leak — just note it and move on.
+        console.error('Failed to release the migration advisory lock:', error);
+      }
+    }
+    client.release();
+  }
+}
+
+export type MigrationRunResult = { applied: number; skipped: number };
+
+/**
+ * Bring the database up to the migrations shipped alongside this build.
+ * Serialised across instances by an advisory lock; safe to call concurrently.
+ */
+export async function runMigrations(pool: Pool, migrationDir: string): Promise<MigrationRunResult> {
+  const migrationFiles = await listMigrationFiles(migrationDir);
+
+  return withMigrationLock(pool, async () => {
+    await ensureTrackingTable(pool);
+    await bootstrapIfNeeded(pool, migrationFiles);
+
+    let applied = 0;
+    let skipped = 0;
+    for (const filePath of migrationFiles) {
+      if (await applyMigration(pool, filePath)) applied += 1;
+      else skipped += 1;
+    }
+
+    return { applied, skipped };
+  });
 }

--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -3,22 +3,57 @@ import assert from 'node:assert/strict';
 import { computeReadiness } from '@/routes/health';
 
 test('computeReadiness: file mode is ready without a database check', () => {
-  assert.deepEqual(computeReadiness('file', false), {
+  assert.deepEqual(computeReadiness('file', false, { state: 'skipped' }), {
     statusCode: 200,
-    body: { status: 'ready', mode: 'file', db: 'skipped' },
+    body: { status: 'ready', mode: 'file', db: 'skipped', migrations: 'skipped' },
   });
 });
 
-test('computeReadiness: postgres reachable is ready (db ok)', () => {
-  assert.deepEqual(computeReadiness('postgres', true), {
+test('computeReadiness: postgres reachable and migrated is ready (db ok)', () => {
+  assert.deepEqual(computeReadiness('postgres', true, { state: 'ok' }), {
     statusCode: 200,
-    body: { status: 'ready', mode: 'postgres', db: 'ok' },
+    body: { status: 'ready', mode: 'postgres', db: 'ok', migrations: 'ok' },
   });
 });
 
 test('computeReadiness: postgres unreachable is not ready (503, db error)', () => {
-  assert.deepEqual(computeReadiness('postgres', false), {
+  assert.deepEqual(computeReadiness('postgres', false, { state: 'unknown', reason: 'x' }), {
     statusCode: 503,
-    body: { status: 'not_ready', mode: 'postgres', db: 'error' },
+    body: { status: 'not_ready', mode: 'postgres', db: 'error', migrations: 'unknown' },
   });
+});
+
+// The regression this whole change exists for: production ran nine migrations
+// behind and every probe stayed green, because a read against a missing table
+// returns an empty result rather than an error.
+test('computeReadiness: reachable but behind on migrations is NOT ready', () => {
+  assert.deepEqual(
+    computeReadiness('postgres', true, {
+      state: 'pending',
+      pending: ['008_agent_outputs.sql', '010_scale_stores.sql'],
+    }),
+    {
+      statusCode: 503,
+      body: {
+        status: 'not_ready',
+        mode: 'postgres',
+        db: 'ok',
+        migrations: 'pending',
+        pending: ['008_agent_outputs.sql', '010_scale_stores.sql'],
+      },
+    },
+  );
+});
+
+// Deliberately lenient: an unreadable schema_migrations must not flap the probe
+// and have App Service restart a working API. The deploy gate requires
+// migrations == "ok", so this still blocks a ship.
+test('computeReadiness: unknown migration state stays ready but is reported', () => {
+  assert.deepEqual(
+    computeReadiness('postgres', true, { state: 'unknown', reason: 'schema_migrations unreadable' }),
+    {
+      statusCode: 200,
+      body: { status: 'ready', mode: 'postgres', db: 'ok', migrations: 'unknown' },
+    },
+  );
 });

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,25 +1,60 @@
 import { Router } from 'express';
 import { getStoreMode } from '@/data/job-store';
 import { isAgentEnabled } from '@/lib/agent-client';
+import { getMigrationStatus, type MigrationStatus } from '@/lib/migrate-on-boot';
 import { pingDatabase } from '@/lib/postgres';
 
 export const healthRouter = Router();
 
 type Readiness = {
   statusCode: number;
-  body: { status: string; mode: string; db: string };
+  body: { status: string; mode: string; db: string; migrations: string; pending?: string[] };
 };
 
 // Pure decision logic for the readiness probe, kept separate so it is unit-testable
 // without a live database.
-export function computeReadiness(mode: 'postgres' | 'file', dbReachable: boolean): Readiness {
+export function computeReadiness(
+  mode: 'postgres' | 'file',
+  dbReachable: boolean,
+  migrations: MigrationStatus,
+): Readiness {
   if (mode !== 'postgres') {
-    return { statusCode: 200, body: { status: 'ready', mode, db: 'skipped' } };
+    return {
+      statusCode: 200,
+      body: { status: 'ready', mode, db: 'skipped', migrations: 'skipped' },
+    };
   }
 
-  return dbReachable
-    ? { statusCode: 200, body: { status: 'ready', mode, db: 'ok' } }
-    : { statusCode: 503, body: { status: 'not_ready', mode, db: 'error' } };
+  if (!dbReachable) {
+    return {
+      statusCode: 503,
+      body: { status: 'not_ready', mode, db: 'error', migrations: 'unknown' },
+    };
+  }
+
+  // A reachable database running behind its migrations is NOT ready. Reads
+  // against a missing table return empty rather than failing, so the only way
+  // this surfaces is if the probe refuses to go green.
+  if (migrations.state === 'pending') {
+    return {
+      statusCode: 503,
+      body: {
+        status: 'not_ready',
+        mode,
+        db: 'ok',
+        migrations: 'pending',
+        pending: migrations.pending,
+      },
+    };
+  }
+
+  // 'unknown' (schema_migrations unreadable) stays 200: connectivity is proven,
+  // and flapping the probe would have App Service restart a working API. The
+  // deploy gate asserts migrations == "ok", so an unknown still blocks a ship.
+  return {
+    statusCode: 200,
+    body: { status: 'ready', mode, db: 'ok', migrations: migrations.state },
+  };
 }
 
 healthRouter.get('/health', (_request, response) => {
@@ -36,7 +71,10 @@ healthRouter.get('/health', (_request, response) => {
 healthRouter.get('/health/ready', async (_request, response) => {
   const mode = getStoreMode();
   const dbReachable = mode === 'postgres' ? await pingDatabase() : false;
-  const { statusCode, body } = computeReadiness(mode, dbReachable);
+  const migrations: MigrationStatus = dbReachable
+    ? await getMigrationStatus()
+    : { state: 'unknown', reason: 'database unreachable' };
+  const { statusCode, body } = computeReadiness(mode, dbReachable, migrations);
   response.status(statusCode).json(body);
 });
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -8,17 +8,33 @@ registerProcessSafetyNet();
 
 import { createApp } from '@/app';
 import { assertProductionAuthConfigured } from '@/lib/auth';
+import { migrateOnBoot } from '@/lib/migrate-on-boot';
 import { registerGracefulShutdown } from '@/lib/shutdown';
 
 // Fail closed: refuse to boot a production deploy whose authentication would be disabled.
 assertProductionAuthConfigured();
 
 const port = Number(process.env.PORT ?? 4000);
-const app = createApp();
 
-const server = app.listen(port, () => {
-  console.log(`JobOps Copilot API listening on http://localhost:${port}`);
+async function start() {
+  // Before the first request, not after: an API serving a schema its code does
+  // not match is exactly how five missing tables went unnoticed — the reads
+  // failed open with empty results. Throwing here fails the deploy's readiness
+  // gate instead. Set RUN_MIGRATIONS_ON_BOOT=false to boot without migrating.
+  await migrateOnBoot();
+
+  const app = createApp();
+
+  const server = app.listen(port, () => {
+    console.log(`JobOps Copilot API listening on http://localhost:${port}`);
+  });
+
+  // Drain in-flight requests + close the DB pool on SIGTERM/SIGINT (Azure deploy/restart).
+  registerGracefulShutdown(server);
+}
+
+start().catch((error: unknown) => {
+  console.error('JobOps Copilot API failed to start.');
+  console.error(error);
+  process.exit(1);
 });
-
-// Drain in-flight requests + close the DB pool on SIGTERM/SIGINT (Azure deploy/restart).
-registerGracefulShutdown(server);

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -62,6 +62,38 @@ npm run dev:api
 
 5. Verify that `GET /api/health` reports `mode: "postgres"`.
 
+## Database migrations
+
+**Production migrates itself.** The API applies every pending migration at boot,
+before it accepts a request (`apps/api/src/lib/migrate-on-boot.ts`). The
+migrations ship inside the deploy package, so the schema and the code that
+expects it are always the same version. `npm run db:init` remains the manual
+path for local and one-off use; it runs the same runner.
+
+Why not a migrate step in CI: a GitHub runner can only reach Azure Postgres by
+opening a firewall rule for an ephemeral IP on every deploy and closing it
+afterwards, and it would need a production `DATABASE_URL` in GitHub Secrets. A
+cleanup that silently fails leaves the database open to the internet — one such
+`firewall-rule delete` has already been observed to no-op. The App Service is
+already inside the firewall and already holds the credential.
+
+What this fixed: production ran **nine migrations behind** for weeks, with
+`agent_outputs`, `ai_usage`, `cache_entries`, `embeddings` and `rate_limit_hits`
+missing entirely. Nothing caught it because a read against a missing table fails
+open with an empty result — `/api/health/ready` reported `db: "ok"` throughout.
+
+- `/api/health/ready` now also reports `migrations`. A reachable database that is
+  behind returns **503** and lists the pending files, and the deploy gate
+  requires `migrations: "ok"`.
+- Concurrent instances are serialised by a Postgres advisory lock, so a
+  scale-out cannot apply the same migration twice.
+- A failing migration **fails the boot** rather than serving a mismatched schema.
+
+**Recovery lever:** if a bad migration wedges startup, set the app setting
+`RUN_MIGRATIONS_ON_BOOT=false` and restart. The API comes back without
+migrating and readiness reports the pending migrations until it is unset — no
+code deploy needed.
+
 ## Cost Controls
 
 - Keep high availability off unless you truly need it.


### PR DESCRIPTION
## The gap this closes

Production ran **nine migrations behind** for weeks. `agent_outputs`, `ai_usage`, `cache_entries`, `embeddings` and `rate_limit_hits` did not exist at all.

Nothing caught it. A read against a missing table fails open with an empty result, so `fetchAgentOutputs` just returned `[]`, and `/api/health/ready` reported `db: "ok"` throughout. **No workflow ran `db:init` against production** — that was the root cause, found while applying #221.

## Why not a migrate step in CI

The obvious fix is a `db:init` step in `deploy-api.yml`. It needs two things I don't want:

1. A production `DATABASE_URL` in GitHub Secrets.
2. A Postgres firewall rule opened for an ephemeral runner IP on **every deploy**, then closed. One such `firewall-rule delete` has already been observed to silently no-op — a failed cleanup leaves the production database open to the internet, and nothing would report it.

The App Service is already inside the firewall and already holds the credential. Migrations ship in the same package as the code that expects them, so applying them at boot makes drift *structurally impossible* rather than merely monitored.

## What changed

- **`src/lib/migrations.ts`** — the runner, moved out of `scripts/` so it's typechecked, linted and built like the rest of `src` (moving it immediately surfaced a latent type error in its own test). Adds `runMigrations()` (advisory-locked, `lock_timeout`-bounded), `pendingMigrations()`, and `findMigrationDir()`, which walks up to `db/migrations` so the same code works from `apps/api/src/lib` and `.deploy/dist/lib` — different depths.
- **`server.ts`** awaits `migrateOnBoot()` before `createApp()`. A failing migration fails the boot rather than serving a schema the code doesn't match.
- **`/api/health/ready`** reports `migrations`. Reachable-but-behind is now **503** and names the pending files. `db: "ok"` alone is precisely what stayed green through the incident.
- **`deploy-api.yml`** ships `db/migrations` in the package, triggers on changes to it, and the gate now requires `migrations: "ok"`.
- `db:init` still works and now calls the same runner, so manual and automatic bootstrap can't disagree.

**Escape hatch:** app setting `RUN_MIGRATIONS_ON_BOOT=false` + restart boots without migrating. A bad migration never needs a code deploy to recover from.

## Verification

Against a real pgvector Postgres, reproducing production's exact state (tracker stuck at `002`, the five tables dropped):

| Case | Result |
|---|---|
| Migrations disabled (old behaviour) | `503` `migrations:"pending"` listing all nine — **used to be `200 {"status":"ready"}`** |
| Normal boot | applies all nine, `200 migrations:"ok"`, five tables restored |
| Deliberately broken migration | exit 1, no listener opened, advisory lock **not** stranded |
| Escape hatch after that failure | API serves, reports `503` naming `012_broken.sql` |
| Two instances booting simultaneously | lock serialises — 9 applied by one, 0 by the other, both healthy, no duplicates |

Also verified the deploy package layout resolves (`.deploy/dist/lib` → `.deploy/db/migrations`) and that `db:init` reports `0 applied, 12 skipped` on an up-to-date database.

Full suite green: 222 API tests, 101 web tests, `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)