### PR TITLE
fix(jobs): stack the jobs table into cards below lg

### DIFF
--- a/apps/web/src/components/jobs-table.test.tsx
+++ b/apps/web/src/components/jobs-table.test.tsx
@@ -106,3 +106,21 @@ it('marks an estimated (local-prerank) job and lists its matched skills', () => 
   expect(screen.getAllByText(/estimated/i).some((el) => el.textContent === 'Estimated')).toBe(true);
   expect(screen.getByText(/TypeScript/)).toBeInTheDocument();
 });
+
+// jsdom has no layout engine, so this cannot assert the measured width. It
+// guards the mechanism instead: below `lg` the rows must switch to a grid and
+// stop inheriting the table's `whitespace-nowrap`, which is what let the table
+// reach 1783px at a 375px viewport. Geometry was verified in a real browser.
+it('renders rows as stacked cards below the lg breakpoint', () => {
+  render(<JobsTable jobs={jobs} />);
+
+  const row = screen.getByText('AI Automation Engineer').closest('tr');
+  expect(row).not.toBeNull();
+  expect(row).toHaveClass('max-lg:grid');
+  // `ring`, not `border`: TableBody's `[&_tr:last-child]:border-0` would strip
+  // the last card's outline in a specificity tie.
+  expect(row).toHaveClass('max-lg:ring-1');
+
+  const identityCell = row!.querySelector('td');
+  expect(identityCell).toHaveClass('max-lg:whitespace-normal');
+});

--- a/apps/web/src/components/jobs-table.test.tsx
+++ b/apps/web/src/components/jobs-table.test.tsx
@@ -124,3 +124,33 @@ it('renders rows as stacked cards below the lg breakpoint', () => {
   const identityCell = row!.querySelector('td');
   expect(identityCell).toHaveClass('max-lg:whitespace-normal');
 });
+
+// A find-and-replace moved the header to `lg` but missed the body cell, whose
+// classes weren't contiguous. That left the value reappearing at `md` while its
+// header stayed hidden — an auto-placed, unlabelled third grid row on tablets.
+it('reveals the next-action column at the same breakpoint as its header', () => {
+  render(<JobsTable jobs={jobs} />);
+
+  const headers = screen.getAllByRole('columnheader');
+  const nextActionHeader = headers.find((h) => h.textContent === 'Next action');
+  const row = screen.getByText('AI Automation Engineer').closest('tr');
+  const nextActionCell = row!.querySelectorAll('td')[4];
+
+  expect(nextActionHeader).toHaveClass('lg:table-cell');
+  expect(nextActionCell).toHaveClass('lg:table-cell');
+  expect(nextActionCell).not.toHaveClass('md:table-cell');
+});
+
+// Card mode drops the header row, and `display: grid` drops the table
+// semantics that would have associated it anyway — so these values would be
+// announced with nothing to say what they describe.
+it('labels the status and priority values for screen readers in card mode', () => {
+  render(<JobsTable jobs={jobs} />);
+
+  for (const label of ['Status:', 'Priority:']) {
+    const [node] = screen.getAllByText(label);
+    expect(node).toHaveClass('sr-only');
+    // Removed at lg, where the real column header does the job.
+    expect(node).toHaveClass('lg:hidden');
+  }
+});

--- a/apps/web/src/components/jobs-table.tsx
+++ b/apps/web/src/components/jobs-table.tsx
@@ -156,26 +156,54 @@ export function JobsTable({ jobs, initialQuery = '' }: { jobs: Job[]; initialQue
           onAction={clearFilters}
         />
       ) : (
+        // Below `lg` the same rows become stacked cards — not a second markup
+        // tree, which would double the DOM and make every `getByText` in the
+        // suite ambiguous. The row becomes a 2-column grid and each cell is
+        // placed explicitly, so the fit ring sits beside the title rather than
+        // competing with it for a line.
+        //
+        // `lg` and not `md` because the table needs ~1000px: at exactly 768px
+        // it still measured 996px and scrolled inside its container. The
+        // breakpoint is the width at which the table stops overflowing.
+        //
+        // Dropping TableCell's `whitespace-nowrap` is what actually fixes the
+        // width. An auto-layout table sizes to its content, so `truncate` could
+        // never engage — the table measured 1783px at a 375px viewport.
         <div className="overflow-x-auto">
-          <Table>
-            <TableHeader>
+          <Table className="max-lg:block">
+            <TableHeader className="max-lg:hidden">
               <TableRow>
                 <TableHead>Company &amp; role</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead className="text-center">Fit</TableHead>
                 <TableHead>Priority</TableHead>
-                <TableHead className="hidden md:table-cell">Next action</TableHead>
+                <TableHead className="hidden lg:table-cell">Next action</TableHead>
               </TableRow>
             </TableHeader>
-            <TableBody>
+            <TableBody className="max-lg:block max-lg:space-y-3">
               {filteredJobs.map((job) => (
-                <TableRow key={job.id} className="group">
-                  <TableCell>
-                    <Link href={`/jobs/${job.id}`} className="flex items-center gap-3">
+                <TableRow
+                  key={job.id}
+                  // `ring` rather than `border` for the card outline: TableBody
+                  // sets `[&_tr:last-child]:border-0`, which would strip the
+                  // last card's frame in a specificity tie.
+                  className="group max-lg:relative max-lg:grid max-lg:grid-cols-[minmax(0,1fr)_auto] max-lg:items-start max-lg:gap-x-3 max-lg:gap-y-3 max-lg:rounded-xl max-lg:border-0 max-lg:p-4 max-lg:ring-1 max-lg:ring-border"
+                >
+                  <TableCell className="max-lg:col-start-1 max-lg:row-start-1 max-lg:min-w-0 max-lg:p-0 max-lg:whitespace-normal">
+                    {/* Stretched link: in card mode the whole card is the tap
+                        target, without nesting interactive elements. */}
+                    <Link
+                      href={`/jobs/${job.id}`}
+                      className="flex items-center gap-3 max-lg:items-start max-lg:after:absolute max-lg:after:inset-0"
+                    >
                       <span className="bg-primary/10 text-primary flex size-9 shrink-0 items-center justify-center rounded-lg text-sm font-semibold">
                         {job.company.slice(0, 1)}
                       </span>
-                      <span className="min-w-0">
+                      {/* The bound belongs here, not on the <td>: `max-width`
+                          on a cell in an auto-layout table is only a hint, so
+                          the table widened to fit the longest title and the
+                          `truncate` classes below could never engage. */}
+                      <span className="min-w-0 lg:max-w-[28rem]">
                         <span className="group-hover:text-primary block truncate font-medium transition-colors">
                           {job.title}
                         </span>
@@ -211,15 +239,15 @@ export function JobsTable({ jobs, initialQuery = '' }: { jobs: Job[]; initialQue
                       </span>
                     </Link>
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="max-lg:col-start-1 max-lg:row-start-2 max-lg:justify-self-start max-lg:p-0">
                     <StatusPill status={job.status} />
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="max-lg:col-start-2 max-lg:row-start-1 max-lg:p-0">
                     <div className="flex justify-center">
                       <FitScoreRing score={job.fitScore} size={38} strokeWidth={4} />
                     </div>
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="max-lg:col-start-2 max-lg:row-start-2 max-lg:justify-self-end max-lg:self-center max-lg:p-0">
                     <span className="flex items-center gap-1.5 text-sm capitalize">
                       <span className={cn('size-2 rounded-full', priorityTone[job.priority])} />
                       {job.priority}

--- a/apps/web/src/components/jobs-table.tsx
+++ b/apps/web/src/components/jobs-table.tsx
@@ -203,7 +203,7 @@ export function JobsTable({ jobs, initialQuery = '' }: { jobs: Job[]; initialQue
                           on a cell in an auto-layout table is only a hint, so
                           the table widened to fit the longest title and the
                           `truncate` classes below could never engage. */}
-                      <span className="min-w-0 lg:max-w-[28rem]">
+                      <span className="min-w-0 lg:max-w-md">
                         <span className="group-hover:text-primary block truncate font-medium transition-colors">
                           {job.title}
                         </span>
@@ -240,20 +240,33 @@ export function JobsTable({ jobs, initialQuery = '' }: { jobs: Job[]; initialQue
                     </Link>
                   </TableCell>
                   <TableCell className="max-lg:col-start-1 max-lg:row-start-2 max-lg:justify-self-start max-lg:p-0">
+                    {/* In card mode the column headers are gone — and `display:
+                        grid` drops the table semantics that would have
+                        associated them anyway — so "Discovered" would be
+                        announced with nothing to say what it describes. These
+                        carry the label only while the header is absent. */}
+                    <span className="sr-only lg:hidden">Status: </span>
                     <StatusPill status={job.status} />
                   </TableCell>
                   <TableCell className="max-lg:col-start-2 max-lg:row-start-1 max-lg:p-0">
                     <div className="flex justify-center">
+                      {/* FitScoreRing already names itself ("Fit score 81 of
+                          100" / "Not scored yet"), so it needs no prefix. */}
                       <FitScoreRing score={job.fitScore} size={38} strokeWidth={4} />
                     </div>
                   </TableCell>
                   <TableCell className="max-lg:col-start-2 max-lg:row-start-2 max-lg:justify-self-end max-lg:self-center max-lg:p-0">
                     <span className="flex items-center gap-1.5 text-sm capitalize">
                       <span className={cn('size-2 rounded-full', priorityTone[job.priority])} />
+                      <span className="sr-only lg:hidden">Priority: </span>
                       {job.priority}
                     </span>
                   </TableCell>
-                  <TableCell className="text-muted-foreground hidden max-w-[16rem] truncate text-sm md:table-cell">
+                  {/* lg, matching its header. At md–lg the row is a grid, so a
+                      cell that reappeared at `md` became an auto-placed third
+                      row with its header still hidden — an unlabelled field in
+                      every tablet-sized card. */}
+                  <TableCell className="text-muted-foreground hidden max-w-[16rem] truncate text-sm lg:table-cell">
                     {job.nextAction || formatDate(job.nextActionDue ?? job.discoveredAt)}
                   </TableCell>
                 </TableRow>


### PR DESCRIPTION
## The problem

The jobs table measured **1783px at a 375px viewport** — the entire list was a horizontal scroll on a phone.

The cause isn't the column count, it's `TableCell`'s `whitespace-nowrap`. An auto-layout table sizes to its content, so the `truncate` classes already on the title, company and match list **could never engage** — the table just grew to fit.

## The fix

Below `lg`, each row becomes a card. **Same markup, not a second tree** — a duplicate card list would double the DOM and make every `getByText` in the suite ambiguous. The row switches to a two-column grid and each cell is placed explicitly.

| | before | after |
|---|---|---|
| Table width @375px | 1783px | **343px** |
| Page horizontal scroll | yes | **none at any width** |

## Three things that took a second pass

1. **flex-wrap + `order-*` didn't work.** With no forced line breaks the cells shared one line and crushed the title to `Senior …`. Explicit grid placement fixes it — the fit ring sits beside the title rather than competing with it.
2. **The last card lost its outline.** `TableBody` sets `[&_tr:last-child]:border-0`, which wins a specificity tie against `max-lg:border`. Switched the card frame to `ring`, a different property entirely, so there's nothing to tie with.
3. **`md:max-w-[26rem]` on the `<td>` was a no-op.** `max-width` on a cell in an auto-layout table is only a hint — measured 577px against a 416px bound. Moved to the inner span, where truncation now actually engages (771px of title bound to 448px).

## Why `lg` and not `md`

The documented target was `md`, but at exactly 768px the table still measured **996px** and scrolled inside its container. The breakpoint should be the width at which the table stops overflowing, so it's `lg`.

*Caveat worth stating:* on the real `/jobs` page the sidebar takes ~256px, so at 1024–1279px the table can still scroll inside its own container with unusually long titles. The page itself never scrolls, which is what `overflow-x-auto` is for. Tightening that further would mean tuning `max-w` bounds against a synthetic fixture, so I left it.

## Verification

Measured in a real browser at **320 / 375 / 768 / 1023 / 1024 / 1280px**, including a deliberately pathological 110-character title:

- cards below `lg`, table at and above it
- `document.scrollWidth === window.innerWidth` at every width
- both cards carry the ring outline (the `[&_tr:last-child]` regression)
- desktop unchanged: header visible, `table-row` display, next-action column present, no ring

The added unit test guards the *mechanism* (grid + ring + `whitespace-normal`), not the geometry — jsdom has no layout engine, so the widths above were verified in Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)