### PR TITLE
fix(jobs): drop the header search on /jobs, where the list has its own

### DIFF
--- a/apps/web/src/components/app-header.test.tsx
+++ b/apps/web/src/components/app-header.test.tsx
@@ -44,10 +44,21 @@ it('does not navigate when the query is empty/whitespace', async () => {
   expect(push).not.toHaveBeenCalled();
 });
 
-it('pre-fills the input from ?q= when already on /jobs', () => {
+// The jobs list renders its own live-filtering search with the same icon and
+// the same "Search jobs" label. Two identically-named searchboxes on one page
+// is a confusing duplicate and an ambiguous accessible name, so the header's
+// shortcut yields to the in-page control.
+it('hides its search on /jobs, where the list has its own', () => {
   pathname = '/jobs';
   search = 'q=backend';
   render(<AppHeader />);
 
-  expect(screen.getByRole('searchbox', { name: /search/i })).toHaveValue('backend');
+  expect(screen.queryByRole('searchbox', { name: /search/i })).not.toBeInTheDocument();
+});
+
+it('still shows its search on other pages', () => {
+  pathname = '/outreach';
+  render(<AppHeader />);
+
+  expect(screen.getByRole('searchbox', { name: /search/i })).toBeInTheDocument();
 });

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -32,11 +32,19 @@ export function AppHeader() {
   const searchParams = useSearchParams();
   const title = deriveTitle(pathname);
 
+  // This box is a shortcut TO the jobs list from elsewhere. On /jobs itself the
+  // list already carries its own search — sitting directly below this one, with
+  // the same icon and the same "Search jobs" label, but filtering live instead
+  // of requiring Enter and a navigation. Two identically-named searchboxes on
+  // one page is both a confusing duplicate and an ambiguous accessible name, so
+  // the redundant (and weaker) one steps aside.
+  const isJobsList = pathname === '/jobs';
+
   // Keep the box in sync with the active jobs query so it reflects deep links
   // and reads back what the user is currently filtering by. Adjusting state
   // during render (vs. an effect) is the React-recommended way to reset on a
   // changing input. https://react.dev/learn/you-might-not-need-an-effect
-  const activeQuery = pathname === '/jobs' ? (searchParams.get('q') ?? '') : '';
+  const activeQuery = isJobsList ? (searchParams.get('q') ?? '') : '';
   const [query, setQuery] = useState(activeQuery);
   const [syncedQuery, setSyncedQuery] = useState(activeQuery);
   if (activeQuery !== syncedQuery) {
@@ -59,19 +67,21 @@ export function AppHeader() {
       <p className="font-heading truncate text-base font-semibold sm:text-lg">{title}</p>
 
       <div className="ml-auto flex items-center gap-1.5 sm:gap-2">
-        <form onSubmit={handleSubmit} role="search" className="relative hidden sm:block">
-          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
-          <Input
-            type="search"
-            name="q"
-            enterKeyHint="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search jobs…"
-            aria-label="Search jobs"
-            className="bg-card w-44 pl-8 lg:w-64"
-          />
-        </form>
+        {isJobsList ? null : (
+          <form onSubmit={handleSubmit} role="search" className="relative hidden sm:block">
+            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+            <Input
+              type="search"
+              name="q"
+              enterKeyHint="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search jobs…"
+              aria-label="Search jobs"
+              className="bg-card w-44 pl-8 lg:w-64"
+            />
+          </form>
+        )}
         <ModeToggle />
         <UserButton />
       </div>


### PR DESCRIPTION
## The problem

`/jobs` rendered **two searchboxes about 40px apart, both labelled "Search jobs"**, both with the same magnifier icon:

| | header | jobs list |
|---|---|---|
| Behaviour | type, press Enter, page navigation to `/jobs?q=…` | filters live as you type |
| Context | floats top-right, next to theme + avatar | sits with the status / priority / recency filters it belongs with |

Beyond looking like a bug, it's an **ambiguous accessible name** — two elements sharing a role and an accessible name on the same page, so "the Search jobs box" stops identifying anything for a screen-reader or keyboard user.

## The fix

The header box exists to jump *to* the jobs list from elsewhere. On the jobs list itself it has no job to do, so it steps aside there.

Nothing is lost: arriving via the header search still lands on `/jobs?q=…`, and `JobsTable` seeds its own box from `initialQuery` — the query was already going there.

## Tests

Replaced the "pre-fills from ?q= when already on /jobs" test (it asserted the behaviour being removed) with the two that now matter:

- hides its search on `/jobs`
- still shows it on other pages

4 passing, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)