### PR TITLE
feat(auth): brand the sign-in/sign-up pages and title the auth routes

### DIFF
--- a/apps/web/src/app/onboarding/layout.tsx
+++ b/apps/web/src/app/onboarding/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+// page.tsx is a client component and so cannot export metadata; this layout
+// exists only to give the route a title. Without it the tab reads
+// "JobOps Copilot — AI Job Search Platform", the same as every other page.
+export const metadata: Metadata = {
+  title: 'Set up your workspace',
+  description: 'Add your resume and target roles so JobOps Copilot can score fit against real experience.',
+};
+
+export default function OnboardingLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,9 +1,19 @@
-import { SignIn } from "@clerk/nextjs";
+import { SignIn } from '@clerk/nextjs';
+import type { Metadata } from 'next';
+import { AuthShell } from '@/components/auth-shell';
+
+// Without this the tab reads "JobOps Copilot — AI Job Search Platform", exactly
+// like every other page, so a bookmark or a row of open tabs gives no clue
+// which one is the sign-in. The root layout's template appends the product.
+export const metadata: Metadata = {
+  title: 'Sign in',
+  description: 'Sign in to your JobOps Copilot workspace.',
+};
 
 export default function SignInPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <AuthShell>
       <SignIn />
-    </div>
+    </AuthShell>
   );
 }

--- a/apps/web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,9 +1,16 @@
-import { SignUp } from "@clerk/nextjs";
+import { SignUp } from '@clerk/nextjs';
+import type { Metadata } from 'next';
+import { AuthShell } from '@/components/auth-shell';
+
+export const metadata: Metadata = {
+  title: 'Create your account',
+  description: 'Create a JobOps Copilot workspace and start tracking roles with AI.',
+};
 
 export default function SignUpPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <AuthShell>
       <SignUp />
-    </div>
+    </AuthShell>
   );
 }

--- a/apps/web/src/components/auth-shell.tsx
+++ b/apps/web/src/components/auth-shell.tsx
@@ -1,0 +1,45 @@
+import { Sparkles } from 'lucide-react';
+import Link from 'next/link';
+
+/**
+ * Frame for the sign-in / sign-up pages.
+ *
+ * These were a bare Clerk widget centred on an empty page: no wordmark, no
+ * product name, no way back to the marketing site. That reads as a generic
+ * hosted login rather than part of this product — and it is the first screen a
+ * visitor sees after clicking "Get started".
+ *
+ * Reuses the sidebar's brand lockup verbatim (same mark, same wordmark, same
+ * "AI Operations" line) so the app doesn't introduce a second identity at its
+ * own front door.
+ *
+ * Deliberately contributes no heading of its own. Clerk's card already renders
+ * one ("Sign in to JobOps Copilot"), and suppressing it would mean betting on
+ * an internal `appearance.elements` key — a duplicate <h1> is a worse outcome
+ * than letting Clerk own the title.
+ */
+export function AuthShell({ children }: { children: React.ReactNode }) {
+  return (
+    // `min-h-dvh`, not `min-h-screen`: on mobile 100vh is the viewport with
+    // browser chrome hidden, so a centred layout sits partly under the URL bar.
+    <div className="flex min-h-dvh flex-col items-center justify-center gap-8 px-4 py-10">
+      <Link
+        href="/"
+        aria-label="JobOps Copilot home"
+        className="focus-visible:ring-ring rounded-lg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      >
+        <span className="flex items-center gap-2.5">
+          <span className="bg-primary text-primary-foreground flex size-9 shrink-0 items-center justify-center rounded-lg shadow-sm">
+            <Sparkles className="size-4.5" />
+          </span>
+          <span className="grid text-left leading-tight">
+            <span className="font-heading text-base font-bold">JobOps Copilot</span>
+            <span className="text-muted-foreground text-xs">AI Operations</span>
+          </span>
+        </span>
+      </Link>
+
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## The problem

`/sign-in` and `/sign-up` were a bare Clerk widget centred on an empty page:

```tsx
<div className="flex min-h-screen items-center justify-center">
  <SignIn />
</div>
```

No wordmark, no product name, no way back to the marketing site. This is the **first screen a visitor sees after clicking "Get started"**, and it read as a generic hosted login rather than part of this product.

All three auth-adjacent routes also had no title of their own, so the tab read `JobOps Copilot — AI Job Search Platform` exactly like every other page — a row of open tabs or a bookmark gave no clue which was the sign-in.

## What changed

- **New `AuthShell`** frames both pages with the sidebar's brand lockup, reused verbatim (same mark, same wordmark, same "AI Operations" line) so the app doesn't introduce a *second* identity at its own front door. The lockup links home.
- **`min-h-dvh` instead of `min-h-screen`** — `100vh` is the viewport with mobile browser chrome hidden, so the centred card sat partly under the URL bar.
- **Titles**: `Sign in`, `Create your account`, `Set up your workspace`. The root layout's `%s · JobOps Copilot` template appends the product.
- `/onboarding` is a client component and so can't export `metadata`; it gets a layout that exists only to carry the title. It was already branded.

## One deliberate omission

`AuthShell` contributes **no heading of its own**. Clerk's card already renders one, and suppressing it would mean betting on an internal `appearance.elements` key. Per the Clerk docs, `elements` is additive className-based styling, so a wrong key fails silently — and a duplicate `<h1>` is a worse outcome than letting Clerk own the title.

## Verification

`tsc --noEmit` clean, lint clean, 101 web tests pass, production build succeeds with all three routes present.

Adding the onboarding layout initially broke `tsc` against Next's stale generated route types — regenerated via a full build, clean after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)