### PR TITLE
feat(assistant): run on a job already in the pipeline

### DIFF
--- a/apps/web/src/app/(app)/assistant/page.tsx
+++ b/apps/web/src/app/(app)/assistant/page.tsx
@@ -1,10 +1,27 @@
 import type { Metadata } from 'next';
-import { AssistantPanel } from '@/components/assistant-panel';
+import { AssistantPanel, type AssistantJobOption } from '@/components/assistant-panel';
 import { SectionCard } from '@/components/section-card';
+import { loadJobs } from '@/lib/job-data';
+
+export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = { title: 'Assistant' };
 
-export default function AssistantPage() {
+export default async function AssistantPage() {
+  const { jobs } = await loadJobs();
+
+  // Only jobs that carry a description can be run: the assistant's first step
+  // parses that text, so offering one without it would fail immediately.
+  // Sent as {id, label, descriptionText} rather than whole Job objects to keep
+  // the client payload to what the picker actually needs.
+  const jobOptions: AssistantJobOption[] = jobs
+    .filter((job) => job.descriptionText.trim().length > 0)
+    .map((job) => ({
+      id: job.id,
+      label: `${job.company} · ${job.title}`,
+      descriptionText: job.descriptionText,
+    }));
+
   return (
     <div className="mx-auto w-full max-w-4xl space-y-6">
       <div className="space-y-1">
@@ -16,9 +33,9 @@ export default function AssistantPage() {
       </div>
       <SectionCard
         title="Run the assistant"
-        description="Paste a job description to start a streamed, human-in-the-loop run. It scores against the resume on file."
+        description="Pick a job from your pipeline or paste a description to start a streamed, human-in-the-loop run. It scores against the resume on file."
       >
-        <AssistantPanel />
+        <AssistantPanel jobs={jobOptions} />
       </SectionCard>
     </div>
   );

--- a/apps/web/src/app/(app)/assistant/page.tsx
+++ b/apps/web/src/app/(app)/assistant/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { AssistantPanel, type AssistantJobOption } from '@/components/assistant-panel';
 import { SectionCard } from '@/components/section-card';
+import { Card } from '@/components/ui/card';
 import { loadJobs } from '@/lib/job-data';
 
 export const dynamic = 'force-dynamic';
@@ -8,19 +9,27 @@ export const dynamic = 'force-dynamic';
 export const metadata: Metadata = { title: 'Assistant' };
 
 export default async function AssistantPage() {
-  const { jobs } = await loadJobs();
+  const { jobs, source } = await loadJobs();
+
+  // `loadJobs` falls back to the local seed dataset when the API is
+  // unreachable, so `source` has to be checked before any of this is offered
+  // as "your pipeline" — otherwise an outage would put fabricated sample roles
+  // in the picker and the user could run a real assistant pass against one.
+  const pipelineReachable = source === 'api';
 
   // Only jobs that carry a description can be run: the assistant's first step
   // parses that text, so offering one without it would fail immediately.
   // Sent as {id, label, descriptionText} rather than whole Job objects to keep
   // the client payload to what the picker actually needs.
-  const jobOptions: AssistantJobOption[] = jobs
-    .filter((job) => job.descriptionText.trim().length > 0)
-    .map((job) => ({
-      id: job.id,
-      label: `${job.company} · ${job.title}`,
-      descriptionText: job.descriptionText,
-    }));
+  const jobOptions: AssistantJobOption[] = pipelineReachable
+    ? jobs
+        .filter((job) => job.descriptionText.trim().length > 0)
+        .map((job) => ({
+          id: job.id,
+          label: `${job.company} · ${job.title}`,
+          descriptionText: job.descriptionText,
+        }))
+    : [];
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-6">
@@ -31,6 +40,21 @@ export default async function AssistantPage() {
           only after you approve. Each step streams live; nothing is sent automatically.
         </p>
       </div>
+      {/* Say why the picker is missing, rather than letting it silently vanish
+          for someone who knows they have jobs saved. Mirrors the "Seed data
+          shown" notice on /jobs. */}
+      {pipelineReachable ? null : (
+        <Card className="gap-1 border-amber-500/30 bg-amber-500/5 p-4">
+          <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
+            Your pipeline is unavailable
+          </p>
+          <p className="text-muted-foreground text-sm">
+            The API is not reachable, so saved jobs can&apos;t be listed here. You can still paste a
+            description below to run the assistant.
+          </p>
+        </Card>
+      )}
+
       <SectionCard
         title="Run the assistant"
         description="Pick a job from your pipeline or paste a description to start a streamed, human-in-the-loop run. It scores against the resume on file."

--- a/apps/web/src/components/assistant-panel.test.tsx
+++ b/apps/web/src/components/assistant-panel.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() } }));
 
+import { chooseOption } from '@/test/select';
 import { AssistantPanel } from './assistant-panel';
 
 /** Minimal fetch Response stand-in that streams pre-baked SSE frames. */
@@ -73,4 +74,47 @@ it('announces the drafted outreach in a live region', async () => {
   const draft = await screen.findByText('Drafted hello');
   // The draft output must sit inside a live region so a screen reader hears it arrive.
   expect(draft.closest('[aria-live]')).not.toBeNull();
+});
+
+// The pipeline already holds these descriptions. Before this, running the
+// assistant on a saved job meant opening it, selecting the description and
+// pasting it back — for every job.
+const pipelineJobs = [
+  { id: 'job-1', label: 'Northwind Labs · AI Automation Engineer', descriptionText: 'Northwind JD body' },
+  { id: 'job-2', label: 'BeaconOps · Solutions Consultant', descriptionText: 'BeaconOps JD body' },
+];
+
+it('fills the description from a job chosen out of the pipeline', async () => {
+  const user = userEvent.setup();
+  render(<AssistantPanel jobs={pipelineJobs} />);
+
+  const description = screen.getByPlaceholderText(/paste a job description/i);
+  expect(description).toHaveValue('');
+
+  await chooseOption(user, /use a job from your pipeline/i, /AI Automation Engineer/i);
+
+  expect(description).toHaveValue('Northwind JD body');
+});
+
+it('hides the picker when no saved job carries a description', () => {
+  render(<AssistantPanel jobs={[]} />);
+
+  expect(
+    screen.queryByRole('combobox', { name: /use a job from your pipeline/i }),
+  ).not.toBeInTheDocument();
+});
+
+it('releases the chosen job once the description is edited by hand', async () => {
+  const user = userEvent.setup();
+  render(<AssistantPanel jobs={pipelineJobs} />);
+
+  await chooseOption(user, /use a job from your pipeline/i, /AI Automation Engineer/i);
+  const trigger = screen.getByRole('combobox', { name: /use a job from your pipeline/i });
+  expect(trigger).toHaveTextContent(/AI Automation Engineer/i);
+
+  // Typing makes the text the user's own, so the trigger must stop claiming a
+  // job whose description is no longer what is in the box.
+  await user.type(screen.getByPlaceholderText(/paste a job description/i), ' plus my notes');
+
+  expect(trigger).not.toHaveTextContent(/AI Automation Engineer/i);
 });

--- a/apps/web/src/components/assistant-panel.tsx
+++ b/apps/web/src/components/assistant-panel.tsx
@@ -5,7 +5,22 @@ import { Check, Loader2, Sparkles, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { OptionSelect } from '@/components/ui/option-select';
 import { Textarea } from '@/components/ui/textarea';
+
+/**
+ * A job from the pipeline that the assistant can be pointed at. Only jobs that
+ * actually carry a description qualify — the run parses that text, so offering
+ * one without it would just fail at the first step.
+ */
+export type AssistantJobOption = {
+  id: string;
+  label: string;
+  descriptionText: string;
+};
+
+/** Sentinel for "none chosen", so the trigger shows the placeholder. */
+const NO_JOB = '';
 
 interface Step {
   node: string;
@@ -27,9 +42,13 @@ const NODE_LABELS: Record<string, string> = {
   below_fit_bar: 'Below the fit bar — stopping',
 };
 
-export function AssistantPanel() {
+export function AssistantPanel({ jobs = [] }: { jobs?: AssistantJobOption[] }) {
   const [description, setDescription] = useState('');
   const [resume, setResume] = useState('');
+  // Which pipeline job filled the box, or NO_JOB when the text is the user's
+  // own. Typing clears it, so the trigger never claims a job the text no
+  // longer matches.
+  const [sourceJobId, setSourceJobId] = useState<string>(NO_JOB);
   const [steps, setSteps] = useState<Step[]>([]);
   const [threadId, setThreadId] = useState<string | null>(null);
   const [awaiting, setAwaiting] = useState(false);
@@ -125,8 +144,36 @@ export function AssistantPanel() {
     }
   }
 
+  function chooseJob(id: string) {
+    setSourceJobId(id);
+    if (id === NO_JOB) return;
+    const job = jobs.find((entry) => entry.id === id);
+    if (job) setDescription(job.descriptionText);
+  }
+
   return (
     <div className="space-y-4">
+      {/* The pipeline already holds these descriptions. Without this the only
+          way to run the assistant on a job you have already saved was to open
+          it, select the description and paste it back — for every job. */}
+      {jobs.length > 0 ? (
+        <div className="space-y-1.5">
+          <Label htmlFor="assistant-job">Use a job from your pipeline</Label>
+          <OptionSelect
+            id="assistant-job"
+            aria-label="Use a job from your pipeline"
+            value={sourceJobId}
+            onValueChange={chooseJob}
+            placeholder="Choose a saved job…"
+            options={jobs.map((job) => ({ value: job.id, label: job.label }))}
+            className="sm:max-w-md"
+          />
+          <p className="text-muted-foreground text-xs">
+            Fills the description below. You can edit it, or ignore this and paste your own.
+          </p>
+        </div>
+      ) : null}
+
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="space-y-1.5">
           <Label htmlFor="assistant-jd">Job description</Label>
@@ -135,7 +182,11 @@ export function AssistantPanel() {
             className="min-h-32"
             placeholder="Paste a job description…"
             value={description}
-            onChange={(e) => setDescription(e.target.value)}
+            onChange={(e) => {
+              setDescription(e.target.value);
+              // The text is now the user's, not the chosen job's.
+              setSourceJobId(NO_JOB);
+            }}
           />
         </div>
         <div className="space-y-1.5">


### PR DESCRIPTION
## The gap

`/assistant` only accepted a **pasted** job description. To run it against a job the app had already stored, you had to: open the job → select its description → copy → navigate back → paste. For every job. The test account has 60 of them.

The descriptions were already in the database the whole time.

## What changed

The page loads the pipeline server-side and offers a picker. Choosing a job fills the description box, which stays fully editable.

Four decisions worth stating:

- **Only jobs that carry a description are offered.** The run's first step parses that text, so offering a job without one would just fail at step one.
- **Sent as `{id, label, descriptionText}`, not whole `Job` objects** — the client payload is what the picker needs and nothing more.
- **Typing releases the chosen job.** Otherwise the trigger would keep naming a job whose description is no longer what's in the box.
- **The picker is absent entirely when nothing qualifies**, so the original paste-only flow is untouched for a new account.

## Tests

Three new, all driving the control the way a user does (open the combobox, click the option by label):

- fills the description from a chosen job
- hides the picker when no saved job carries a description
- releases the chosen job once the description is edited by hand

105 web tests pass, `tsc --noEmit` clean, lint clean, production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)