### PR TITLE
feat(api): agent_configs table + hot-swappable per-agent model config API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,11 @@ NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:4000
 API_SHARED_SECRET=
 NEXT_PUBLIC_API_SHARED_SECRET=
 
+# Operators allowed to change global, non-tenant-scoped settings — currently the per-agent
+# model config (PUT /api/agents/:agentId/config). Comma-separated Clerk user ids. Leave empty
+# for local development; any real deploy that leaves it empty denies every such write.
+ADMIN_USER_IDS=
+
 # JobOps MCP server (services/mcp, Phase 3 · Workstream L). Bridges the REST API.
 # MCP_SERVER_API_KEY must equal API_SHARED_SECRET so the API's service-auth resolves the user.
 MCP_SERVER_API_BASE_URL=http://127.0.0.1:4000

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,6 +11,7 @@ import { assistantStreamRouter } from '@/routes/assistant';
 import { assistantChatRouter } from '@/routes/assistant-chat';
 import { demoRouter } from '@/routes/demo';
 import { healthRouter } from '@/routes/health';
+import { agentConfigRouter } from '@/routes/agent-config';
 import { agentOutputsRouter } from '@/routes/agent-outputs';
 import { jobExtractRouter } from '@/routes/job-extract';
 import { jobsRouter } from '@/routes/jobs';
@@ -91,6 +92,9 @@ export function createApp() {
   // Stricter per-user limit on the expensive AI + discovery routes; the AI routes
   // additionally enforce the per-user daily spend ceiling (discovery has no LLM cost).
   app.use('/api/ai', strictLimiter, enforceDailyBudget, aiRouter);
+  // Per-agent model configuration (read + hot-swap). Later parity tickets mount the agent
+  // stream/resume proxy on the same prefix under distinct sub-paths.
+  app.use('/api/agents', agentConfigRouter);
   app.use('/api/profile', profileRouter);
   app.use('/api/demo', demoRouter);
   app.use('/api/outreach', outreachRouter);

--- a/apps/api/src/data/agent-config-store.pgtest.ts
+++ b/apps/api/src/data/agent-config-store.pgtest.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getPool } from '@/lib/postgres';
+import {
+  activateAgentConfigVersion,
+  insertAgentConfigVersion,
+  listAgentConfigs,
+} from '@/data/agent-config-store';
+
+// Real-Postgres only (named *.pgtest.ts so `npm test` skips it; run via `npm run test:pg`).
+// The one-active-row invariant lives in a partial unique index, so only a live database can
+// prove it: a fake query fn will happily accept a swap that Postgres would reject.
+const DB = process.env.DATABASE_URL?.trim();
+
+const AGENT = 'feed-curator' as const;
+
+test(
+  'agent_configs: seeded tiering, version insert/repoint, and the one-active invariant',
+  { skip: DB ? false : 'DATABASE_URL not set — Postgres integration test skipped' },
+  async (t) => {
+    const pool = getPool();
+    assert.ok(pool, 'expected a live pool');
+
+    async function activeCount(agentId: string): Promise<number> {
+      const { rows } = await pool!.query<{ count: string }>(
+        'select count(*)::text as count from agent_configs where agent_id = $1 and active',
+        [agentId],
+      );
+      return Number(rows[0]!.count);
+    }
+
+    try {
+      await t.test('the migration seeds exactly one active config per agent', async () => {
+        const { rows } = await pool.query<{ agent_id: string; actives: string }>(
+          `select agent_id, count(*) filter (where active)::text as actives
+             from agent_configs group by agent_id order by agent_id`,
+        );
+        assert.equal(rows.length, 4, 'expected the four specialist agents to be seeded');
+        for (const row of rows) {
+          assert.equal(row.actives, '1', `${row.agent_id} must have exactly one active config`);
+        }
+      });
+
+      await t.test('inserting a version activates it and deactivates the previous one', async () => {
+        const version = await insertAgentConfigVersion(AGENT, 'openai:gpt-5.6-luna', { temperature: 0.1 }, {});
+        assert.ok(version >= 2, 'expected a version above the seeded v1');
+        assert.equal(await activeCount(AGENT), 1);
+
+        const configs = await listAgentConfigs(AGENT);
+        assert.equal(configs[0]?.version, version, 'newest version comes first');
+        assert.equal(configs[0]?.active, true);
+        assert.equal(configs[0]?.model, 'openai:gpt-5.6-luna');
+        assert.deepEqual(configs[0]?.params, { temperature: 0.1 });
+        assert.equal(configs.find((config) => config.version === 1)?.active, false);
+      });
+
+      await t.test('repointing active to an older version rolls the model back', async () => {
+        assert.equal(await activateAgentConfigVersion(AGENT, 1), true);
+        assert.equal(await activeCount(AGENT), 1);
+        const configs = await listAgentConfigs(AGENT);
+        assert.equal(configs.find((config) => config.active)?.version, 1);
+      });
+
+      await t.test('repointing to a missing version changes nothing and reports false', async () => {
+        assert.equal(await activateAgentConfigVersion(AGENT, 9_999), false);
+        assert.equal(await activeCount(AGENT), 1, 'a failed repoint must not leave the agent unconfigured');
+        const configs = await listAgentConfigs(AGENT);
+        assert.equal(configs.find((config) => config.active)?.version, 1);
+      });
+    } finally {
+      // Restore the seeded state: drop the versions this test added, keep v1 active.
+      await pool.query('delete from agent_configs where agent_id = $1 and version > 1', [AGENT]);
+      await pool.query('update agent_configs set active = true where agent_id = $1 and version = 1', [AGENT]);
+    }
+  },
+);

--- a/apps/api/src/data/agent-config-store.pgtest.ts
+++ b/apps/api/src/data/agent-config-store.pgtest.ts
@@ -61,7 +61,20 @@ test(
         assert.equal(configs.find((config) => config.active)?.version, 1);
       });
 
+      await t.test('overlapping swaps for one agent serialize instead of colliding', async () => {
+        // Without the per-agent advisory lock both transactions deactivate the row they saw
+        // and then both insert an active row, and the partial unique index rejects the loser.
+        const versions = await Promise.all([
+          insertAgentConfigVersion(AGENT, 'anthropic:claude-haiku-4-5', {}, {}),
+          insertAgentConfigVersion(AGENT, 'openai:gpt-5.6-luna', {}, {}),
+          insertAgentConfigVersion(AGENT, 'anthropic:claude-sonnet-4-6', {}, {}),
+        ]);
+        assert.equal(new Set(versions).size, 3, 'each concurrent insert takes its own version');
+        assert.equal(await activeCount(AGENT), 1, 'exactly one config stays active');
+      });
+
       await t.test('repointing to a missing version changes nothing and reports false', async () => {
+        await activateAgentConfigVersion(AGENT, 1);
         assert.equal(await activateAgentConfigVersion(AGENT, 9_999), false);
         assert.equal(await activeCount(AGENT), 1, 'a failed repoint must not leave the agent unconfigured');
         const configs = await listAgentConfigs(AGENT);

--- a/apps/api/src/data/agent-config-store.ts
+++ b/apps/api/src/data/agent-config-store.ts
@@ -10,6 +10,7 @@
  * gate on `hasPostgresConnection()` and return 503 when the database is absent.
  */
 
+import type { PoolClient } from 'pg';
 import { getPool } from '@/lib/postgres';
 
 export const AGENT_IDS = ['feed-curator', 'resume-tailor', 'apply-copilot', 'connection-scout'] as const;
@@ -61,6 +62,18 @@ function mapRow(row: AgentConfigRow): AgentConfigRecord {
   };
 }
 
+/**
+ * Serializes config swaps for one agent within the calling transaction.
+ *
+ * Without it two overlapping writes can each deactivate the active row they saw in their own
+ * snapshot and then both insert an active row, and the partial unique index rejects the loser
+ * with a 500. A transaction-scoped advisory lock makes the read-modify-write atomic per agent;
+ * it is released automatically on commit or rollback, and different agents never block.
+ */
+async function lockAgent(client: PoolClient, agentId: AgentId): Promise<void> {
+  await client.query('select pg_advisory_xact_lock(hashtext($1))', [`agent_configs:${agentId}`]);
+}
+
 /** Every stored version for an agent, newest first. */
 export async function listAgentConfigs(agentId: AgentId): Promise<AgentConfigRecord[]> {
   const { rows } = await poolOrThrow().query<AgentConfigRow>(
@@ -88,6 +101,7 @@ export async function activateAgentConfigVersion(agentId: AgentId, version: numb
   const client = await poolOrThrow().connect();
   try {
     await client.query('begin');
+    await lockAgent(client, agentId);
     await client.query('update agent_configs set active = false where agent_id = $1 and active', [agentId]);
     const { rowCount } = await client.query(
       'update agent_configs set active = true where agent_id = $1 and version = $2',
@@ -117,6 +131,7 @@ export async function insertAgentConfigVersion(
   const client = await poolOrThrow().connect();
   try {
     await client.query('begin');
+    await lockAgent(client, agentId);
     await client.query('update agent_configs set active = false where agent_id = $1 and active', [agentId]);
     const { rows } = await client.query<{ version: number }>(
       `insert into agent_configs (agent_id, version, model, params, prompt_overrides, active)

--- a/apps/api/src/data/agent-config-store.ts
+++ b/apps/api/src/data/agent-config-store.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-agent, versioned, hot-swappable model configuration (Jobright-parity Epic 1, #251).
+ *
+ * Every specialist agent resolves its model from `agent_configs` at run time, so no model
+ * id is hard-coded anywhere. Rows are immutable versions; exactly one row per agent is
+ * `active` (enforced by a partial unique index). Swapping a model = insert the next version
+ * and activate it; rollback = re-activate an older version.
+ *
+ * Postgres-only: there is no JSON-file fallback (unlike the job/agent-output stores). Callers
+ * gate on `hasPostgresConnection()` and return 503 when the database is absent.
+ */
+
+import { getPool } from '@/lib/postgres';
+
+export const AGENT_IDS = ['feed-curator', 'resume-tailor', 'apply-copilot', 'connection-scout'] as const;
+
+export type AgentId = (typeof AGENT_IDS)[number];
+
+export function isAgentId(value: string): value is AgentId {
+  return (AGENT_IDS as readonly string[]).includes(value);
+}
+
+export interface AgentConfigRecord {
+  agentId: AgentId;
+  version: number;
+  /** A LangChain `init_chat_model` string: `"provider:model-id"`. */
+  model: string;
+  params: Record<string, unknown>;
+  promptOverrides: Record<string, unknown>;
+  active: boolean;
+  createdAt: string;
+}
+
+type AgentConfigRow = {
+  agent_id: string;
+  version: number;
+  model: string;
+  params: Record<string, unknown>;
+  prompt_overrides: Record<string, unknown>;
+  active: boolean;
+  created_at: string | Date;
+};
+
+function poolOrThrow() {
+  const pool = getPool();
+  if (!pool) {
+    throw new Error('Postgres is not configured. Set DATABASE_URL to enable agent configs.');
+  }
+  return pool;
+}
+
+function mapRow(row: AgentConfigRow): AgentConfigRecord {
+  return {
+    agentId: row.agent_id as AgentId,
+    version: row.version,
+    model: row.model,
+    params: row.params ?? {},
+    promptOverrides: row.prompt_overrides ?? {},
+    active: row.active,
+    createdAt: new Date(row.created_at).toISOString(),
+  };
+}
+
+/** Every stored version for an agent, newest first. */
+export async function listAgentConfigs(agentId: AgentId): Promise<AgentConfigRecord[]> {
+  const { rows } = await poolOrThrow().query<AgentConfigRow>(
+    `select agent_id, version, model, params, prompt_overrides, active, created_at
+       from agent_configs
+      where agent_id = $1
+      order by version desc`,
+    [agentId],
+  );
+  return rows.map(mapRow);
+}
+
+/**
+ * Repoints `active` to an existing version. Returns false (leaving the table untouched) when
+ * that version does not exist.
+ *
+ * Deactivate and activate are two statements inside one transaction rather than the single
+ * `set active = (version = $n)` update: a partial unique index is checked per row as the
+ * update walks the table, so a single statement can transiently hold two active rows and
+ * fail with a duplicate-key error depending on row order. Splitting the statements makes the
+ * intermediate state (zero active rows) one the index permits, and the transaction keeps it
+ * invisible to everyone else.
+ */
+export async function activateAgentConfigVersion(agentId: AgentId, version: number): Promise<boolean> {
+  const client = await poolOrThrow().connect();
+  try {
+    await client.query('begin');
+    await client.query('update agent_configs set active = false where agent_id = $1 and active', [agentId]);
+    const { rowCount } = await client.query(
+      'update agent_configs set active = true where agent_id = $1 and version = $2',
+      [agentId, version],
+    );
+    if (!rowCount) {
+      await client.query('rollback');
+      return false;
+    }
+    await client.query('commit');
+    return true;
+  } catch (error) {
+    await client.query('rollback').catch(() => {});
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+/** Inserts the next version for an agent and makes it active. Returns the new version number. */
+export async function insertAgentConfigVersion(
+  agentId: AgentId,
+  model: string,
+  params: Record<string, unknown>,
+  promptOverrides: Record<string, unknown>,
+): Promise<number> {
+  const client = await poolOrThrow().connect();
+  try {
+    await client.query('begin');
+    await client.query('update agent_configs set active = false where agent_id = $1 and active', [agentId]);
+    const { rows } = await client.query<{ version: number }>(
+      `insert into agent_configs (agent_id, version, model, params, prompt_overrides, active)
+       select $1, coalesce(max(version), 0) + 1, $2, $3::jsonb, $4::jsonb, true
+         from agent_configs where agent_id = $1
+       returning version`,
+      [agentId, model, JSON.stringify(params), JSON.stringify(promptOverrides)],
+    );
+    await client.query('commit');
+    return rows[0]!.version;
+  } catch (error) {
+    await client.query('rollback').catch(() => {});
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/apps/api/src/lib/auth.test.ts
+++ b/apps/api/src/lib/auth.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import http from 'node:http';
 import test from 'node:test';
 import express from 'express';
-import { assertProductionAuthConfigured, attachUserId } from './auth';
+import { assertProductionAuthConfigured, attachUserId, isAdminUser } from './auth';
 
 function snapshotEnv(keys: string[]) {
   const snapshot = new Map<string, string | undefined>();
@@ -107,6 +107,46 @@ test('assertProductionAuthConfigured is a no-op in local development', () => {
   delete process.env.WEBSITE_SITE_NAME;
   try {
     assert.doesNotThrow(() => assertProductionAuthConfigured());
+  } finally {
+    restore();
+  }
+});
+
+const ADMIN_ENV = ['ADMIN_USER_IDS', 'CLERK_SECRET_KEY', 'NODE_ENV', 'WEBSITE_SITE_NAME', 'CONTAINER_APP_NAME'];
+
+test('an explicit ADMIN_USER_IDS allowlist decides who may administer', () => {
+  const restore = snapshotEnv(ADMIN_ENV);
+  process.env.ADMIN_USER_IDS = ' user_admin , user_second ';
+  try {
+    assert.equal(isAdminUser('user_admin'), true);
+    assert.equal(isAdminUser('user_second'), true);
+    assert.equal(isAdminUser('user_other'), false);
+  } finally {
+    restore();
+  }
+});
+
+test('with no allowlist, only a local dev runtime administers — a real deploy fails closed', () => {
+  const restore = snapshotEnv(ADMIN_ENV);
+  try {
+    delete process.env.ADMIN_USER_IDS;
+    delete process.env.CLERK_SECRET_KEY;
+    delete process.env.WEBSITE_SITE_NAME;
+    delete process.env.CONTAINER_APP_NAME;
+    process.env.NODE_ENV = 'development';
+    assert.equal(isAdminUser('user_local_dev'), true, 'local dev keeps working offline');
+
+    // A deploy that forgot ADMIN_USER_IDS must deny, not admit every signed-in user.
+    process.env.CLERK_SECRET_KEY = 'sk_test';
+    assert.equal(isAdminUser('user_local_dev'), false, 'Clerk configured means real users exist');
+
+    delete process.env.CLERK_SECRET_KEY;
+    process.env.NODE_ENV = 'production';
+    assert.equal(isAdminUser('user_local_dev'), false, 'production denies without an allowlist');
+
+    process.env.NODE_ENV = 'development';
+    process.env.CONTAINER_APP_NAME = 'jobops-api';
+    assert.equal(isAdminUser('user_local_dev'), false, 'an Azure runtime denies too');
   } finally {
     restore();
   }

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -88,6 +88,37 @@ export function assertProductionAuthConfigured(): void {
   }
 }
 
+/**
+ * Operator allowlist for global, non-tenant-scoped settings (e.g. `agent_configs`, which is
+ * keyed by agent id alone — one user's write changes every user's agents).
+ *
+ * `ADMIN_USER_IDS` is a comma-separated list of Clerk user ids. With no allowlist configured
+ * this fails closed: only a local dev runtime (no Clerk, not production) is treated as the
+ * operator, so a real deploy that forgets the variable denies every write rather than letting
+ * any signed-in user through. Read dynamically so tests and config reloads see changes.
+ */
+export function isAdminUser(userId: string): boolean {
+  const allowlist = (process.env.ADMIN_USER_IDS ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (allowlist.length > 0) {
+    return allowlist.includes(userId);
+  }
+  return !inProduction() && !process.env.CLERK_SECRET_KEY?.trim();
+}
+
+/** Returns the request user id when it belongs to an operator, else sends 401/403 and null. */
+export function requireAdmin(request: Request, response: Response): string | null {
+  const userId = requireUser(request, response);
+  if (!userId) return null;
+  if (!isAdminUser(userId)) {
+    response.status(403).json({ error: 'Administrator access required' });
+    return null;
+  }
+  return userId;
+}
+
 /** Returns the request user id, or sends 401 and returns null when absent. */
 export function requireUser(request: Request, response: Response): string | null {
   const userId = request.userId;

--- a/apps/api/src/routes/agent-config.test.ts
+++ b/apps/api/src/routes/agent-config.test.ts
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+import express from 'express';
+import { createAgentConfigRouter } from './agent-config';
+import type { AgentConfigDeps } from './agent-config';
+import type { AgentConfigRecord } from '@/data/agent-config-store';
+
+async function withServer(
+  deps: Partial<AgentConfigDeps>,
+  run: (baseUrl: string) => Promise<void>,
+) {
+  const app = express();
+  app.use(express.json());
+  app.use((request, _response, next) => {
+    const header = request.header('X-User-Id');
+    if (header) request.userId = header.trim();
+    next();
+  });
+  app.use(
+    '/api/agents',
+    createAgentConfigRouter({
+      hasDb: () => true,
+      listConfigs: async () => [],
+      activateVersion: async () => false,
+      insertVersion: async () => 1,
+      ...deps,
+    }),
+  );
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('no server address');
+  }
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+const authed = { headers: { 'X-User-Id': 'u1' } };
+
+function jsonPut(body: unknown) {
+  return {
+    method: 'PUT',
+    headers: { 'X-User-Id': 'u1', 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+const sampleConfigs: AgentConfigRecord[] = [
+  {
+    agentId: 'feed-curator',
+    version: 2,
+    model: 'openai:gpt-5.6-luna',
+    params: {},
+    promptOverrides: {},
+    active: true,
+    createdAt: '2026-08-15T00:00:00.000Z',
+  },
+  {
+    agentId: 'feed-curator',
+    version: 1,
+    model: 'anthropic:claude-haiku-4-5',
+    params: { temperature: 0.2 },
+    promptOverrides: {},
+    active: false,
+    createdAt: '2026-08-14T00:00:00.000Z',
+  },
+];
+
+test('GET /api/agents/:agentId/config requires a signed-in user', async () => {
+  await withServer({}, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/feed-curator/config`);
+    assert.equal(response.status, 401);
+  });
+});
+
+test('GET /api/agents/:agentId/config 404s an unknown agent id', async () => {
+  await withServer({}, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/nope/config`, authed);
+    assert.equal(response.status, 404);
+  });
+});
+
+test('GET /api/agents/:agentId/config 503s without a database', async () => {
+  await withServer({ hasDb: () => false }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/feed-curator/config`, authed);
+    assert.equal(response.status, 503);
+  });
+});
+
+test('GET /api/agents/:agentId/config returns the active config and every version', async () => {
+  await withServer({ listConfigs: async () => sampleConfigs }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/feed-curator/config`, authed);
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      active: AgentConfigRecord | null;
+      versions: AgentConfigRecord[];
+    };
+    assert.equal(body.active?.version, 2);
+    assert.equal(body.active?.model, 'openai:gpt-5.6-luna');
+    assert.equal(body.versions.length, 2);
+  });
+});
+
+test('GET /api/agents/:agentId/config reports a null active config when none is active', async () => {
+  await withServer(
+    { listConfigs: async () => sampleConfigs.map((config) => ({ ...config, active: false })) },
+    async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/agents/feed-curator/config`, authed);
+      assert.equal(response.status, 200);
+      const body = (await response.json()) as { active: AgentConfigRecord | null };
+      assert.equal(body.active, null);
+    },
+  );
+});
+
+test('PUT /api/agents/:agentId/config repoints active to an existing version', async () => {
+  const calls: Array<[string, number]> = [];
+  await withServer(
+    {
+      activateVersion: async (agentId, version) => {
+        calls.push([agentId, version]);
+        return true;
+      },
+    },
+    async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/agents/feed-curator/config`, jsonPut({ version: 1 }));
+      assert.equal(response.status, 200);
+      const body = (await response.json()) as { activeVersion: number };
+      assert.equal(body.activeVersion, 1);
+      assert.deepEqual(calls, [['feed-curator', 1]]);
+    },
+  );
+});
+
+test('PUT /api/agents/:agentId/config 404s repointing to a version that does not exist', async () => {
+  await withServer({ activateVersion: async () => false }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/feed-curator/config`, jsonPut({ version: 99 }));
+    assert.equal(response.status, 404);
+  });
+});
+
+test('PUT /api/agents/:agentId/config inserts and activates a new version from { model }', async () => {
+  const calls: unknown[] = [];
+  await withServer(
+    {
+      insertVersion: async (agentId, model, params, promptOverrides) => {
+        calls.push([agentId, model, params, promptOverrides]);
+        return 3;
+      },
+    },
+    async (baseUrl) => {
+      const response = await fetch(
+        `${baseUrl}/api/agents/resume-tailor/config`,
+        jsonPut({ model: 'openai:gpt-5.6-luna', params: { temperature: 0.1 } }),
+      );
+      assert.equal(response.status, 201);
+      const body = (await response.json()) as { activeVersion: number };
+      assert.equal(body.activeVersion, 3);
+      assert.deepEqual(calls, [['resume-tailor', 'openai:gpt-5.6-luna', { temperature: 0.1 }, {}]]);
+    },
+  );
+});
+
+test('PUT /api/agents/:agentId/config 400s a model without a provider prefix', async () => {
+  await withServer({}, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/resume-tailor/config`, jsonPut({ model: 'no-colon' }));
+    assert.equal(response.status, 400);
+  });
+});
+
+test('PUT /api/agents/:agentId/config 400s a body that is neither a version nor a model', async () => {
+  await withServer({}, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/resume-tailor/config`, jsonPut({ nonsense: true }));
+    assert.equal(response.status, 400);
+  });
+});
+
+test('PUT /api/agents/:agentId/config 400s a non-integer version', async () => {
+  await withServer({}, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/resume-tailor/config`, jsonPut({ version: 1.5 }));
+    assert.equal(response.status, 400);
+  });
+});
+
+test('PUT /api/agents/:agentId/config requires a signed-in user', async () => {
+  await withServer({}, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/feed-curator/config`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ version: 1 }),
+    });
+    assert.equal(response.status, 401);
+  });
+});
+
+test('PUT /api/agents/:agentId/config 503s without a database', async () => {
+  await withServer({ hasDb: () => false }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/feed-curator/config`, jsonPut({ version: 1 }));
+    assert.equal(response.status, 503);
+  });
+});

--- a/apps/api/src/routes/agent-config.test.ts
+++ b/apps/api/src/routes/agent-config.test.ts
@@ -174,6 +174,69 @@ test('PUT /api/agents/:agentId/config 400s a model without a provider prefix', a
   });
 });
 
+// A model string with an empty half satisfies `like '%:%'` but can never resolve through
+// `init_chat_model` — activating one would silently disable every run of that agent.
+for (const model of [':', 'anthropic:', ':claude-haiku-4-5', ' :model', 'provider: ']) {
+  test(`PUT /api/agents/:agentId/config 400s the unusable model string ${JSON.stringify(model)}`, async () => {
+    let inserted = false;
+    await withServer(
+      {
+        insertVersion: async () => {
+          inserted = true;
+          return 2;
+        },
+      },
+      async (baseUrl) => {
+        const response = await fetch(`${baseUrl}/api/agents/resume-tailor/config`, jsonPut({ model }));
+        assert.equal(response.status, 400);
+        assert.equal(inserted, false, 'an unusable model must never reach the store');
+      },
+    );
+  });
+}
+
+test('PUT /api/agents/:agentId/config 403s a non-administrator when an admin allowlist is set', async () => {
+  const previous = process.env.ADMIN_USER_IDS;
+  process.env.ADMIN_USER_IDS = 'user_admin';
+  try {
+    await withServer({}, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/agents/feed-curator/config`, jsonPut({ version: 1 }));
+      assert.equal(response.status, 403);
+    });
+  } finally {
+    if (previous === undefined) delete process.env.ADMIN_USER_IDS;
+    else process.env.ADMIN_USER_IDS = previous;
+  }
+});
+
+test('PUT /api/agents/:agentId/config allows an allowlisted administrator', async () => {
+  const previous = process.env.ADMIN_USER_IDS;
+  process.env.ADMIN_USER_IDS = 'u1, user_admin';
+  try {
+    await withServer({ activateVersion: async () => true }, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/agents/feed-curator/config`, jsonPut({ version: 1 }));
+      assert.equal(response.status, 200);
+    });
+  } finally {
+    if (previous === undefined) delete process.env.ADMIN_USER_IDS;
+    else process.env.ADMIN_USER_IDS = previous;
+  }
+});
+
+test('GET /api/agents/:agentId/config stays readable by a non-administrator', async () => {
+  const previous = process.env.ADMIN_USER_IDS;
+  process.env.ADMIN_USER_IDS = 'user_admin';
+  try {
+    await withServer({ listConfigs: async () => sampleConfigs }, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/agents/feed-curator/config`, authed);
+      assert.equal(response.status, 200);
+    });
+  } finally {
+    if (previous === undefined) delete process.env.ADMIN_USER_IDS;
+    else process.env.ADMIN_USER_IDS = previous;
+  }
+});
+
 test('PUT /api/agents/:agentId/config 400s a body that is neither a version nor a model', async () => {
   await withServer({}, async (baseUrl) => {
     const response = await fetch(`${baseUrl}/api/agents/resume-tailor/config`, jsonPut({ nonsense: true }));

--- a/apps/api/src/routes/agent-config.ts
+++ b/apps/api/src/routes/agent-config.ts
@@ -1,0 +1,126 @@
+import { Router } from 'express';
+import { requireUser } from '@/lib/auth';
+import { hasPostgresConnection } from '@/lib/postgres';
+import {
+  activateAgentConfigVersion,
+  insertAgentConfigVersion,
+  isAgentId,
+  listAgentConfigs,
+} from '@/data/agent-config-store';
+import type { AgentConfigRecord, AgentId } from '@/data/agent-config-store';
+
+export interface AgentConfigDeps {
+  hasDb: () => boolean;
+  listConfigs: (agentId: AgentId) => Promise<AgentConfigRecord[]>;
+  activateVersion: (agentId: AgentId, version: number) => Promise<boolean>;
+  insertVersion: (
+    agentId: AgentId,
+    model: string,
+    params: Record<string, unknown>,
+    promptOverrides: Record<string, unknown>,
+  ) => Promise<number>;
+}
+
+const defaultDeps: AgentConfigDeps = {
+  hasDb: hasPostgresConnection,
+  listConfigs: listAgentConfigs,
+  activateVersion: activateAgentConfigVersion,
+  insertVersion: insertAgentConfigVersion,
+};
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (value === undefined) return {};
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+/**
+ * `GET /api/agents/:agentId/config` — the active config plus every stored version.
+ * `PUT /api/agents/:agentId/config` — `{ version }` repoints active to an existing version;
+ * `{ model, params?, promptOverrides? }` inserts the next version and activates it.
+ */
+export function createAgentConfigRouter(deps: AgentConfigDeps = defaultDeps) {
+  const router = Router({ mergeParams: true });
+
+  /** Resolves the route's agent id, or writes the failing response and returns null. */
+  function resolveAgent(agentId: string, response: import('express').Response): AgentId | null {
+    if (!isAgentId(agentId)) {
+      response.status(404).json({ error: `Unknown agent: ${agentId}` });
+      return null;
+    }
+    if (!deps.hasDb()) {
+      response.status(503).json({ error: 'Agent configs require a database (DATABASE_URL).' });
+      return null;
+    }
+    return agentId;
+  }
+
+  router.get('/:agentId/config', async (request, response, next) => {
+    if (!requireUser(request, response)) return;
+    const agentId = resolveAgent(request.params.agentId ?? '', response);
+    if (!agentId) return;
+
+    try {
+      const versions = await deps.listConfigs(agentId);
+      response.json({ active: versions.find((config) => config.active) ?? null, versions });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.put('/:agentId/config', async (request, response, next) => {
+    if (!requireUser(request, response)) return;
+    const agentId = resolveAgent(request.params.agentId ?? '', response);
+    if (!agentId) return;
+
+    const body = (request.body ?? {}) as {
+      version?: unknown;
+      model?: unknown;
+      params?: unknown;
+      promptOverrides?: unknown;
+    };
+
+    try {
+      if (body.version !== undefined) {
+        if (typeof body.version !== 'number' || !Number.isInteger(body.version)) {
+          response.status(400).json({ error: '`version` must be an integer.' });
+          return;
+        }
+        if (!(await deps.activateVersion(agentId, body.version))) {
+          response.status(404).json({ error: `No version ${body.version} for ${agentId}` });
+          return;
+        }
+        response.json({ ok: true, activeVersion: body.version });
+        return;
+      }
+
+      if (body.model !== undefined) {
+        // A model is a LangChain `init_chat_model` string, so the provider prefix is required —
+        // a bare model id would silently resolve against whichever provider happened to be default.
+        if (typeof body.model !== 'string' || !body.model.includes(':')) {
+          response.status(400).json({ error: '`model` must be a "provider:model-id" string.' });
+          return;
+        }
+        const params = asObject(body.params);
+        const promptOverrides = asObject(body.promptOverrides);
+        if (!params || !promptOverrides) {
+          response.status(400).json({ error: '`params` and `promptOverrides` must be objects.' });
+          return;
+        }
+        const version = await deps.insertVersion(agentId, body.model, params, promptOverrides);
+        response.status(201).json({ ok: true, activeVersion: version });
+        return;
+      }
+
+      response
+        .status(400)
+        .json({ error: 'Body must be { version } or { model, params?, promptOverrides? }.' });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+export const agentConfigRouter = createAgentConfigRouter();

--- a/apps/api/src/routes/agent-config.ts
+++ b/apps/api/src/routes/agent-config.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { requireUser } from '@/lib/auth';
+import { requireAdmin, requireUser } from '@/lib/auth';
 import { hasPostgresConnection } from '@/lib/postgres';
 import {
   activateAgentConfigVersion,
@@ -27,6 +27,9 @@ const defaultDeps: AgentConfigDeps = {
   activateVersion: activateAgentConfigVersion,
   insertVersion: insertAgentConfigVersion,
 };
+
+/** `provider:model-id` — neither half may be empty or padded with whitespace. */
+const MODEL_PATTERN = /^\S+:\S+$/;
 
 function asObject(value: unknown): Record<string, unknown> | null {
   if (value === undefined) return {};
@@ -68,8 +71,10 @@ export function createAgentConfigRouter(deps: AgentConfigDeps = defaultDeps) {
     }
   });
 
+  // Writes are operator-only: `agent_configs` is global (keyed by agent id, not user), so an
+  // ordinary signed-in user must not be able to repoint the model every tenant's agents run on.
   router.put('/:agentId/config', async (request, response, next) => {
-    if (!requireUser(request, response)) return;
+    if (!requireAdmin(request, response)) return;
     const agentId = resolveAgent(request.params.agentId ?? '', response);
     if (!agentId) return;
 
@@ -95,9 +100,11 @@ export function createAgentConfigRouter(deps: AgentConfigDeps = defaultDeps) {
       }
 
       if (body.model !== undefined) {
-        // A model is a LangChain `init_chat_model` string, so the provider prefix is required —
-        // a bare model id would silently resolve against whichever provider happened to be default.
-        if (typeof body.model !== 'string' || !body.model.includes(':')) {
+        // A model is a LangChain `init_chat_model` string, so both halves must be present and
+        // non-empty: a bare model id would resolve against whichever provider happened to be
+        // default, and an empty half ('anthropic:', ':haiku') resolves to nothing at all —
+        // activating one would silently disable every run of that agent until a rollback.
+        if (typeof body.model !== 'string' || !MODEL_PATTERN.test(body.model)) {
           response.status(400).json({ error: '`model` must be a "provider:model-id" string.' });
           return;
         }

--- a/db/migrations/012_agent_configs.sql
+++ b/db/migrations/012_agent_configs.sql
@@ -1,0 +1,32 @@
+-- Per-agent, versioned, hot-swappable model configuration (Jobright-parity Epic 1, #251).
+--
+-- One row per (agent_id, version); exactly one active row per agent, enforced by a partial
+-- unique index. Changing a model = insert the next version and repoint `active`; rollback =
+-- repoint back. No deploy either way, and no model id is hard-coded in code.
+--
+-- `model` is a LangChain `init_chat_model` string: "provider:model-id",
+-- e.g. 'anthropic:claude-haiku-4-5', 'openai:gpt-5.6-luna'.
+create table if not exists agent_configs (
+  id uuid primary key default gen_random_uuid(),
+  agent_id text not null check (agent_id in ('feed-curator', 'resume-tailor', 'apply-copilot', 'connection-scout')),
+  version integer not null check (version >= 1),
+  model text not null check (model like '%:%'),
+  params jsonb not null default '{}'::jsonb,
+  prompt_overrides jsonb not null default '{}'::jsonb,
+  active boolean not null default false,
+  created_at timestamptz not null default now(),
+  unique (agent_id, version)
+);
+
+create unique index if not exists agent_configs_one_active_idx
+  on agent_configs (agent_id) where active;
+
+-- Initial tiering (spec section 3.3) — defaults only, swappable at runtime through
+-- PUT /api/agents/:agentId/config. Cheap tier for the high-volume feed-curator, premium
+-- tier for the three quality-critical agents.
+insert into agent_configs (agent_id, version, model, params, active) values
+  ('feed-curator',     1, 'anthropic:claude-haiku-4-5',  '{"temperature": 0.2, "max_tokens": 2048}', true),
+  ('resume-tailor',    1, 'anthropic:claude-sonnet-4-6', '{"temperature": 0.2, "max_tokens": 4096}', true),
+  ('apply-copilot',    1, 'anthropic:claude-sonnet-4-6', '{"temperature": 0.2, "max_tokens": 4096}', true),
+  ('connection-scout', 1, 'anthropic:claude-sonnet-4-6', '{"temperature": 0.2, "max_tokens": 4096}', true)
+on conflict (agent_id, version) do nothing;

--- a/db/migrations/012_agent_configs.sql
+++ b/db/migrations/012_agent_configs.sql
@@ -10,7 +10,10 @@ create table if not exists agent_configs (
   id uuid primary key default gen_random_uuid(),
   agent_id text not null check (agent_id in ('feed-curator', 'resume-tailor', 'apply-copilot', 'connection-scout')),
   version integer not null check (version >= 1),
-  model text not null check (model like '%:%'),
+  -- "provider:model-id" with both halves non-empty and unpadded: 'anthropic:' or ':haiku'
+  -- would satisfy a plain like '%:%' yet resolve to nothing in init_chat_model, silently
+  -- disabling every run of the agent.
+  model text not null check (model ~ '^\S+:\S+$'),
   params jsonb not null default '{}'::jsonb,
   prompt_overrides jsonb not null default '{}'::jsonb,
   active boolean not null default false,


### PR DESCRIPTION
Closes #251. First ticket of the Jobright-parity program (Epic 1, #244) — unblocks #252 and transitively epics 2, 4 and 6.

Per-agent model configuration becomes data instead of code: swapping a model is `PUT /api/agents/:agentId/config`, not a deploy, and rollback is repointing `active` to an older version.

## What changed

- **`db/migrations/012_agent_configs.sql`** — table + partial unique index `on (agent_id) where active` + the spec §3.3 seed tiering (cheap tier for `feed-curator`, premium for the other three). Idempotent; applied by `migrate-on-boot.ts`.
- **`apps/api/src/data/agent-config-store.ts`** — Postgres-only store: `listAgentConfigs`, `activateAgentConfigVersion`, `insertAgentConfigVersion`.
- **`apps/api/src/routes/agent-config.ts`** — `GET /api/agents/:agentId/config` → `{ active, versions }`; `PUT` with `{ version }` repoints (200) or `{ model, params?, promptOverrides? }` inserts + activates (201). Unknown agent → 404, no DB → 503, unauthenticated → 401, malformed body → 400.
- Registered under `/api/agents` in `app.ts` (#253 mounts stream/resume on the same prefix under distinct sub-paths).

## Deviations from the ticket (all deliberate)

1. **Migration numbered 012, not 018.** Per the ticket's own header note: 011 is the highest on `main`, so 012 is the next free number.
2. **Test framework.** The ticket's skeleton is jest/supertest; this repo uses `node:test` + `node:assert/strict` + raw `http`. Mirrors `agent-outputs.test.ts` as the ticket's prose instructs.
3. **Store layer instead of an injected `query`.** House style puts SQL in `src/data/*-store.ts` and injects store functions into routers. Also, the ticket's `getPool().query(...)` does not typecheck here — `getPool()` returns `Pool | null`.
4. **Two statements in a transaction instead of `set active = (version = $2)`.** A partial unique index is checked per row as an UPDATE walks the table, so that single-statement swap can transiently hold two active rows and fail with a duplicate-key error depending on row order. Deactivate-then-activate inside one transaction makes the intermediate state (zero active) one the index permits, invisible to other sessions. A repoint to a nonexistent version rolls back, so a bad request can never leave an agent with no active config.
5. **camelCase in responses** (`promptOverrides`, `createdAt`), consistent with the other stores; `#252` reads the table directly, so no cross-service contract is affected.

## Verification

```
npm run check     # lint + typecheck + build — pass
npm run test:api  # 244 tests, 244 pass, 0 fail (13 new)
npm run test:pg   # skipped locally (no DATABASE_URL); runs in CI after db:init
```

The new `agent-config-store.pgtest.ts` proves the one-active invariant against real Postgres — the partial unique index cannot be verified with a fake query fn. **It has not been executed locally** (no local `DATABASE_URL`, Docker daemon not running); CI's Postgres job is its first real run. The migration likewise has not been applied against a live database from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)