### PR TITLE
fix(agent): bump pinned cryptography and langgraph-checkpoint-postgres past new advisories

### DIFF
--- a/services/agent/constraints.txt
+++ b/services/agent/constraints.txt
@@ -32,7 +32,7 @@ certifi==2026.7.22
 cffi==2.1.0
 charset-normalizer==3.4.9
 click==8.4.2
-cryptography==49.0.0
+cryptography==50.0.0
 distro==1.9.0
 docstring_parser==0.18.0
 fastapi==0.140.0
@@ -68,7 +68,7 @@ langchain-protocol==0.0.18
 langfuse==4.14.1
 langgraph==1.2.9
 langgraph-checkpoint==4.1.1
-langgraph-checkpoint-postgres==3.1.0
+langgraph-checkpoint-postgres==3.1.1
 langgraph-prebuilt==1.1.0
 langgraph-sdk==0.4.2
 langsmith==0.10.10


### PR DESCRIPTION
The `Dependency audit` job started failing on every PR: two advisories were published against versions pinned in the agent image lock since main last ran CI (2026-07-27).

```
Name                          Version ID              Fix Versions
cryptography                  49.0.0  PYSEC-2026-3552 50.0.0
langgraph-checkpoint-postgres 3.1.0   PYSEC-2026-3635 3.1.1
```

Bumps both pins in `services/agent/constraints.txt` to the fixed versions. Nothing else changes.

Not a regeneration from a real image build (the header's documented procedure) — that needs Docker, and this is a targeted security bump of two lines rather than a dependency refresh. Low risk in this direction: the `pip-audit (agent pinned image lock)` step runs `--no-deps`, so it is a pure version-list check, and the `Agent service (Python)` job installs the *ranged* `requirements-dev.txt`, meaning CI has already been resolving and testing against these newer versions.

Housekeeping, unblocks #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)