### PR TITLE
feat(agent): add four-graph registry and generic SSE proxy

### DIFF
--- a/apps/api/src/app.agents.test.ts
+++ b/apps/api/src/app.agents.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+import { createApp } from './app';
+
+async function withApp(run: (baseUrl: string) => Promise<void>) {
+  const app = createApp({
+    runLimiter: (_request, _response, next) => {
+      appCalls.limiter += 1;
+      next();
+    },
+    runBudget: (_request, _response, next) => {
+      appCalls.budget += 1;
+      next();
+    },
+  });
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no server address');
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+const appCalls = { limiter: 0, budget: 0 };
+const auth = { headers: { 'X-User-Id': 'u_app_test' } };
+
+test('production specialist mount guards stream/resume with or without trailing slashes, not config routes', async () => {
+  appCalls.limiter = 0;
+  appCalls.budget = 0;
+  await withApp(async (baseUrl) => {
+    for (const path of [
+      '/api/agents/feed-curator/stream',
+      '/api/agents/feed-curator/stream/',
+      '/api/agents/feed-curator/resume',
+      '/api/agents/feed-curator/resume/',
+    ]) {
+      const response = await fetch(`${baseUrl}${path}`, {
+        method: 'POST',
+        headers: { ...auth.headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ threadId: 'u_app_test:feed-curator', payload: {} }),
+      });
+      assert.equal(response.status, 503);
+    }
+
+    const configGet = await fetch(`${baseUrl}/api/agents/feed-curator/config`, auth);
+    assert.equal(configGet.status, 503);
+    const configPut = await fetch(`${baseUrl}/api/agents/feed-curator/config`, {
+      method: 'PUT',
+      headers: { ...auth.headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ version: 1 }),
+    });
+    assert.equal(configPut.status, 503);
+  });
+
+  assert.equal(appCalls.limiter, 4);
+  assert.equal(appCalls.budget, 4);
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,6 +12,7 @@ import { assistantChatRouter } from '@/routes/assistant-chat';
 import { demoRouter } from '@/routes/demo';
 import { healthRouter } from '@/routes/health';
 import { agentConfigRouter } from '@/routes/agent-config';
+import { agentsRouter } from '@/routes/agents';
 import { agentOutputsRouter } from '@/routes/agent-outputs';
 import { jobExtractRouter } from '@/routes/job-extract';
 import { jobsRouter } from '@/routes/jobs';
@@ -92,6 +93,22 @@ export function createApp() {
   // Stricter per-user limit on the expensive AI + discovery routes; the AI routes
   // additionally enforce the per-user daily spend ceiling (discovery has no LLM cost).
   app.use('/api/ai', strictLimiter, enforceDailyBudget, aiRouter);
+  // Generic specialist streams/resumes are charged independently from config reads/writes.
+  // Keep the guards path-aware because this mount shares the /api/agents prefix with the
+  // config router below; config GET/PUT must not consume a run budget.
+  app.use('/api/agents', (request, response, next) => {
+    if (!request.path.endsWith('/stream') && !request.path.endsWith('/resume')) {
+      next();
+      return;
+    }
+    strictLimiter(request, response, (error?: unknown) => {
+      if (error) {
+        next(error);
+        return;
+      }
+      enforceDailyBudget(request, response, next);
+    });
+  }, agentsRouter);
   // Per-agent model configuration (read + hot-swap). Later parity tickets mount the agent
   // stream/resume proxy on the same prefix under distinct sub-paths.
   app.use('/api/agents', agentConfigRouter);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -53,8 +53,15 @@ function requireSharedApiKey(
   next();
 }
 
-export function createApp() {
+export interface AppDependencies {
+  runLimiter?: express.RequestHandler;
+  runBudget?: express.RequestHandler;
+}
+
+export function createApp(dependencies: AppDependencies = {}) {
   const app = express();
+  const runLimiter = dependencies.runLimiter ?? strictLimiter;
+  const runBudget = dependencies.runBudget ?? enforceDailyBudget;
 
   app.disable('x-powered-by');
   // One proxy hop in front of the app (Azure App Service) — needed so `req.ip` is
@@ -97,16 +104,17 @@ export function createApp() {
   // Keep the guards path-aware because this mount shares the /api/agents prefix with the
   // config router below; config GET/PUT must not consume a run budget.
   app.use('/api/agents', (request, response, next) => {
-    if (!request.path.endsWith('/stream') && !request.path.endsWith('/resume')) {
+    const normalizedPath = request.path.replace(/\/+$/, '');
+    if (!normalizedPath.endsWith('/stream') && !normalizedPath.endsWith('/resume')) {
       next();
       return;
     }
-    strictLimiter(request, response, (error?: unknown) => {
+    runLimiter(request, response, (error?: unknown) => {
       if (error) {
         next(error);
         return;
       }
-      enforceDailyBudget(request, response, next);
+      runBudget(request, response, next);
     });
   }, agentsRouter);
   // Per-agent model configuration (read + hot-swap). Later parity tickets mount the agent

--- a/apps/api/src/lib/agent-client.test.ts
+++ b/apps/api/src/lib/agent-client.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { agentHeaders, isColdStartError, withColdStartRetry } from './agent-client';
+import { agentHeaders, isColdStartError, withColdStartRetry, streamAgentUpstream, resumeAgentUpstream } from './agent-client';
 
 function timeoutError() {
   const error = new Error('The operation was aborted due to timeout');
@@ -82,4 +82,26 @@ test('withColdStartRetry gives up after a second timeout (so the caller can mock
     /timeout/,
   );
   assert.equal(calls, 2);
+});
+
+test('specialist stream and resume clients URL-encode ids and send agent headers', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: Array<[string, RequestInit]> = [];
+  process.env.AGENT_SERVICE_URL = 'https://agent.example.test/';
+  process.env.AGENT_API_KEY = 'key';
+  globalThis.fetch = (async (input, init) => {
+    calls.push([String(input), init ?? {}]);
+    return new Response('event: result\\ndata: {}\\n\\n', { status: 200 });
+  }) as typeof fetch;
+  try {
+    await streamAgentUpstream('feed curator', { user_id: 'u1' });
+    await resumeAgentUpstream('resume/tailor', { thread_id: 'u1:resume/tailor', payload: {} });
+  } finally {
+    globalThis.fetch = originalFetch;
+    delete process.env.AGENT_SERVICE_URL;
+    delete process.env.AGENT_API_KEY;
+  }
+  assert.equal(calls[0]?.[0], 'https://agent.example.test/agents/feed%20curator/stream');
+  assert.equal(calls[1]?.[0], 'https://agent.example.test/agents/resume%2Ftailor/resume');
+  assert.equal((calls[0]?.[1].headers as Record<string, string>).Authorization, 'Bearer key');
 });

--- a/apps/api/src/lib/agent-client.ts
+++ b/apps/api/src/lib/agent-client.ts
@@ -52,12 +52,18 @@ export class AgentDisabledError extends Error {
   }
 }
 
+function agentServiceUrl(): string | undefined {
+  return process.env.AGENT_SERVICE_URL?.trim().replace(/\/$/, '') || AGENT_URL;
+}
+
 export function isAgentEnabled(): boolean {
-  return Boolean(AGENT_URL);
+  return Boolean(agentServiceUrl());
 }
 
 async function callAgent<T>(path: string, payload: unknown, timeoutMs = AGENT_TIMEOUT_MS): Promise<T> {
-  const response = await fetch(`${AGENT_URL}${path}`, {
+  const baseUrl = agentServiceUrl();
+  if (!baseUrl) throw new AgentDisabledError();
+  const response = await fetch(`${baseUrl}${path}`, {
     method: 'POST',
     headers: agentHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify(payload),
@@ -152,7 +158,7 @@ export async function streamAssistantUpstream(payload: unknown): Promise<Respons
   // the retry too (the container wakes during the first attempt; the retry still streams),
   // so we pass a fixed-timeout lambda and ignore the attempt number.
   return withColdStartRetry(() =>
-    fetch(`${AGENT_URL}/assistant/stream`, {
+    fetch(`${agentServiceUrl()}/assistant/stream`, {
       method: 'POST',
       headers: agentHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(payload),
@@ -168,7 +174,7 @@ export async function streamAssistantChatUpstream(payload: unknown): Promise<Res
   }
   // Same cold-start retry as streamAssistantUpstream — see comment there.
   return withColdStartRetry(() =>
-    fetch(`${AGENT_URL}/assistant/chat`, {
+    fetch(`${agentServiceUrl()}/assistant/chat`, {
       method: 'POST',
       headers: agentHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(payload),
@@ -187,7 +193,7 @@ export async function fetchEvDemoViaAgent(): Promise<TelemetryInsights> {
   if (!isAgentEnabled()) {
     throw new AgentDisabledError();
   }
-  const response = await fetch(`${AGENT_URL}/telemetry/ev-demo`, {
+  const response = await fetch(`${agentServiceUrl()}/telemetry/ev-demo`, {
     headers: agentHeaders(),
     signal: AbortSignal.timeout(AGENT_TASK_TIMEOUT_MS),
   });
@@ -195,6 +201,34 @@ export async function fetchEvDemoViaAgent(): Promise<TelemetryInsights> {
     throw new Error(`agent /telemetry/ev-demo responded with ${response.status}`);
   }
   return (await response.json()) as TelemetryInsights;
+}
+
+/** Open a generic specialist-agent stream and return the raw response for piping. */
+export async function streamAgentUpstream(agentId: string, payload: unknown): Promise<Response> {
+  if (!isAgentEnabled()) throw new AgentDisabledError();
+  const encodedId = encodeURIComponent(agentId);
+  return withColdStartRetry(() =>
+    fetch(`${agentServiceUrl()}/agents/${encodedId}/stream`, {
+      method: 'POST',
+      headers: agentHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(AGENT_TASK_TIMEOUT_MS),
+    }),
+  );
+}
+
+/** Resume a generic specialist-agent stream and return the raw response for piping. */
+export async function resumeAgentUpstream(agentId: string, payload: unknown): Promise<Response> {
+  if (!isAgentEnabled()) throw new AgentDisabledError();
+  const encodedId = encodeURIComponent(agentId);
+  return withColdStartRetry(() =>
+    fetch(`${agentServiceUrl()}/agents/${encodedId}/resume`, {
+      method: 'POST',
+      headers: agentHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(AGENT_TASK_TIMEOUT_MS),
+    }),
+  );
 }
 
 export interface ScoreFitInput {

--- a/apps/api/src/routes/agents.test.ts
+++ b/apps/api/src/routes/agents.test.ts
@@ -15,6 +15,16 @@ function sseStream(frames: string[]): ReadableStream<Uint8Array> {
   });
 }
 
+function erroringSseStream(frame: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(frame));
+      setTimeout(() => controller.error(new Error('upstream details should stay private')), 0);
+    },
+  });
+}
+
 async function withServer(deps: Partial<AgentsRouterDeps>, run: (baseUrl: string) => Promise<void>) {
   const app = express();
   app.use(express.json());
@@ -87,6 +97,27 @@ test('stream maps body and pipes unbuffered SSE headers', async () => {
     assert.match(text, /event: result/);
   });
   assert.deepEqual(sent, ['feed-curator', { user_id: 'u1', job_id: 'job-1', input: { q: 'python' } }]);
+});
+
+test('stream emits a generic terminal error event when upstream fails after a frame', async () => {
+  await withServer({
+    openStream: async () => ({
+      ok: true,
+      status: 200,
+      body: erroringSseStream('event: status\ndata: {"status":"running"}\n\n'),
+    }),
+  }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/feed-curator/stream`, {
+      method: 'POST',
+      ...auth,
+    });
+    assert.equal(response.status, 200);
+    const text = await response.text();
+    assert.match(text, /event: status/);
+    assert.match(text, /event: error/);
+    assert.match(text, /Agent stream failed/);
+    assert.doesNotMatch(text, /upstream details should stay private/);
+  });
 });
 
 test('stream preserves upstream non-OK status', async () => {

--- a/apps/api/src/routes/agents.test.ts
+++ b/apps/api/src/routes/agents.test.ts
@@ -96,6 +96,19 @@ test('stream preserves upstream non-OK status', async () => {
   });
 });
 
+test('stream returns 502 when an otherwise-successful upstream has no body', async () => {
+  await withServer(
+    { openStream: async () => ({ ok: true, status: 200, body: null }) },
+    async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/agents/feed-curator/stream`, {
+        method: 'POST',
+        ...auth,
+      });
+      assert.equal(response.status, 502);
+    },
+  );
+});
+
 test('resume validates thread tenancy and payload before upstream', async () => {
   let calls = 0;
   await withServer({ openResume: async () => { calls += 1; return { ok: true, status: 200, body: sseStream([]) }; } }, async (baseUrl) => {
@@ -106,6 +119,27 @@ test('resume validates thread tenancy and payload before upstream', async () => 
       assert.ok([400, 403].includes(response.status), `${threadId}: ${response.status}`);
     }
   });
+  assert.equal(calls, 0);
+});
+
+test('resume requires a missing threadId and does not contact upstream', async () => {
+  let calls = 0;
+  await withServer(
+    {
+      openResume: async () => {
+        calls += 1;
+        return { ok: true, status: 200, body: sseStream([]) };
+      },
+    },
+    async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/agents/feed-curator/resume`, {
+        method: 'POST',
+        headers: { ...auth.headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ payload: {} }),
+      });
+      assert.equal(response.status, 400);
+    },
+  );
   assert.equal(calls, 0);
 });
 

--- a/apps/api/src/routes/agents.test.ts
+++ b/apps/api/src/routes/agents.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+import express from 'express';
+import { AgentDisabledError } from '@/lib/agent-client';
+import { createAgentsRouter, type AgentsRouterDeps } from './agents';
+
+function sseStream(frames: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const frame of frames) controller.enqueue(encoder.encode(frame));
+      controller.close();
+    },
+  });
+}
+
+async function withServer(deps: Partial<AgentsRouterDeps>, run: (baseUrl: string) => Promise<void>) {
+  const app = express();
+  app.use(express.json());
+  app.use((request, _response, next) => {
+    const userId = request.header('X-User-Id');
+    if (userId) request.userId = userId;
+    next();
+  });
+  app.use('/api/agents', createAgentsRouter({
+    openStream: async () => ({ ok: true, status: 200, body: sseStream([]) }),
+    openResume: async () => ({ ok: true, status: 200, body: sseStream([]) }),
+    ...deps,
+  }));
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no server address');
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+const auth = { headers: { 'X-User-Id': 'u1' } };
+
+test('agent stream requires a signed-in user', async () => {
+  let calls = 0;
+  await withServer({ openStream: async () => { calls += 1; return { ok: true, status: 200, body: sseStream([]) }; } }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/feed-curator/stream`, { method: 'POST' });
+    assert.equal(response.status, 401);
+  });
+  assert.equal(calls, 0);
+});
+
+test('unknown ids 404 without contacting upstream', async () => {
+  let calls = 0;
+  await withServer({ openStream: async () => { calls += 1; return { ok: true, status: 200, body: sseStream([]) }; } }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/nope/stream`, { method: 'POST', ...auth });
+    assert.equal(response.status, 404);
+  });
+  assert.equal(calls, 0);
+});
+
+test('disabled agent service maps to 503', async () => {
+  await withServer({ openStream: async () => { throw new AgentDisabledError(); } }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/feed-curator/stream`, { method: 'POST', ...auth });
+    assert.equal(response.status, 503);
+  });
+});
+
+test('stream maps body and pipes unbuffered SSE headers', async () => {
+  let sent: unknown;
+  await withServer({
+    openStream: async (agentId, payload) => {
+      sent = [agentId, payload];
+      return { ok: true, status: 200, body: sseStream(['event: status\ndata: {"status":"done"}\n\n', 'event: result\ndata: {}\n\n']) };
+    },
+  }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/feed-curator/stream`, {
+      method: 'POST', headers: { ...auth.headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jobId: 'job-1', input: { q: 'python' } }),
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'text/event-stream');
+    assert.equal(response.headers.get('cache-control'), 'no-cache, no-transform');
+    assert.equal(response.headers.get('x-accel-buffering'), 'no');
+    const text = await response.text();
+    assert.match(text, /event: status/);
+    assert.match(text, /event: result/);
+  });
+  assert.deepEqual(sent, ['feed-curator', { user_id: 'u1', job_id: 'job-1', input: { q: 'python' } }]);
+});
+
+test('stream preserves upstream non-OK status', async () => {
+  await withServer({ openStream: async () => ({ ok: false, status: 429, body: null }) }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/feed-curator/stream`, { method: 'POST', ...auth });
+    assert.equal(response.status, 429);
+  });
+});
+
+test('resume validates thread tenancy and payload before upstream', async () => {
+  let calls = 0;
+  await withServer({ openResume: async () => { calls += 1; return { ok: true, status: 200, body: sseStream([]) }; } }, async (baseUrl) => {
+    for (const threadId of ['', 'u1:feed-curatorx:evil', 'u10:feed-curator', 'other:feed-curator']) {
+      const response = await fetch(`${baseUrl}/api/agents/feed-curator/resume`, {
+        method: 'POST', headers: { ...auth.headers, 'Content-Type': 'application/json' }, body: JSON.stringify({ threadId, payload: { approved: true } }),
+      });
+      assert.ok([400, 403].includes(response.status), `${threadId}: ${response.status}`);
+    }
+  });
+  assert.equal(calls, 0);
+});
+
+test('resume accepts exact or job-scoped thread and forwards payload', async () => {
+  let sent: unknown;
+  await withServer({ openResume: async (agentId, payload) => { sent = [agentId, payload]; return { ok: true, status: 200, body: sseStream(['event: result\ndata: {}\n\n']) }; } }, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agents/resume-tailor/resume`, {
+      method: 'POST', headers: { ...auth.headers, 'Content-Type': 'application/json' }, body: JSON.stringify({ threadId: 'u1:resume-tailor:job-7', payload: { approved: true } }),
+    });
+    assert.equal(response.status, 200);
+    await response.text();
+  });
+  assert.deepEqual(sent, ['resume-tailor', { thread_id: 'u1:resume-tailor:job-7', payload: { approved: true } }]);
+});

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -1,0 +1,136 @@
+import { Router } from 'express';
+import { isAgentId } from '@/data/agent-config-store';
+import { requireUser } from '@/lib/auth';
+import {
+  AgentDisabledError,
+  resumeAgentUpstream,
+  streamAgentUpstream,
+} from '@/lib/agent-client';
+import type { UpstreamStream } from '@/routes/assistant';
+
+const AGENT_DISABLED_MESSAGE =
+  'The AI agent service is not configured. Set AGENT_SERVICE_URL and a provider key to enable the agents.';
+
+export interface AgentsRouterDeps {
+  openStream: (agentId: string, payload: unknown) => Promise<UpstreamStream>;
+  openResume: (agentId: string, payload: unknown) => Promise<UpstreamStream>;
+}
+
+const defaultDeps: AgentsRouterDeps = {
+  openStream: streamAgentUpstream,
+  openResume: resumeAgentUpstream,
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function pipeSse(upstream: UpstreamStream, response: import('express').Response) {
+  if (!upstream.ok || !upstream.body) {
+    response.status(upstream.status || 502).json({ error: 'Agent stream unavailable' });
+    return;
+  }
+
+  response.status(200);
+  response.setHeader('Content-Type', 'text/event-stream');
+  response.setHeader('Cache-Control', 'no-cache, no-transform');
+  response.setHeader('Connection', 'keep-alive');
+  response.setHeader('X-Accel-Buffering', 'no');
+
+  const reader = upstream.body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      response.write(Buffer.from(value));
+    }
+  } catch {
+    // Client disconnects and mid-stream upstream failures end the pipe quietly.
+  } finally {
+    response.end();
+  }
+}
+
+function resolveAgent(agentId: string, response: import('express').Response): boolean {
+  if (!isAgentId(agentId)) {
+    response.status(404).json({ error: `Unknown agent: ${agentId}` });
+    return false;
+  }
+  return true;
+}
+
+export function createAgentsRouter(deps: AgentsRouterDeps = defaultDeps) {
+  const router = Router();
+
+  router.post('/:agentId/stream', async (request, response, next) => {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+    const agentId = request.params.agentId ?? '';
+    if (!resolveAgent(agentId, response)) return;
+
+    const body = (request.body ?? {}) as { jobId?: unknown; input?: unknown };
+    if (body.jobId !== undefined && typeof body.jobId !== 'string') {
+      response.status(400).json({ error: 'jobId must be a string' });
+      return;
+    }
+    if (body.input !== undefined && !isObject(body.input)) {
+      response.status(400).json({ error: 'input must be an object' });
+      return;
+    }
+
+    try {
+      const upstream = await deps.openStream(agentId, {
+        user_id: userId,
+        job_id: body.jobId,
+        input: body.input ?? {},
+      });
+      await pipeSse(upstream, response);
+    } catch (error) {
+      if (error instanceof AgentDisabledError) {
+        response.status(503).json({ error: AGENT_DISABLED_MESSAGE });
+        return;
+      }
+      next(error);
+    }
+  });
+
+  router.post('/:agentId/resume', async (request, response, next) => {
+    const userId = requireUser(request, response);
+    if (!userId) return;
+    const agentId = request.params.agentId ?? '';
+    if (!resolveAgent(agentId, response)) return;
+
+    const body = (request.body ?? {}) as { threadId?: unknown; payload?: unknown };
+    if (typeof body.threadId !== 'string' || !body.threadId.trim()) {
+      response.status(400).json({ error: 'threadId is required' });
+      return;
+    }
+    if (body.payload !== undefined && !isObject(body.payload)) {
+      response.status(400).json({ error: 'payload must be an object' });
+      return;
+    }
+    const prefix = `${userId}:${agentId}`;
+    if (body.threadId !== prefix && !body.threadId.startsWith(`${prefix}:`)) {
+      response.status(403).json({ error: 'Thread does not belong to this user and agent' });
+      return;
+    }
+
+    try {
+      const upstream = await deps.openResume(agentId, {
+        thread_id: body.threadId,
+        payload: body.payload ?? {},
+      });
+      await pipeSse(upstream, response);
+    } catch (error) {
+      if (error instanceof AgentDisabledError) {
+        response.status(503).json({ error: AGENT_DISABLED_MESSAGE });
+        return;
+      }
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+export const agentsRouter = createAgentsRouter();

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -26,8 +26,12 @@ function isObject(value: unknown): value is Record<string, unknown> {
 }
 
 async function pipeSse(upstream: UpstreamStream, response: import('express').Response) {
-  if (!upstream.ok || !upstream.body) {
+  if (!upstream.ok) {
     response.status(upstream.status || 502).json({ error: 'Agent stream unavailable' });
+    return;
+  }
+  if (!upstream.body) {
+    response.status(502).json({ error: 'Agent stream unavailable' });
     return;
   }
 

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -10,6 +10,7 @@ import type { UpstreamStream } from '@/routes/assistant';
 
 const AGENT_DISABLED_MESSAGE =
   'The AI agent service is not configured. Set AGENT_SERVICE_URL and a provider key to enable the agents.';
+const AGENT_STREAM_ERROR_FRAME = 'event: error\ndata: {"message":"Agent stream failed"}\n\n';
 
 export interface AgentsRouterDeps {
   openStream: (agentId: string, payload: unknown) => Promise<UpstreamStream>;
@@ -49,7 +50,13 @@ async function pipeSse(upstream: UpstreamStream, response: import('express').Res
       response.write(Buffer.from(value));
     }
   } catch {
-    // Client disconnects and mid-stream upstream failures end the pipe quietly.
+    if (!response.destroyed && !response.writableEnded) {
+      try {
+        response.write(AGENT_STREAM_ERROR_FRAME);
+      } catch {
+        // The downstream may disconnect between the state check and write.
+      }
+    }
   } finally {
     response.end();
   }

--- a/services/agent/app/graph/agent_state.py
+++ b/services/agent/app/graph/agent_state.py
@@ -1,0 +1,15 @@
+"""State shared by the generic specialist-agent graphs."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class AgentRunState(TypedDict, total=False):
+    user_id: str
+    job_id: str | None
+    input: dict[str, Any]
+    output: dict[str, Any]
+    status: str
+    tokens_used: int
+    approved: bool

--- a/services/agent/app/graph/registry.py
+++ b/services/agent/app/graph/registry.py
@@ -1,0 +1,86 @@
+"""Registry of the four Jobright-parity specialist graph entrypoints.
+
+The graphs intentionally remain no-cost echo stubs until the specialist behavior is
+implemented in later tickets. They are still real, separately compiled LangGraph
+graphs so the streaming and checkpoint contracts are exercised now.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from langgraph.graph import END, START, StateGraph
+
+from app.graph.agent_state import AgentRunState
+from app.llm.provider import get_model_for_agent
+
+AGENT_IDS = ("feed-curator", "resume-tailor", "apply-copilot", "connection-scout")
+
+
+def make_thread_id(user_id: str, agent_id: str, job_id: str | None = None) -> str:
+    """Return a tenant- and agent-scoped checkpoint id."""
+    return f"{user_id}:{agent_id}" + (f":{job_id}" if job_id else "")
+
+
+def _echo_node(agent_id: str) -> Callable[[AgentRunState], dict[str, Any]]:
+    def echo(state: AgentRunState) -> dict[str, Any]:
+        # Resolving a configured model records the eventual model label without ever
+        # invoking it. Keyless CI/local runs intentionally use an explicit fallback label.
+        try:
+            _model, model_label, _config = get_model_for_agent(agent_id)
+        except Exception:  # noqa: BLE001 - provider setup is optional for echo stubs
+            model_label = "unconfigured"
+        return {
+            "output": {"agent_id": agent_id, "echo": state.get("input", {}), "model": model_label},
+            "status": "done",
+        }
+
+    return echo
+
+
+def _build_graph(agent_id: str, checkpointer=None, store=None):
+    builder = StateGraph(AgentRunState)
+    builder.add_node("echo", _echo_node(agent_id))
+    builder.add_edge(START, "echo")
+    builder.add_edge("echo", END)
+    return builder.compile(checkpointer=checkpointer, store=store, name=agent_id)
+
+
+def build_feed_curator_graph(checkpointer=None, store=None):
+    return _build_graph("feed-curator", checkpointer, store)
+
+
+def build_resume_tailor_graph(checkpointer=None, store=None):
+    return _build_graph("resume-tailor", checkpointer, store)
+
+
+def build_apply_copilot_graph(checkpointer=None, store=None):
+    return _build_graph("apply-copilot", checkpointer, store)
+
+
+def build_connection_scout_graph(checkpointer=None, store=None):
+    return _build_graph("connection-scout", checkpointer, store)
+
+
+# Short factory names keep the registry easy to consume from later specialist tooling.
+build_feed_curator = build_feed_curator_graph
+build_resume_tailor = build_resume_tailor_graph
+build_apply_copilot = build_apply_copilot_graph
+build_connection_scout = build_connection_scout_graph
+
+
+_FACTORIES = {
+    "feed-curator": build_feed_curator_graph,
+    "resume-tailor": build_resume_tailor_graph,
+    "apply-copilot": build_apply_copilot_graph,
+    "connection-scout": build_connection_scout_graph,
+}
+
+
+def build_registry(checkpointer=None, store=None):
+    """Compile one graph per specialist id and return the id-to-graph registry."""
+    return {
+        agent_id: _FACTORIES[agent_id](checkpointer=checkpointer, store=store)
+        for agent_id in AGENT_IDS
+    }

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -15,6 +15,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
+from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.types import Command
 from pydantic import BaseModel, Field
 
@@ -26,6 +27,7 @@ from app.chains.score_fit import score_fit
 from app.chains.weekly import weekly_recommendations
 from app.config import settings
 from app.graph.assistant import build_assistant_graph
+from app.graph.registry import AGENT_IDS, build_registry, make_thread_id
 from app.llm.provider import LLMNotConfigured, get_model, llm_available, resolve_provider
 from app.obs import traced_config, traced_span
 from app.prompts import CHAT_ASSISTANT_SYSTEM
@@ -89,6 +91,7 @@ _configure_app_insights()
 # all drive the graph through its async API (ainvoke/astream/aget_state).
 _assistant_graph = None
 _checkpointer_pool = None
+_agent_registry = None
 
 
 async def _build_durable_assistant_graph():
@@ -137,7 +140,7 @@ async def _lifespan(_app: FastAPI):
     """Upgrade the assistant graph to the durable Postgres checkpointer on
     startup when DATABASE_URL is set; degrade to the in-memory saver on any
     failure so a checkpointer outage never blocks the service from starting."""
-    global _assistant_graph, _checkpointer_pool
+    global _assistant_graph, _checkpointer_pool, _agent_registry
     # Fail closed: refuse to start on a public cloud runtime with auth disabled.
     assert_auth_configured()
     if settings.database_url:
@@ -150,6 +153,7 @@ async def _lifespan(_app: FastAPI):
                 "(in-flight runs will not survive a restart)",
                 exc_info=True,
             )
+    _agent_registry = build_registry(checkpointer=InMemorySaver())
     try:
         yield
     finally:
@@ -159,6 +163,7 @@ async def _lifespan(_app: FastAPI):
             except Exception:  # noqa: BLE001 - never let teardown raise on shutdown
                 logger.warning("error closing HITL checkpointer pool", exc_info=True)
             _checkpointer_pool = None
+        _agent_registry = None
 
 
 app = FastAPI(
@@ -364,6 +369,14 @@ def _get_assistant_graph():
     return _assistant_graph
 
 
+def _get_agent_registry():
+    """Return the lifespan-built specialist registry, with a test/dev fallback."""
+    global _agent_registry
+    if _agent_registry is None:
+        _agent_registry = build_registry(checkpointer=InMemorySaver())
+    return _agent_registry
+
+
 async def _arun(coro_fn, *args):
     """Await an async graph call, translating provider errors into HTTP errors."""
     try:
@@ -436,6 +449,79 @@ async def assistant_resume_endpoint(req: AssistantResumeRequest) -> dict:
 
 def _sse(event: str, data: dict) -> str:
     return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+class AgentStreamRequest(BaseModel):
+    user_id: str
+    job_id: str | None = None
+    input: dict = Field(default_factory=dict)
+
+
+class AgentResumeRequest(BaseModel):
+    thread_id: str
+    payload: dict = Field(default_factory=dict)
+
+
+def _agent_response(agent_id: str, thread_id: str, state: dict) -> dict:
+    awaiting = "__interrupt__" in state
+    return {
+        "agent_id": agent_id,
+        "thread_id": thread_id,
+        "status": "awaiting_approval" if awaiting else state.get("status"),
+        "output": state.get("output"),
+    }
+
+
+async def _agent_event_stream(agent_id: str, graph_input, config: dict):
+    graph = _get_agent_registry()[agent_id]
+    thread_id = config["configurable"]["thread_id"]
+    awaiting = False
+    try:
+        async for update in graph.astream(graph_input, config, stream_mode="updates"):
+            for node, delta in update.items():
+                if node == "__interrupt__":
+                    awaiting = True
+                    state = (await graph.aget_state(config)).values
+                    snapshot = _agent_response(agent_id, thread_id, state)
+                    snapshot["status"] = "awaiting_approval"
+                    yield _sse("awaiting_approval", snapshot)
+                else:
+                    status = delta.get("status") if isinstance(delta, dict) else None
+                    yield _sse("status", {"node": node, "status": status})
+        if not awaiting:
+            final = (await graph.aget_state(config)).values
+            yield _sse("result", _agent_response(agent_id, thread_id, final))
+    except Exception as exc:  # noqa: BLE001 - stream failures are represented in-band
+        logger.exception("specialist agent stream failed")
+        yield _sse("error", {"message": str(exc)})
+
+
+def _resolve_agent_or_404(agent_id: str):
+    if agent_id not in AGENT_IDS:
+        raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_id}")
+    return _get_agent_registry()[agent_id]
+
+
+@app.post("/agents/{agent_id}/stream")
+async def agent_stream_endpoint(agent_id: str, req: AgentStreamRequest) -> StreamingResponse:
+    _resolve_agent_or_404(agent_id)
+    thread_id = make_thread_id(req.user_id, agent_id, req.job_id)
+    config = _traced_graph_config(f"agent-{agent_id}-stream", thread_id, req.user_id)
+    payload = {"user_id": req.user_id, "job_id": req.job_id, "input": req.input}
+    return StreamingResponse(
+        _agent_event_stream(agent_id, payload, config), media_type="text/event-stream"
+    )
+
+
+@app.post("/agents/{agent_id}/resume")
+async def agent_resume_endpoint(agent_id: str, req: AgentResumeRequest) -> StreamingResponse:
+    _resolve_agent_or_404(agent_id)
+    user_id = req.thread_id.split(":", 1)[0]
+    config = _traced_graph_config(f"agent-{agent_id}-resume", req.thread_id, user_id)
+    return StreamingResponse(
+        _agent_event_stream(agent_id, Command(resume=req.payload), config),
+        media_type="text/event-stream",
+    )
 
 
 async def _assistant_event_stream(payload: dict, config: dict):

--- a/services/agent/tests/test_agent_registry.py
+++ b/services/agent/tests/test_agent_registry.py
@@ -1,0 +1,106 @@
+"""Behavioral tests for the specialist graph registry and generic routes."""
+
+from fastapi.testclient import TestClient
+
+import app.main as main
+from app.config import settings
+from app.graph.registry import AGENT_IDS, build_registry, make_thread_id
+
+
+def test_registry_has_exactly_the_four_specialist_ids():
+    assert AGENT_IDS == ("feed-curator", "resume-tailor", "apply-copilot", "connection-scout")
+    registry = build_registry()
+    assert set(registry) == set(AGENT_IDS)
+    assert len({id(graph) for graph in registry.values()}) == 4
+
+
+def test_thread_id_is_user_agent_and_optional_job_scoped():
+    assert make_thread_id("u1", "feed-curator") == "u1:feed-curator"
+    assert make_thread_id("u1", "feed-curator", "job-7") == "u1:feed-curator:job-7"
+
+
+def test_keyless_echo_stream_returns_status_and_result(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", None)
+    with TestClient(main.app) as client:
+        response = client.post(
+            "/agents/feed-curator/stream",
+            json={"user_id": "u1", "job_id": "job-7", "input": {"query": "python"}},
+        )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert "event: status" in response.text
+    assert '"status": "done"' in response.text
+    assert "event: result" in response.text
+    assert '"agent_id": "feed-curator"' in response.text
+    assert '"echo": {"query": "python"}' in response.text
+
+
+def test_unknown_agent_is_404_before_stream(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", None)
+    with TestClient(main.app) as client:
+        response = client.post("/agents/not-an-agent/stream", json={"user_id": "u1", "input": {}})
+    assert response.status_code == 404
+
+
+def test_lifespan_builds_and_clears_specialist_registry(monkeypatch):
+    built = {}
+    sentinel = {"feed-curator": object()}
+
+    def fake_build(**kwargs):
+        built["kwargs"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr(main, "build_registry", fake_build)
+    main._agent_registry = None
+    with TestClient(main.app):
+        assert main._agent_registry is sentinel
+        assert "checkpointer" in built["kwargs"]
+    assert main._agent_registry is None
+
+
+def test_resume_stream_passes_command_payload_and_thread_id_to_graph(monkeypatch):
+    captured = {}
+
+    class FakeState:
+        values = {"status": "done", "output": {"agent_id": "feed-curator"}}
+
+    class FakeGraph:
+        async def astream(self, payload, config, stream_mode=None):
+            captured["payload"] = payload
+            captured["config"] = config
+            yield {"echo": {"status": "done"}}
+
+        async def aget_state(self, config):
+            return FakeState()
+
+    monkeypatch.setattr(settings, "agent_api_key", None)
+    monkeypatch.setattr(main, "build_registry", lambda **_kwargs: {"feed-curator": FakeGraph()})
+    with TestClient(main.app) as client:
+        response = client.post(
+            "/agents/feed-curator/resume",
+            json={"thread_id": "u1:feed-curator:job-7", "payload": {"approved": True}},
+        )
+    assert response.status_code == 200
+    assert "event: result" in response.text
+    assert captured["payload"].resume == {"approved": True}
+    assert captured["config"]["configurable"]["thread_id"] == "u1:feed-curator:job-7"
+
+
+def test_agent_routes_require_the_shared_key(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", "secret")
+    with TestClient(main.app) as client:
+        assert client.post("/agents/feed-curator/stream", json={"user_id": "u1"}).status_code == 401
+        assert (
+            client.post(
+                "/agents/feed-curator/stream",
+                json={"user_id": "u1"},
+                headers={"Authorization": "Bearer wrong"},
+            ).status_code
+            == 401
+        )
+        response = client.post(
+            "/agents/feed-curator/stream",
+            json={"user_id": "u1"},
+            headers={"Authorization": "Bearer secret"},
+        )
+    assert response.status_code == 200


### PR DESCRIPTION
Closes #253.

## What changed

- Added the four specialist LangGraph registry entries: `feed-curator`, `resume-tailor`, `apply-copilot`, and `connection-scout`.
- Added shared specialist run state, stable tenant/agent/job thread IDs, lifespan-owned registry construction, and generic SSE stream/resume endpoints.
- Added API upstream clients and an authenticated, tenant-safe SSE proxy with strict rate limiting and daily-budget enforcement.
- Kept echo stubs keyless and zero-cost: model configuration is resolved for its label but no model is invoked.
- Preserved existing assistant and legacy agent routes.

## Review-driven fixes

- Return 502 when an otherwise-successful upstream response has no SSE body.
- Reject cross-user and lookalike resume thread IDs using an exact/colon-delimited boundary.
- Guard both normal and trailing-slash stream/resume paths, with app-level coverage proving config routes do not consume run guards.

## Verification

- `npm test`: API 265 passed; web 108 passed.
- `npm run check`: lint/typecheck/build exited 0. One pre-existing web lint warning remains outside this diff.
- `python -m pytest tests/ -q`: 268 passed, 5 skipped.
- `python -m ruff check app tests`: clean.
- `git diff --check`: clean.

## Scope boundaries

Durable specialist checkpoints/store remain #254. Real specialist pipelines, Langfuse/budget internals, assistant specialist tools, and web UI remain later tickets.