### PR TITLE
feat(agent): add durable checkpoint and specialist memory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 DATABASE_URL=
 AZURE_STORAGE_CONNECTION_STRING=
 AZURE_STORAGE_CONTAINER_NAME=
+# LangGraph durable checkpoint/Store setup. DATABASE_URL deployments run both
+# idempotent setup steps by default; set false only when the schema is managed
+# separately. Retention is a positive number of days (default 30).
+AGENT_RUN_SETUP_ON_BOOT=true
+CHECKPOINT_RETENTION_DAYS=30
 # When set, the Node API delegates AI analysis to the Python agent service
 # (services/agent). Leave blank to use the built-in deterministic mock.
 AGENT_SERVICE_URL=http://127.0.0.1:8000

--- a/services/agent/.env.example
+++ b/services/agent/.env.example
@@ -22,6 +22,11 @@ GEMINI_MODEL=gemini-2.0-flash
 
 # RAG (Phase 10) — reuse the same Postgres as the Node API
 DATABASE_URL=
+# LangGraph durable checkpoint/Store setup. DATABASE_URL deployments run both
+# idempotent setup steps by default; set false only when the schema is managed
+# separately. Retention is a positive number of days (default 30).
+AGENT_RUN_SETUP_ON_BOOT=true
+CHECKPOINT_RETENTION_DAYS=30
 
 # RAG retrieval tuning (Phase 4). Defaults shown; all optional.
 # RAG_RETRIEVAL_MODE: "hybrid" (dense pgvector + Postgres FTS via RRF) or "vector" (dense only).

--- a/services/agent/app/config.py
+++ b/services/agent/app/config.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Literal
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -38,6 +39,10 @@ class Settings(BaseSettings):
 
     # Shared
     database_url: str | None = None
+    # LangGraph durable-memory setup. When a database is configured, startup
+    # fails closed if either backend cannot be opened or compiled.
+    agent_run_setup_on_boot: bool = True
+    checkpoint_retention_days: int = Field(default=30, gt=0)
     request_timeout: int = 60
     llm_temperature: float = 0.2
 

--- a/services/agent/app/graph/memory.py
+++ b/services/agent/app/graph/memory.py
@@ -1,0 +1,199 @@
+"""Durable LangGraph checkpoint and long-term memory helpers.
+
+The Postgres imports intentionally live inside :func:`open_durable_backends` so
+the agent can keep its dependency-light, in-memory local/CI mode. A configured
+database has exactly one pool shared by the assistant saver, specialist saver,
+and Store for the lifetime of the FastAPI application.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+__all__ = [
+    "agent_namespace",
+    "open_durable_backends",
+    "profile_namespace",
+    "prune_checkpoints",
+]
+
+
+def profile_namespace(user_id: str) -> tuple[str, str, str]:
+    """Return the shared profile namespace.
+
+    The four specialist agents may read this namespace for resume, preference,
+    and constraint context. Profile writes remain outside the specialist
+    graphs, so this helper documents the namespace as read-only to them.
+    """
+
+    return ("user", user_id, "profile")
+
+
+def agent_namespace(user_id: str, agent_id: str) -> tuple[str, str, str]:
+    """Return the private long-term-memory namespace for one specialist."""
+
+    return ("user", user_id, agent_id)
+
+
+async def _close_pool(pool: Any) -> None:
+    """Close a pool while preserving the original startup/maintenance error."""
+
+    try:
+        await pool.close()
+    except BaseException:
+        # The operation which caused startup to fail is more useful to callers
+        # than a secondary teardown exception. The pool close was still tried.
+        pass
+
+
+async def open_durable_backends(
+    database_url: str,
+    *,
+    agent_run_setup_on_boot: bool = True,
+):
+    """Open one pgbouncer-safe pool and its saver/Store pair.
+
+    PostgreSQL dependencies are imported lazily here. ``setup()`` is idempotent
+    and is controlled only by ``AGENT_RUN_SETUP_ON_BOOT``; when enabled, both
+    the checkpoint saver and long-term Store schemas are initialized before the
+    tuple is returned. Any error after pool construction closes that pool before
+    re-raising, so callers never receive a partially initialized backend.
+    """
+
+    # Keep all PostgreSQL imports in this function: importing app.main without a
+    # DATABASE_URL must remain possible in the light CI image.
+    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+    from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+    from langgraph.store.postgres.aio import AsyncPostgresStore
+    from psycopg.rows import dict_row
+    from psycopg_pool import AsyncConnectionPool
+
+    pool = None
+    try:
+        # ``prepare_threshold=0`` avoids server-side prepared statements through
+        # transaction/statement poolers. Autocommit is required by the installed
+        # checkpointer migrations, including CREATE INDEX CONCURRENTLY.
+        pool = AsyncConnectionPool(
+            conninfo=database_url,
+            max_size=10,
+            open=False,
+            kwargs={
+                "autocommit": True,
+                "prepare_threshold": 0,
+                "row_factory": dict_row,
+            },
+        )
+        await pool.open()
+
+        # Restrict checkpoint deserialization to LangGraph's safe built-in types;
+        # the permissive serializer would allow arbitrary msgpack modules.
+        serde = JsonPlusSerializer(allowed_msgpack_modules=None)
+        saver = AsyncPostgresSaver(pool, serde=serde)
+        store = AsyncPostgresStore(pool)
+        if agent_run_setup_on_boot:
+            await saver.setup()
+            await store.setup()
+        return pool, saver, store
+    except BaseException:
+        if pool is not None:
+            await _close_pool(pool)
+        raise
+
+
+async def _delete_returning_count(cursor: Any, statement: str, params: tuple[Any, ...]) -> int:
+    """Execute a DELETE...RETURNING statement and count deleted rows."""
+
+    await cursor.execute(statement, params)
+    return len(await cursor.fetchall())
+
+
+async def prune_checkpoints(
+    pool: Any,
+    retention_days: int,
+    *,
+    now: datetime | None = None,
+) -> dict[str, int]:
+    """Delete expired checkpoints and unreferenced checkpoint payload rows.
+
+    The installed ``langgraph-checkpoint-postgres==3.1.0`` schema stores the
+    checkpoint timestamp in ``checkpoints.checkpoint->>'ts'``. The three tables
+    are locked in ``SHARE ROW EXCLUSIVE`` mode for one transaction: this blocks
+    saver writes and serializes concurrent maintenance calls while the expired
+    checkpoints and orphan writes/blobs are selected, preventing a current
+    checkpoint from losing a payload during the sweep. Store rows are
+    intentionally untouched.
+    """
+
+    if isinstance(retention_days, bool) or retention_days <= 0:
+        raise ValueError("retention_days must be a positive integer")
+
+    if now is None:
+        now = datetime.now(UTC)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    else:
+        now = now.astimezone(UTC)
+    cutoff = now - timedelta(days=retention_days)
+
+    async with pool.connection() as connection:
+        async with connection.transaction():
+            async with connection.cursor() as cursor:
+                # SHARE ROW EXCLUSIVE conflicts with the ROW EXCLUSIVE locks
+                # taken by saver INSERT/UPDATE statements and with another
+                # maintenance run. All three tables are included because writes
+                # can be persisted independently via ``aput_writes``.
+                # Match the saver's blob -> checkpoint write order to avoid a
+                # lock-order cycle when a checkpoint is being persisted while
+                # maintenance starts.
+                await cursor.execute(
+                    "LOCK TABLE checkpoint_blobs, checkpoints, checkpoint_writes "
+                    "IN SHARE ROW EXCLUSIVE MODE"
+                )
+                checkpoints_deleted = await _delete_returning_count(
+                    cursor,
+                    """
+                    DELETE FROM checkpoints
+                    WHERE (checkpoint->>'ts')::timestamptz < %s
+                    RETURNING thread_id, checkpoint_ns, checkpoint_id
+                    """,
+                    (cutoff,),
+                )
+                writes_deleted = await _delete_returning_count(
+                    cursor,
+                    """
+                    DELETE FROM checkpoint_writes AS writes
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM checkpoints AS checkpoints
+                        WHERE checkpoints.thread_id = writes.thread_id
+                          AND checkpoints.checkpoint_ns = writes.checkpoint_ns
+                          AND checkpoints.checkpoint_id = writes.checkpoint_id
+                    )
+                    RETURNING thread_id, checkpoint_ns, checkpoint_id, task_id, idx
+                    """,
+                    (),
+                )
+                blobs_deleted = await _delete_returning_count(
+                    cursor,
+                    """
+                    DELETE FROM checkpoint_blobs AS blobs
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM checkpoints AS checkpoints
+                        WHERE checkpoints.thread_id = blobs.thread_id
+                          AND checkpoints.checkpoint_ns = blobs.checkpoint_ns
+                          AND checkpoints.checkpoint->'channel_versions'->>blobs.channel
+                              = blobs.version
+                    )
+                    RETURNING thread_id, checkpoint_ns, channel, version
+                    """,
+                    (),
+                )
+
+    return {
+        "checkpoints_deleted": int(checkpoints_deleted),
+        "writes_deleted": int(writes_deleted),
+        "blobs_deleted": int(blobs_deleted),
+        "retention_days": int(retention_days),
+    }

--- a/services/agent/app/graph/memory.py
+++ b/services/agent/app/graph/memory.py
@@ -87,6 +87,7 @@ async def open_durable_backends(
             },
         )
         await pool.open()
+        await pool.wait()
 
         # Restrict checkpoint deserialization to LangGraph's safe built-in types;
         # the permissive serializer would allow arbitrary msgpack modules.
@@ -190,12 +191,17 @@ async def prune_checkpoints(
                     WHERE writes.ctid IN (
                         SELECT candidate.ctid
                         FROM checkpoint_writes AS candidate
+                        -- Legacy LangGraph checkpoints can load pending sends
+                        -- from a surviving child's parent checkpoint.
                         WHERE NOT EXISTS (
                             SELECT 1
                             FROM checkpoints AS checkpoints
                             WHERE checkpoints.thread_id = candidate.thread_id
                               AND checkpoints.checkpoint_ns = candidate.checkpoint_ns
-                              AND checkpoints.checkpoint_id = candidate.checkpoint_id
+                              AND (
+                                  checkpoints.checkpoint_id = candidate.checkpoint_id
+                                  OR checkpoints.parent_checkpoint_id = candidate.checkpoint_id
+                              )
                         )
                         ORDER BY candidate.thread_id, candidate.checkpoint_ns,
                                  candidate.checkpoint_id, candidate.task_id,

--- a/services/agent/app/graph/memory.py
+++ b/services/agent/app/graph/memory.py
@@ -18,6 +18,8 @@ __all__ = [
     "prune_checkpoints",
 ]
 
+_PRUNE_BATCH_SIZE = 1_000
+
 
 def profile_namespace(user_id: str) -> tuple[str, str, str]:
     """Return the shared profile namespace.
@@ -101,11 +103,27 @@ async def open_durable_backends(
         raise
 
 
-async def _delete_returning_count(cursor: Any, statement: str, params: tuple[Any, ...]) -> int:
-    """Execute a DELETE...RETURNING statement and count deleted rows."""
+async def _delete_in_batches(
+    cursor: Any,
+    statement: str,
+    params: tuple[Any, ...],
+    *,
+    batch_size: int = _PRUNE_BATCH_SIZE,
+) -> int:
+    """Delete bounded batches and count rows from the server-provided rowcount."""
 
-    await cursor.execute(statement, params)
-    return len(await cursor.fetchall())
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+
+    deleted_total = 0
+    while True:
+        await cursor.execute(statement, (*params, batch_size))
+        deleted = cursor.rowcount
+        if deleted is None or deleted < 0:
+            raise RuntimeError("database did not provide a DELETE row count")
+        deleted_total += deleted
+        if deleted < batch_size:
+            return deleted_total
 
 
 async def prune_checkpoints(
@@ -142,51 +160,70 @@ async def prune_checkpoints(
                 # SHARE ROW EXCLUSIVE conflicts with the ROW EXCLUSIVE locks
                 # taken by saver INSERT/UPDATE statements and with another
                 # maintenance run. All three tables are included because writes
-                # can be persisted independently via ``aput_writes``.
-                # Match the saver's blob -> checkpoint write order to avoid a
-                # lock-order cycle when a checkpoint is being persisted while
-                # maintenance starts.
+                # can be persisted independently via ``aput_writes``. Keep this
+                # order identical to AsyncPostgresSaver.adelete_thread
+                # (checkpoints, blobs, writes), so concurrent maintenance and
+                # thread deletion cannot form a lock-order cycle.
                 await cursor.execute(
-                    "LOCK TABLE checkpoint_blobs, checkpoints, checkpoint_writes "
+                    "LOCK TABLE checkpoints, checkpoint_blobs, checkpoint_writes "
                     "IN SHARE ROW EXCLUSIVE MODE"
                 )
-                checkpoints_deleted = await _delete_returning_count(
+                checkpoints_deleted = await _delete_in_batches(
                     cursor,
                     """
-                    DELETE FROM checkpoints
-                    WHERE (checkpoint->>'ts')::timestamptz < %s
-                    RETURNING thread_id, checkpoint_ns, checkpoint_id
+                    DELETE FROM checkpoints AS checkpoints
+                    WHERE checkpoints.ctid IN (
+                        SELECT candidate.ctid
+                        FROM checkpoints AS candidate
+                        WHERE (candidate.checkpoint->>'ts')::timestamptz < %s
+                        ORDER BY candidate.thread_id, candidate.checkpoint_ns,
+                                 candidate.checkpoint_id
+                        LIMIT %s
+                    )
                     """,
                     (cutoff,),
                 )
-                writes_deleted = await _delete_returning_count(
+                writes_deleted = await _delete_in_batches(
                     cursor,
                     """
                     DELETE FROM checkpoint_writes AS writes
-                    WHERE NOT EXISTS (
-                        SELECT 1
-                        FROM checkpoints AS checkpoints
-                        WHERE checkpoints.thread_id = writes.thread_id
-                          AND checkpoints.checkpoint_ns = writes.checkpoint_ns
-                          AND checkpoints.checkpoint_id = writes.checkpoint_id
+                    WHERE writes.ctid IN (
+                        SELECT candidate.ctid
+                        FROM checkpoint_writes AS candidate
+                        WHERE NOT EXISTS (
+                            SELECT 1
+                            FROM checkpoints AS checkpoints
+                            WHERE checkpoints.thread_id = candidate.thread_id
+                              AND checkpoints.checkpoint_ns = candidate.checkpoint_ns
+                              AND checkpoints.checkpoint_id = candidate.checkpoint_id
+                        )
+                        ORDER BY candidate.thread_id, candidate.checkpoint_ns,
+                                 candidate.checkpoint_id, candidate.task_id,
+                                 candidate.idx
+                        LIMIT %s
                     )
-                    RETURNING thread_id, checkpoint_ns, checkpoint_id, task_id, idx
                     """,
                     (),
                 )
-                blobs_deleted = await _delete_returning_count(
+                blobs_deleted = await _delete_in_batches(
                     cursor,
                     """
                     DELETE FROM checkpoint_blobs AS blobs
-                    WHERE NOT EXISTS (
-                        SELECT 1
-                        FROM checkpoints AS checkpoints
-                        WHERE checkpoints.thread_id = blobs.thread_id
-                          AND checkpoints.checkpoint_ns = blobs.checkpoint_ns
-                          AND checkpoints.checkpoint->'channel_versions'->>blobs.channel
-                              = blobs.version
+                    WHERE blobs.ctid IN (
+                        SELECT candidate.ctid
+                        FROM checkpoint_blobs AS candidate
+                        WHERE NOT EXISTS (
+                            SELECT 1
+                            FROM checkpoints AS checkpoints
+                            WHERE checkpoints.thread_id = candidate.thread_id
+                              AND checkpoints.checkpoint_ns = candidate.checkpoint_ns
+                              AND checkpoints.checkpoint->'channel_versions'->>
+                                  candidate.channel = candidate.version
+                        )
+                        ORDER BY candidate.thread_id, candidate.checkpoint_ns,
+                                 candidate.channel, candidate.version
+                        LIMIT %s
                     )
-                    RETURNING thread_id, checkpoint_ns, channel, version
                     """,
                     (),
                 )

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -27,6 +27,7 @@ from app.chains.score_fit import score_fit
 from app.chains.weekly import weekly_recommendations
 from app.config import settings
 from app.graph.assistant import build_assistant_graph
+from app.graph.memory import open_durable_backends, prune_checkpoints
 from app.graph.registry import AGENT_IDS, build_registry, make_thread_id
 from app.llm.provider import LLMNotConfigured, get_model, llm_available, resolve_provider
 from app.obs import traced_config, traced_span
@@ -82,88 +83,63 @@ def _configure_app_insights() -> bool:
 _configure_app_insights()
 
 
-# --- Assistant graph + durable HITL checkpointer (QA·D) ---------------------
-# The assistant graph is checkpointed so a run can pause at the human-review
-# interrupt and resume later — possibly on a different instance or after a
-# restart. With DATABASE_URL set we persist those checkpoints in Postgres
-# (durable); otherwise we fall back to an in-memory saver (lost on restart).
-# The Postgres saver is async-only, so the assistant run/resume/stream paths
-# all drive the graph through its async API (ainvoke/astream/aget_state).
+# --- Graphs + shared durable memory ------------------------------------------
+# The assistant and specialist graphs share one checkpointer for the lifetime
+# of the service. With DATABASE_URL set it is an AsyncPostgresSaver backed by
+# one pool, alongside one AsyncPostgresStore; local/light-CI runs use an
+# InMemorySaver and no Store.
 _assistant_graph = None
 _checkpointer_pool = None
+_checkpointer_saver = None
+_agent_store = None
 _agent_registry = None
-
-
-async def _build_durable_assistant_graph():
-    """Build the assistant graph backed by a Postgres checkpointer.
-
-    Returns ``(graph, pool)``; the caller owns closing ``pool`` on shutdown.
-    Postgres deps are imported lazily so the light CI test job (which runs
-    without DATABASE_URL and omits requirements-rag.txt) never imports them.
-    Raises on any connection/setup failure so callers can fall back to memory.
-    """
-    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
-    from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
-    from psycopg.rows import dict_row
-    from psycopg_pool import AsyncConnectionPool
-
-    # The saver requires autocommit + dict rows + no server-side prepared
-    # statements (the latter keeps it pgbouncer-safe). open=False so we can
-    # await .open() explicitly and surface connection errors here.
-    pool = AsyncConnectionPool(
-        conninfo=settings.database_url,
-        max_size=10,
-        open=False,
-        kwargs={"autocommit": True, "prepare_threshold": 0, "row_factory": dict_row},
-    )
-    await pool.open()
-    # If setup() fails after a successful open() (e.g. the role can't CREATE
-    # TABLE), close the pool here — the caller never receives it, so its
-    # `finally` can't, and the open connections would otherwise leak.
-    try:
-        # Strict msgpack: restrict checkpoint deserialization to a built-in
-        # allowlist of safe types. The default is permissive, which lets anyone
-        # who can write checkpoint rows trigger code execution on resume. Our
-        # graph only persists JSON-native state plus langgraph control types
-        # (Interrupt/Command/…), all of which are in the safe allowlist.
-        serde = JsonPlusSerializer(allowed_msgpack_modules=None)
-        saver = AsyncPostgresSaver(pool, serde=serde)
-        await saver.setup()  # idempotent: creates the checkpoint tables if absent
-        return build_assistant_graph(checkpointer=saver), pool
-    except Exception:
-        await pool.close()
-        raise
 
 
 @asynccontextmanager
 async def _lifespan(_app: FastAPI):
-    """Upgrade the assistant graph to the durable Postgres checkpointer on
-    startup when DATABASE_URL is set; degrade to the in-memory saver on any
-    failure so a checkpointer outage never blocks the service from starting."""
-    global _assistant_graph, _checkpointer_pool, _agent_registry
+    """Build all graphs with one shared saver/Store and close one pool."""
+    global _assistant_graph, _checkpointer_pool, _checkpointer_saver, _agent_store, _agent_registry
+    # Reset state before every startup so repeated lifespan tests and reloads do
+    # not accidentally reuse graphs tied to an old event loop or pool.
+    _assistant_graph = None
+    _checkpointer_pool = None
+    _checkpointer_saver = None
+    _agent_store = None
+    _agent_registry = None
     # Fail closed: refuse to start on a public cloud runtime with auth disabled.
     assert_auth_configured()
-    if settings.database_url:
-        try:
-            _assistant_graph, _checkpointer_pool = await _build_durable_assistant_graph()
-            logger.info("assistant HITL checkpointer: durable (Postgres)")
-        except Exception:  # noqa: BLE001 - degrade gracefully, never block startup
-            logger.warning(
-                "durable HITL checkpointer unavailable; using in-memory saver "
-                "(in-flight runs will not survive a restart)",
-                exc_info=True,
-            )
-    _agent_registry = build_registry(checkpointer=InMemorySaver())
     try:
+        if settings.database_url:
+            (
+                _checkpointer_pool,
+                _checkpointer_saver,
+                _agent_store,
+            ) = await open_durable_backends(
+                settings.database_url,
+                agent_run_setup_on_boot=settings.agent_run_setup_on_boot,
+            )
+            logger.info("assistant and specialist checkpointer: durable (Postgres)")
+        else:
+            _checkpointer_saver = InMemorySaver()
+
+        _assistant_graph = build_assistant_graph(checkpointer=_checkpointer_saver)
+        _agent_registry = build_registry(
+            checkpointer=_checkpointer_saver,
+            store=_agent_store,
+        )
         yield
     finally:
-        if _checkpointer_pool is not None:
+        pool = _checkpointer_pool
+        _assistant_graph = None
+        _checkpointer_pool = None
+        _checkpointer_saver = None
+        _agent_store = None
+        _agent_registry = None
+        if pool is not None:
             try:
-                await _checkpointer_pool.close()
+                await pool.close()
             except Exception:  # noqa: BLE001 - never let teardown raise on shutdown
                 logger.warning("error closing HITL checkpointer pool", exc_info=True)
-            _checkpointer_pool = None
-        _agent_registry = None
 
 
 app = FastAPI(
@@ -189,6 +165,18 @@ async def _enforce_agent_key(request: Request, call_next):
         )
         return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
     return await call_next(request)
+
+
+@app.post("/maintenance/prune-checkpoints")
+async def prune_checkpoints_endpoint() -> dict[str, int]:
+    """Prune expired durable checkpoints; require an active shared pool."""
+
+    if _checkpointer_pool is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Checkpoint pruning requires an active durable Postgres backend.",
+        )
+    return await prune_checkpoints(_checkpointer_pool, settings.checkpoint_retention_days)
 
 
 def _require_llm() -> None:

--- a/services/agent/pyproject.toml
+++ b/services/agent/pyproject.toml
@@ -18,3 +18,6 @@ select = ["E", "F", "I", "UP", "B"]
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
+markers = [
+    "postgres: requires a configured Postgres database",
+]

--- a/services/agent/tests/test_agent_memory.py
+++ b/services/agent/tests/test_agent_memory.py
@@ -75,6 +75,9 @@ def test_open_durable_backends_uses_one_pool_and_runs_both_setups(monkeypatch):
         async def open(self):
             calls["opened"] = True
 
+        async def wait(self):
+            calls["waited"] = True
+
         async def close(self):
             self.closed += 1
             calls["closed"] = self.closed
@@ -112,6 +115,7 @@ def test_open_durable_backends_uses_one_pool_and_runs_both_setups(monkeypatch):
     )
 
     assert calls["opened"] is True
+    assert calls["waited"] is True
     assert calls["saver_pool"] is pool
     assert calls["store_pool"] is pool
     assert calls["saver_setup"] == 1
@@ -126,6 +130,101 @@ def test_open_durable_backends_uses_one_pool_and_runs_both_setups(monkeypatch):
     assert "untrusted" in decoded
     assert not isinstance(decoded, Exception)
     assert saver is not store
+
+
+def test_open_durable_backends_waits_for_pool_when_setup_is_disabled(monkeypatch):
+    checkpoint_aio = pytest.importorskip("langgraph.checkpoint.postgres.aio")
+    store_aio = pytest.importorskip("langgraph.store.postgres.aio")
+    psycopg_pool = pytest.importorskip("psycopg_pool")
+
+    calls: list[str] = []
+
+    class FakePool:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def open(self):
+            calls.append("open")
+
+        async def wait(self):
+            calls.append("wait")
+
+        async def close(self):
+            calls.append("close")
+
+    class FakeSaver:
+        def __init__(self, pool, serde=None):
+            calls.append("saver")
+
+        async def setup(self):
+            calls.append("saver_setup")
+
+    class FakeStore:
+        def __init__(self, pool):
+            calls.append("store")
+
+        async def setup(self):
+            calls.append("store_setup")
+
+    monkeypatch.setattr(psycopg_pool, "AsyncConnectionPool", FakePool)
+    monkeypatch.setattr(checkpoint_aio, "AsyncPostgresSaver", FakeSaver)
+    monkeypatch.setattr(store_aio, "AsyncPostgresStore", FakeStore)
+
+    from app.graph.memory import open_durable_backends
+
+    asyncio.run(
+        open_durable_backends(
+            "postgresql://example/db",
+            agent_run_setup_on_boot=False,
+        )
+    )
+
+    assert calls == ["open", "wait", "saver", "store"]
+
+
+def test_open_durable_backends_closes_pool_when_readiness_fails(monkeypatch):
+    checkpoint_aio = pytest.importorskip("langgraph.checkpoint.postgres.aio")
+    store_aio = pytest.importorskip("langgraph.store.postgres.aio")
+    psycopg_pool = pytest.importorskip("psycopg_pool")
+
+    state = {"closed": 0}
+
+    class FakePool:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def open(self):
+            pass
+
+        async def wait(self):
+            raise RuntimeError("pool readiness failed")
+
+        async def close(self):
+            state["closed"] += 1
+
+    class FakeSaver:
+        def __init__(self, pool, serde=None):
+            raise AssertionError("backends must not be built before readiness")
+
+    class FakeStore:
+        def __init__(self, pool):
+            raise AssertionError("backends must not be built before readiness")
+
+    monkeypatch.setattr(psycopg_pool, "AsyncConnectionPool", FakePool)
+    monkeypatch.setattr(checkpoint_aio, "AsyncPostgresSaver", FakeSaver)
+    monkeypatch.setattr(store_aio, "AsyncPostgresStore", FakeStore)
+
+    from app.graph.memory import open_durable_backends
+
+    with pytest.raises(RuntimeError, match="pool readiness failed"):
+        asyncio.run(
+            open_durable_backends(
+                "postgresql://example/db",
+                agent_run_setup_on_boot=False,
+            )
+        )
+
+    assert state["closed"] == 1
 
 
 def test_pruning_counts_rows_without_fetching_deleted_keys():
@@ -275,6 +374,9 @@ def test_open_durable_backends_skips_setup_when_disabled(monkeypatch):
         async def open(self):
             pass
 
+        async def wait(self):
+            pass
+
         async def close(self):
             self.closed += 1
 
@@ -317,6 +419,9 @@ def test_open_durable_backends_closes_before_propagating_setup_failure(monkeypat
             pass
 
         async def open(self):
+            pass
+
+        async def wait(self):
             pass
 
         async def close(self):
@@ -643,6 +748,127 @@ def test_postgres_pruning_preserves_current_checkpoint_data():
                             "DELETE FROM checkpoints WHERE thread_id IN (%s, %s, %s)",
                             (old_thread, new_thread, orphan_thread),
                         )
+            await pool.close()
+
+    _run(run())
+
+
+@pytest.mark.postgres
+def test_postgres_pruning_preserves_parent_writes_referenced_by_child():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("needs a real Postgres (DATABASE_URL)")
+
+    from app.graph.memory import open_durable_backends, prune_checkpoints
+
+    async def run():
+        suffix = uuid.uuid4().hex
+        thread_id = f"prune-parent-child-{suffix}"
+        parent_id = f"parent-{suffix}"
+        child_id = f"child-{suffix}"
+        orphan_id = f"orphan-{suffix}"
+        pool, _saver, _store = await open_durable_backends(
+            os.environ["DATABASE_URL"],
+            agent_run_setup_on_boot=True,
+        )
+        try:
+            async with pool.connection() as conn:
+                async with conn.transaction():
+                    async with conn.cursor() as cur:
+                        await cur.execute(
+                            """
+                            INSERT INTO checkpoints
+                                (thread_id, checkpoint_ns, checkpoint_id,
+                                 parent_checkpoint_id, checkpoint, metadata)
+                            VALUES
+                                (%s, '', %s, NULL, %s::jsonb, '{}'::jsonb),
+                                (%s, '', %s, %s, %s::jsonb, '{}'::jsonb)
+                            """,
+                            (
+                                thread_id,
+                                parent_id,
+                                '{"v":3,"ts":"2020-01-01T00:00:00+00:00",'
+                                '"channel_versions":{}}',
+                                thread_id,
+                                child_id,
+                                parent_id,
+                                '{"v":3,"ts":"2999-01-01T00:00:00+00:00",'
+                                '"channel_versions":{}}',
+                            ),
+                        )
+                        await cur.execute(
+                            """
+                            INSERT INTO checkpoint_writes
+                                (thread_id, checkpoint_ns, checkpoint_id, task_id, idx,
+                                 channel, type, blob)
+                            VALUES
+                                (%s, '', %s, 'parent-task', 0, '__pregel_tasks', 'json', %s),
+                                (%s, '', %s, 'child-task', 0, 'channel', 'json', %s),
+                                (%s, '', %s, 'orphan-task', 0, 'channel', 'json', %s)
+                            """,
+                            (
+                                thread_id,
+                                parent_id,
+                                b"parent-write",
+                                thread_id,
+                                child_id,
+                                b"child-write",
+                                thread_id,
+                                orphan_id,
+                                b"orphan-write",
+                            ),
+                        )
+
+            result = await prune_checkpoints(
+                pool,
+                30,
+                now=datetime(2025, 1, 1, tzinfo=UTC),
+            )
+            assert result == {
+                "checkpoints_deleted": 1,
+                "writes_deleted": 1,
+                "blobs_deleted": 0,
+                "retention_days": 30,
+            }
+
+            async with pool.connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        """
+                        SELECT checkpoint_id
+                        FROM checkpoints
+                        WHERE thread_id = %s
+                        ORDER BY checkpoint_id
+                        """,
+                        (thread_id,),
+                    )
+                    assert await cur.fetchall() == [{"checkpoint_id": child_id}]
+
+                    await cur.execute(
+                        """
+                        SELECT checkpoint_id, blob
+                        FROM checkpoint_writes
+                        WHERE thread_id = %s
+                        ORDER BY checkpoint_id
+                        """,
+                        (thread_id,),
+                    )
+                    assert await cur.fetchall() == [
+                        {"checkpoint_id": child_id, "blob": b"child-write"},
+                        {"checkpoint_id": parent_id, "blob": b"parent-write"},
+                    ]
+        finally:
+            async with pool.connection() as conn:
+                async with conn.transaction():
+                    async with conn.cursor() as cur:
+                        for table in (
+                            "checkpoints",
+                            "checkpoint_blobs",
+                            "checkpoint_writes",
+                        ):
+                            await cur.execute(
+                                f"DELETE FROM {table} WHERE thread_id = %s",
+                                (thread_id,),
+                            )
             await pool.close()
 
     _run(run())

--- a/services/agent/tests/test_agent_memory.py
+++ b/services/agent/tests/test_agent_memory.py
@@ -1,0 +1,562 @@
+"""Focused tests for durable LangGraph memory and checkpoint maintenance."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main as main
+from app.config import Settings, settings
+from app.graph.memory import agent_namespace, profile_namespace
+
+
+def _run(coro):
+    """Use psycopg's supported selector loop on Windows integration runs."""
+
+    if sys.platform == "win32":
+        selector_policy = getattr(asyncio, "WindowsSelectorEventLoopPolicy", None)
+        if selector_policy is not None:
+            previous_policy = asyncio.get_event_loop_policy()
+            asyncio.set_event_loop_policy(selector_policy())
+            try:
+                return asyncio.run(coro)
+            finally:
+                asyncio.set_event_loop_policy(previous_policy)
+    return asyncio.run(coro)
+
+
+def test_namespaces_preserve_the_platform_contract():
+    assert profile_namespace("user-1") == ("user", "user-1", "profile")
+    assert agent_namespace("user-1", "resume-tailor") == (
+        "user",
+        "user-1",
+        "resume-tailor",
+    )
+
+
+def test_memory_settings_default_to_setup_and_thirty_day_retention():
+    configured = Settings(_env_file=None)
+
+    assert configured.agent_run_setup_on_boot is True
+    assert configured.checkpoint_retention_days == 30
+
+
+def test_memory_settings_read_environment_and_reject_non_positive_retention(monkeypatch):
+    monkeypatch.setenv("AGENT_RUN_SETUP_ON_BOOT", "false")
+    monkeypatch.setenv("CHECKPOINT_RETENTION_DAYS", "45")
+
+    configured = Settings(_env_file=None)
+    assert configured.agent_run_setup_on_boot is False
+    assert configured.checkpoint_retention_days == 45
+
+    with pytest.raises(ValueError):
+        Settings(_env_file=None, checkpoint_retention_days=0)
+
+
+def test_open_durable_backends_uses_one_pool_and_runs_both_setups(monkeypatch):
+    checkpoint_aio = pytest.importorskip("langgraph.checkpoint.postgres.aio")
+    store_aio = pytest.importorskip("langgraph.store.postgres.aio")
+    psycopg_pool = pytest.importorskip("psycopg_pool")
+
+    calls: dict[str, object] = {}
+
+    class FakePool:
+        def __init__(self, *args, **kwargs):
+            calls["pool_args"] = args
+            calls["pool_kwargs"] = kwargs
+            self.closed = 0
+
+        async def open(self):
+            calls["opened"] = True
+
+        async def close(self):
+            self.closed += 1
+            calls["closed"] = self.closed
+
+    class FakeSaver:
+        def __init__(self, pool, serde=None):
+            calls["saver_pool"] = pool
+            calls["serde"] = serde
+            self.setup_calls = 0
+
+        async def setup(self):
+            self.setup_calls += 1
+            calls["saver_setup"] = self.setup_calls
+
+    class FakeStore:
+        def __init__(self, pool):
+            calls["store_pool"] = pool
+            self.setup_calls = 0
+
+        async def setup(self):
+            self.setup_calls += 1
+            calls["store_setup"] = self.setup_calls
+
+    monkeypatch.setattr(psycopg_pool, "AsyncConnectionPool", FakePool)
+    monkeypatch.setattr(checkpoint_aio, "AsyncPostgresSaver", FakeSaver)
+    monkeypatch.setattr(store_aio, "AsyncPostgresStore", FakeStore)
+
+    from app.graph.memory import open_durable_backends
+
+    pool, saver, store = asyncio.run(
+        open_durable_backends(
+            "postgresql://example/db",
+            agent_run_setup_on_boot=True,
+        )
+    )
+
+    assert calls["opened"] is True
+    assert calls["saver_pool"] is pool
+    assert calls["store_pool"] is pool
+    assert calls["saver_setup"] == 1
+    assert calls["store_setup"] == 1
+    assert calls["pool_kwargs"]["open"] is False
+    assert calls["pool_kwargs"]["kwargs"]["autocommit"] is True
+    assert calls["pool_kwargs"]["kwargs"]["prepare_threshold"] == 0
+    assert calls["serde"]._allowed_msgpack_modules is not True
+    assert saver is not store
+
+
+def test_open_durable_backends_skips_setup_when_disabled(monkeypatch):
+    checkpoint_aio = pytest.importorskip("langgraph.checkpoint.postgres.aio")
+    store_aio = pytest.importorskip("langgraph.store.postgres.aio")
+    psycopg_pool = pytest.importorskip("psycopg_pool")
+
+    class FakePool:
+        def __init__(self, *args, **kwargs):
+            self.closed = 0
+
+        async def open(self):
+            pass
+
+        async def close(self):
+            self.closed += 1
+
+    class FakeSaver:
+        def __init__(self, pool, serde=None):
+            self.setup_calls = 0
+
+        async def setup(self):
+            self.setup_calls += 1
+
+    class FakeStore(FakeSaver):
+        def __init__(self, pool):
+            self.setup_calls = 0
+
+    monkeypatch.setattr(psycopg_pool, "AsyncConnectionPool", FakePool)
+    monkeypatch.setattr(checkpoint_aio, "AsyncPostgresSaver", FakeSaver)
+    monkeypatch.setattr(store_aio, "AsyncPostgresStore", FakeStore)
+
+    from app.graph.memory import open_durable_backends
+
+    _pool, saver, store = asyncio.run(
+        open_durable_backends(
+            "postgresql://example/db",
+            agent_run_setup_on_boot=False,
+        )
+    )
+    assert saver.setup_calls == 0
+    assert store.setup_calls == 0
+
+
+def test_open_durable_backends_closes_before_propagating_setup_failure(monkeypatch):
+    checkpoint_aio = pytest.importorskip("langgraph.checkpoint.postgres.aio")
+    store_aio = pytest.importorskip("langgraph.store.postgres.aio")
+    psycopg_pool = pytest.importorskip("psycopg_pool")
+
+    state = {"closed": 0}
+
+    class FakePool:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def open(self):
+            pass
+
+        async def close(self):
+            state["closed"] += 1
+
+    class FailingSaver:
+        def __init__(self, pool, serde=None):
+            pass
+
+        async def setup(self):
+            raise RuntimeError("setup failed")
+
+    class FakeStore:
+        def __init__(self, pool):
+            pass
+
+    monkeypatch.setattr(psycopg_pool, "AsyncConnectionPool", FakePool)
+    monkeypatch.setattr(checkpoint_aio, "AsyncPostgresSaver", FailingSaver)
+    monkeypatch.setattr(store_aio, "AsyncPostgresStore", FakeStore)
+
+    from app.graph.memory import open_durable_backends
+
+    with pytest.raises(RuntimeError, match="setup failed"):
+        asyncio.run(
+            open_durable_backends(
+                "postgresql://example/db",
+                agent_run_setup_on_boot=True,
+            )
+        )
+    assert state["closed"] == 1
+
+
+def test_lifespan_wires_one_in_memory_saver_without_database(monkeypatch):
+    captured: dict[str, object] = {}
+    sentinel_registry = {"feed-curator": object()}
+
+    def fake_assistant(**kwargs):
+        captured["assistant"] = kwargs
+        return object()
+
+    def fake_registry(**kwargs):
+        captured["registry"] = kwargs
+        return sentinel_registry
+
+    monkeypatch.setattr(settings, "database_url", None)
+    monkeypatch.setattr(main, "build_assistant_graph", fake_assistant)
+    monkeypatch.setattr(main, "build_registry", fake_registry)
+
+    with TestClient(main.app):
+        assert main._agent_registry is sentinel_registry
+        assert captured["assistant"]["checkpointer"] is captured["registry"]["checkpointer"]
+        assert captured["registry"]["store"] is None
+        assert main._checkpointer_pool is None
+
+    assert main._assistant_graph is None
+    assert main._agent_registry is None
+
+
+def test_lifespan_wires_one_durable_saver_and_store(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class FakePool:
+        def __init__(self):
+            self.closed = 0
+
+        async def close(self):
+            self.closed += 1
+
+    pool = FakePool()
+    saver = object()
+    store = object()
+
+    async def fake_open(url, *, agent_run_setup_on_boot):
+        captured["open"] = (url, agent_run_setup_on_boot)
+        return pool, saver, store
+
+    def fake_assistant(**kwargs):
+        captured["assistant"] = kwargs
+        return object()
+
+    def fake_registry(**kwargs):
+        captured["registry"] = kwargs
+        return {"feed-curator": object()}
+
+    monkeypatch.setattr(settings, "database_url", "postgresql://example/db")
+    monkeypatch.setattr(settings, "agent_run_setup_on_boot", False)
+    monkeypatch.setattr(main, "open_durable_backends", fake_open)
+    monkeypatch.setattr(main, "build_assistant_graph", fake_assistant)
+    monkeypatch.setattr(main, "build_registry", fake_registry)
+
+    with TestClient(main.app):
+        assert captured["open"] == ("postgresql://example/db", False)
+        assert captured["assistant"] == {"checkpointer": saver}
+        assert captured["registry"] == {"checkpointer": saver, "store": store}
+        assert main._checkpointer_pool is pool
+
+    assert pool.closed == 1
+    assert main._checkpointer_pool is None
+
+
+def test_configured_database_startup_failure_propagates_after_pool_cleanup(monkeypatch):
+    class FakePool:
+        def __init__(self):
+            self.closed = 0
+
+        async def close(self):
+            self.closed += 1
+
+    pool = FakePool()
+
+    async def fake_open(*_args, **_kwargs):
+        return pool, object(), object()
+
+    def boom(**_kwargs):
+        raise RuntimeError("graph compilation failed")
+
+    monkeypatch.setattr(settings, "database_url", "postgresql://example/db")
+    monkeypatch.setattr(main, "open_durable_backends", fake_open)
+    monkeypatch.setattr(main, "build_assistant_graph", boom)
+
+    with pytest.raises(RuntimeError, match="graph compilation failed"):
+        with TestClient(main.app):
+            pass
+    assert pool.closed == 1
+    assert main._checkpointer_pool is None
+
+
+def test_pruning_endpoint_returns_503_without_active_durable_pool(monkeypatch):
+    monkeypatch.setattr(settings, "database_url", None)
+    with TestClient(main.app) as client:
+        response = client.post("/maintenance/prune-checkpoints")
+
+    assert response.status_code == 503
+    assert "durable" in response.json()["detail"].lower()
+
+
+def test_pruning_endpoint_uses_the_existing_auth_middleware(monkeypatch):
+    monkeypatch.setattr(settings, "agent_api_key", "secret")
+    monkeypatch.setattr(settings, "database_url", None)
+    with TestClient(main.app) as client:
+        assert client.post("/maintenance/prune-checkpoints").status_code == 401
+        response = client.post(
+            "/maintenance/prune-checkpoints",
+            headers={"Authorization": "Bearer secret"},
+        )
+
+    assert response.status_code == 503
+
+
+def test_pruning_endpoint_delegates_retention_and_counts(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class FakePool:
+        async def close(self):
+            pass
+
+    pool = FakePool()
+
+    async def fake_open(*_args, **_kwargs):
+        return pool, object(), object()
+
+    async def fake_prune(active_pool, retention_days):
+        captured["args"] = (active_pool, retention_days)
+        return {
+            "checkpoints_deleted": 2,
+            "writes_deleted": 3,
+            "blobs_deleted": 4,
+            "retention_days": retention_days,
+        }
+
+    monkeypatch.setattr(settings, "database_url", "postgresql://example/db")
+    monkeypatch.setattr(settings, "checkpoint_retention_days", 9)
+    monkeypatch.setattr(main, "open_durable_backends", fake_open)
+    monkeypatch.setattr(main, "prune_checkpoints", fake_prune)
+    monkeypatch.setattr(main, "build_assistant_graph", lambda **_kwargs: object())
+    monkeypatch.setattr(main, "build_registry", lambda **_kwargs: {"feed-curator": object()})
+
+    with TestClient(main.app) as client:
+        response = client.post("/maintenance/prune-checkpoints")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "checkpoints_deleted": 2,
+        "writes_deleted": 3,
+        "blobs_deleted": 4,
+        "retention_days": 9,
+    }
+    assert captured["args"] == (pool, 9)
+
+
+@pytest.mark.postgres
+def test_postgres_store_round_trip_in_private_agent_namespace():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("needs a real Postgres (DATABASE_URL)")
+
+    from app.graph.memory import open_durable_backends
+
+    async def run():
+        pool, _saver, store = await open_durable_backends(
+            os.environ["DATABASE_URL"],
+            agent_run_setup_on_boot=True,
+        )
+        try:
+            namespace = agent_namespace("memory-test", "apply-copilot")
+            await store.aput(namespace, "round-trip", {"answer": "grounded"})
+            item = await store.aget(namespace, "round-trip")
+            assert item is not None
+            assert item.value == {"answer": "grounded"}
+        finally:
+            await store.adelete(namespace, "round-trip")
+            await pool.close()
+
+    _run(run())
+
+
+@pytest.mark.postgres
+def test_postgres_pruning_preserves_current_checkpoint_data():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("needs a real Postgres (DATABASE_URL)")
+
+    from app.graph.memory import open_durable_backends, prune_checkpoints
+
+    async def run():
+        suffix = uuid.uuid4().hex
+        old_thread = f"prune-old-{suffix}"
+        new_thread = f"prune-new-{suffix}"
+        orphan_thread = f"prune-orphan-{suffix}"
+        pool, _saver, _store = await open_durable_backends(
+            os.environ["DATABASE_URL"],
+            agent_run_setup_on_boot=True,
+        )
+        try:
+            async with pool.connection() as conn:
+                async with conn.transaction():
+                    async with conn.cursor() as cur:
+                        await cur.execute(
+                            """
+                            INSERT INTO checkpoints
+                                (thread_id, checkpoint_ns, checkpoint_id, checkpoint, metadata)
+                            VALUES
+                                (%s, %s, %s, %s::jsonb, '{}'::jsonb),
+                                (%s, %s, %s, %s::jsonb, '{}'::jsonb)
+                            ON CONFLICT DO NOTHING
+                            """,
+                            (
+                                old_thread,
+                                "",
+                                "old",
+                                '{"ts":"2020-01-01T00:00:00+00:00","channel_versions":{"old":"1"}}',
+                                new_thread,
+                                "",
+                                "new",
+                                '{"ts":"2999-01-01T00:00:00+00:00","channel_versions":{"new":"2"}}',
+                            ),
+                        )
+                        await cur.execute(
+                            """
+                            INSERT INTO checkpoint_writes
+                                (thread_id, checkpoint_ns, checkpoint_id, task_id, idx,
+                                 channel, type, blob)
+                            VALUES (%s, '', 'old', 'task', 0, 'old', 'json', %s),
+                                   (%s, '', 'new', 'task', 0, 'new', 'json', %s),
+                                       (%s, '', 'missing', 'task', 0, 'none', 'json', %s)
+                            ON CONFLICT DO NOTHING
+                            """,
+                            (old_thread, b"old", new_thread, b"new", orphan_thread, b"orphan"),
+                        )
+                        await cur.execute(
+                            """
+                            INSERT INTO checkpoint_blobs
+                                (thread_id, checkpoint_ns, channel, version, type, blob)
+                            VALUES (%s, '', 'old', '1', 'json', %s),
+                                   (%s, '', 'new', '2', 'json', %s),
+                                   (%s, '', 'none', '1', 'json', %s)
+                            ON CONFLICT DO NOTHING
+                            """,
+                            (old_thread, b"old", new_thread, b"new", orphan_thread, b"orphan"),
+                        )
+
+            result = await prune_checkpoints(
+                pool,
+                30,
+                now=datetime(2025, 1, 1, tzinfo=UTC),
+            )
+            assert result == {
+                "checkpoints_deleted": 1,
+                "writes_deleted": 2,
+                "blobs_deleted": 2,
+                "retention_days": 30,
+            }
+
+            async with pool.connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        "SELECT checkpoint_id FROM checkpoints WHERE thread_id = %s",
+                        (new_thread,),
+                    )
+                    assert await cur.fetchone() == {"checkpoint_id": "new"}
+                    await cur.execute(
+                        "SELECT COUNT(*) AS count FROM checkpoint_writes "
+                        "WHERE thread_id = %s",
+                        (new_thread,),
+                    )
+                    assert (await cur.fetchone())["count"] == 1
+                    await cur.execute(
+                        "SELECT COUNT(*) AS count FROM checkpoint_blobs "
+                        "WHERE thread_id = %s",
+                        (new_thread,),
+                    )
+                    assert (await cur.fetchone())["count"] == 1
+        finally:
+            async with pool.connection() as conn:
+                async with conn.transaction():
+                    async with conn.cursor() as cur:
+                        await cur.execute(
+                            "DELETE FROM checkpoint_writes WHERE thread_id IN (%s, %s, %s)",
+                            (old_thread, new_thread, orphan_thread),
+                        )
+                        await cur.execute(
+                            "DELETE FROM checkpoint_blobs WHERE thread_id IN (%s, %s, %s)",
+                            (old_thread, new_thread, orphan_thread),
+                        )
+                        await cur.execute(
+                            "DELETE FROM checkpoints WHERE thread_id IN (%s, %s, %s)",
+                            (old_thread, new_thread, orphan_thread),
+                        )
+            await pool.close()
+
+    _run(run())
+
+
+@pytest.mark.postgres
+def test_postgres_interrupt_resumes_through_a_new_pool_and_graph():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("needs a real Postgres (DATABASE_URL)")
+
+    from langgraph.graph import END, START, StateGraph
+    from langgraph.types import Command, interrupt
+    from typing_extensions import TypedDict
+
+    from app.graph.memory import open_durable_backends
+
+    class State(TypedDict, total=False):
+        approved: bool
+
+    def review(state: State) -> dict:
+        decision = interrupt({"reason": "test"})
+        return {"approved": bool(decision.get("approved"))}
+
+    def build(saver):
+        builder = StateGraph(State)
+        builder.add_node("review", review)
+        builder.add_edge(START, "review")
+        builder.add_edge("review", END)
+        return builder.compile(checkpointer=saver)
+
+    async def run():
+        config = {
+            "configurable": {
+                "thread_id": f"restart-test:apply-copilot:{uuid.uuid4().hex}"
+            }
+        }
+        pool, saver, _store = await open_durable_backends(
+            os.environ["DATABASE_URL"],
+            agent_run_setup_on_boot=True,
+        )
+        try:
+            first = await build(saver).ainvoke({}, config)
+            assert "__interrupt__" in first
+        finally:
+            await pool.close()
+
+        pool, saver, _store = await open_durable_backends(
+            os.environ["DATABASE_URL"],
+            agent_run_setup_on_boot=True,
+        )
+        try:
+            resumed = await build(saver).ainvoke(Command(resume={"approved": True}), config)
+            assert resumed["approved"] is True
+        finally:
+            await pool.close()
+
+    _run(run())

--- a/services/agent/tests/test_agent_memory.py
+++ b/services/agent/tests/test_agent_memory.py
@@ -119,8 +119,148 @@ def test_open_durable_backends_uses_one_pool_and_runs_both_setups(monkeypatch):
     assert calls["pool_kwargs"]["open"] is False
     assert calls["pool_kwargs"]["kwargs"]["autocommit"] is True
     assert calls["pool_kwargs"]["kwargs"]["prepare_threshold"] == 0
-    assert calls["serde"]._allowed_msgpack_modules is not True
+    unsafe_serializer = calls["serde"].__class__(allowed_msgpack_modules=True)
+    type_tag, payload = unsafe_serializer.dumps_typed(Exception("untrusted"))
+    decoded = calls["serde"].loads_typed((type_tag, payload))
+    assert isinstance(decoded, str)
+    assert "untrusted" in decoded
+    assert not isinstance(decoded, Exception)
     assert saver is not store
+
+
+def test_pruning_counts_rows_without_fetching_deleted_keys():
+    from app.graph.memory import _delete_in_batches
+
+    class FakeCursor:
+        def __init__(self):
+            self.rowcount = 2
+            self.execute_calls = 0
+
+        async def execute(self, _statement, _params):
+            self.execute_calls += 1
+            if self.execute_calls == 2:
+                self.rowcount = 0
+
+        async def fetchall(self):
+            raise AssertionError("pruning must count on the server, not fetch keys")
+
+    cursor = FakeCursor()
+    count = asyncio.run(_delete_in_batches(cursor, "DELETE ...", (), batch_size=2))
+
+    assert count == 2
+    assert cursor.execute_calls == 2
+
+
+def test_pruning_uses_saver_compatible_checkpoint_lock_order():
+    from app.graph.memory import prune_checkpoints
+
+    class FakeCursor:
+        def __init__(self):
+            self.statements = []
+            self.rowcount = 0
+
+        async def execute(self, statement, _params=()):
+            self.statements.append(statement)
+
+        async def fetchall(self):
+            return []
+
+    class CursorContext:
+        def __init__(self, cursor):
+            self.cursor = cursor
+
+        async def __aenter__(self):
+            return self.cursor
+
+        async def __aexit__(self, *_args):
+            return False
+
+    class TransactionContext(CursorContext):
+        pass
+
+    class FakeConnection:
+        def __init__(self, cursor):
+            self.cursor_value = cursor
+
+        def transaction(self):
+            return TransactionContext(self.cursor_value)
+
+        def cursor(self):
+            return CursorContext(self.cursor_value)
+
+    class ConnectionContext:
+        def __init__(self, connection):
+            self.connection_value = connection
+
+        async def __aenter__(self):
+            return self.connection_value
+
+        async def __aexit__(self, *_args):
+            return False
+
+    cursor = FakeCursor()
+    connection = FakeConnection(cursor)
+
+    class FakePool:
+        def connection(self):
+            return ConnectionContext(connection)
+
+    asyncio.run(prune_checkpoints(FakePool(), 30))
+
+    lock_statement = cursor.statements[0]
+    assert lock_statement.index("checkpoints") < lock_statement.index("checkpoint_blobs")
+    assert lock_statement.index("checkpoint_blobs") < lock_statement.index("checkpoint_writes")
+
+
+@pytest.mark.postgres
+def test_postgres_pruning_and_saver_deletion_complete_concurrently():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("needs a real Postgres (DATABASE_URL)")
+
+    from app.graph.memory import open_durable_backends, prune_checkpoints
+
+    async def run():
+        thread_id = f"concurrent-delete:{uuid.uuid4().hex}"
+        pool, saver, _store = await open_durable_backends(
+            os.environ["DATABASE_URL"],
+            agent_run_setup_on_boot=True,
+        )
+        try:
+            async with pool.connection() as conn:
+                async with conn.transaction():
+                    async with conn.cursor() as cur:
+                        await cur.execute(
+                            """
+                            INSERT INTO checkpoints
+                                (thread_id, checkpoint_ns, checkpoint_id, checkpoint, metadata)
+                            VALUES (%s, '', 'checkpoint', %s::jsonb, '{}'::jsonb)
+                            """,
+                            (
+                                thread_id,
+                                '{"ts":"2999-01-01T00:00:00+00:00",'
+                                '"channel_versions":{}}',
+                            ),
+                        )
+
+            await asyncio.wait_for(
+                asyncio.gather(
+                    prune_checkpoints(pool, 30, now=datetime(2025, 1, 1, tzinfo=UTC)),
+                    saver.adelete_thread(thread_id),
+                ),
+                timeout=10,
+            )
+        finally:
+            async with pool.connection() as conn:
+                async with conn.transaction():
+                    async with conn.cursor() as cur:
+                        for table in ("checkpoints", "checkpoint_blobs", "checkpoint_writes"):
+                            await cur.execute(
+                                f"DELETE FROM {table} WHERE thread_id = %s",
+                                (thread_id,),
+                            )
+            await pool.close()
+
+    _run(run())
 
 
 def test_open_durable_backends_skips_setup_when_disabled(monkeypatch):
@@ -557,6 +697,19 @@ def test_postgres_interrupt_resumes_through_a_new_pool_and_graph():
             resumed = await build(saver).ainvoke(Command(resume={"approved": True}), config)
             assert resumed["approved"] is True
         finally:
+            thread_id = config["configurable"]["thread_id"]
+            async with pool.connection() as conn:
+                async with conn.transaction():
+                    async with conn.cursor() as cur:
+                        for table in (
+                            "checkpoints",
+                            "checkpoint_blobs",
+                            "checkpoint_writes",
+                        ):
+                            await cur.execute(
+                                f"DELETE FROM {table} WHERE thread_id = %s",
+                                (thread_id,),
+                            )
             await pool.close()
 
     _run(run())

--- a/services/agent/tests/test_assistant_checkpointer.py
+++ b/services/agent/tests/test_assistant_checkpointer.py
@@ -194,4 +194,9 @@ def test_open_durable_backends_keeps_strict_msgpack_serializer(monkeypatch):
     from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 
     assert isinstance(captured["serde"], JsonPlusSerializer)
-    assert captured["serde"]._allowed_msgpack_modules is not True
+    unsafe_serializer = JsonPlusSerializer(allowed_msgpack_modules=True)
+    type_tag, payload = unsafe_serializer.dumps_typed(Exception("untrusted"))
+    decoded = captured["serde"].loads_typed((type_tag, payload))
+    assert isinstance(decoded, str)
+    assert "untrusted" in decoded
+    assert not isinstance(decoded, Exception)

--- a/services/agent/tests/test_assistant_checkpointer.py
+++ b/services/agent/tests/test_assistant_checkpointer.py
@@ -122,6 +122,9 @@ def test_open_durable_backends_closes_pool_when_setup_fails(monkeypatch):
         async def open(self):
             pass
 
+        async def wait(self):
+            pass
+
         async def close(self):
             closed["value"] = True
 
@@ -164,6 +167,9 @@ def test_open_durable_backends_keeps_strict_msgpack_serializer(monkeypatch):
             pass
 
         async def open(self):
+            pass
+
+        async def wait(self):
             pass
 
         async def close(self):

--- a/services/agent/tests/test_assistant_checkpointer.py
+++ b/services/agent/tests/test_assistant_checkpointer.py
@@ -1,9 +1,4 @@
-"""QA·D — durable HITL checkpointer wiring + graceful fallback.
-
-The real Postgres saver can't run in CI, so these tests exercise the lifespan
-logic around it: durable when DATABASE_URL + build succeed, in-memory fallback
-when it's unset or the build fails, and the pool always closed on shutdown.
-"""
+"""Assistant checkpointer wiring after the shared-memory foundation refactor."""
 
 import asyncio
 
@@ -11,79 +6,116 @@ import pytest
 from fastapi.testclient import TestClient
 
 import app.main as main
+from app.config import settings
 
 
 @pytest.fixture(autouse=True)
-def _restore_singleton():
-    """Lifespan mutates module globals; isolate each test from the others."""
-    graph, pool = main._assistant_graph, main._checkpointer_pool
-    main._assistant_graph, main._checkpointer_pool = None, None
+def _restore_singletons():
+    saved = (
+        main._assistant_graph,
+        main._checkpointer_pool,
+        main._checkpointer_saver,
+        main._agent_store,
+        main._agent_registry,
+    )
+    main._assistant_graph = None
+    main._checkpointer_pool = None
+    main._checkpointer_saver = None
+    main._agent_store = None
+    main._agent_registry = None
     yield
-    main._assistant_graph, main._checkpointer_pool = graph, pool
+    (
+        main._assistant_graph,
+        main._checkpointer_pool,
+        main._checkpointer_saver,
+        main._agent_store,
+        main._agent_registry,
+    ) = saved
 
 
-def test_no_database_url_falls_back_to_in_memory(monkeypatch):
-    monkeypatch.setattr(main.settings, "database_url", None)
+def test_no_database_url_builds_in_memory_assistant_and_specialists(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(settings, "database_url", None)
+    monkeypatch.setattr(
+        main,
+        "build_assistant_graph",
+        lambda **kwargs: captured.setdefault("assistant", kwargs) or object(),
+    )
+    monkeypatch.setattr(
+        main,
+        "build_registry",
+        lambda **kwargs: captured.setdefault("registry", kwargs) or {"feed-curator": object()},
+    )
+
     with TestClient(main.app):
-        # Lifespan ran but built nothing durable.
-        assert main._assistant_graph is None
         assert main._checkpointer_pool is None
-        # The lazy fallback still yields a working (in-memory) graph.
-        assert hasattr(main._get_assistant_graph(), "ainvoke")
+        assert captured["assistant"]["checkpointer"] is captured["registry"]["checkpointer"]
+        assert captured["registry"]["store"] is None
 
 
-def test_durable_graph_used_when_available(monkeypatch):
-    sentinel_graph = object()
-
-    class _FakePool:
+def test_durable_saver_is_shared_by_assistant_and_registry(monkeypatch):
+    class FakePool:
         def __init__(self):
-            self.closed = False
+            self.close_calls = 0
 
         async def close(self):
-            self.closed = True
+            self.close_calls += 1
 
-    pool = _FakePool()
+    pool = FakePool()
+    saver = object()
+    store = object()
+    captured = {}
 
-    async def _fake_build():
-        return sentinel_graph, pool
+    async def fake_open(database_url, *, agent_run_setup_on_boot):
+        captured["open"] = (database_url, agent_run_setup_on_boot)
+        return pool, saver, store
 
-    monkeypatch.setattr(main.settings, "database_url", "postgresql://x/db")
-    monkeypatch.setattr(main, "_build_durable_assistant_graph", _fake_build)
+    monkeypatch.setattr(settings, "database_url", "postgresql://x/db")
+    monkeypatch.setattr(settings, "agent_run_setup_on_boot", False)
+    monkeypatch.setattr(main, "open_durable_backends", fake_open)
+    monkeypatch.setattr(
+        main,
+        "build_assistant_graph",
+        lambda **kwargs: captured.setdefault("assistant", kwargs) or object(),
+    )
+    monkeypatch.setattr(
+        main,
+        "build_registry",
+        lambda **kwargs: captured.setdefault("registry", kwargs) or {"feed-curator": object()},
+    )
 
     with TestClient(main.app):
-        assert main._assistant_graph is sentinel_graph
-        assert main._get_assistant_graph() is sentinel_graph
+        assert captured["open"] == ("postgresql://x/db", False)
+        assert captured["assistant"] == {"checkpointer": saver}
+        assert captured["registry"] == {"checkpointer": saver, "store": store}
 
-    # Pool closed and reset on shutdown.
-    assert pool.closed is True
+    assert pool.close_calls == 1
     assert main._checkpointer_pool is None
 
 
-def test_degrades_when_durable_build_fails(monkeypatch):
-    async def _boom():
+def test_configured_database_failure_fails_startup_instead_of_downgrading(monkeypatch):
+    async def boom(*_args, **_kwargs):
         raise RuntimeError("postgres unreachable")
 
-    monkeypatch.setattr(main.settings, "database_url", "postgresql://x/db")
-    monkeypatch.setattr(main, "_build_durable_assistant_graph", _boom)
+    monkeypatch.setattr(settings, "database_url", "postgresql://x/db")
+    monkeypatch.setattr(main, "open_durable_backends", boom)
 
-    with TestClient(main.app) as client:
-        # Startup did not crash; service still serves.
-        assert client.get("/health").status_code == 200
-        # No durable graph -> lazy in-memory fallback applies.
-        assert main._assistant_graph is None
-        assert main._checkpointer_pool is None
+    with pytest.raises(RuntimeError, match="postgres unreachable"):
+        with TestClient(main.app):
+            pass
+    assert main._assistant_graph is None
+    assert main._checkpointer_pool is None
 
 
-def test_build_closes_pool_when_setup_fails(monkeypatch):
-    """If the pool opens but setup() fails, the build must close the pool
-    itself — the caller never receives it, so it can't be torn down later."""
-    # Skip on the light CI job, which omits requirements-rag.txt (no PG deps).
+def test_open_durable_backends_closes_pool_when_setup_fails(monkeypatch):
     pg_aio = pytest.importorskip("langgraph.checkpoint.postgres.aio")
+    store_aio = pytest.importorskip("langgraph.store.postgres.aio")
     psycopg_pool = pytest.importorskip("psycopg_pool")
 
     closed = {"value": False}
 
-    class _FakePool:
+    class FakePool:
         def __init__(self, *args, **kwargs):
             pass
 
@@ -93,33 +125,41 @@ def test_build_closes_pool_when_setup_fails(monkeypatch):
         async def close(self):
             closed["value"] = True
 
-    class _FakeSaver:
+    class FakeSaver:
         def __init__(self, pool, serde=None):
             pass
 
         async def setup(self):
             raise RuntimeError("role cannot CREATE TABLE")
 
-    monkeypatch.setattr(main.settings, "database_url", "postgresql://x/db")
-    monkeypatch.setattr(psycopg_pool, "AsyncConnectionPool", _FakePool)
-    monkeypatch.setattr(pg_aio, "AsyncPostgresSaver", _FakeSaver)
+    class FakeStore:
+        def __init__(self, pool):
+            pass
 
-    with pytest.raises(RuntimeError):
-        asyncio.run(main._build_durable_assistant_graph())
+    monkeypatch.setattr(psycopg_pool, "AsyncConnectionPool", FakePool)
+    monkeypatch.setattr(pg_aio, "AsyncPostgresSaver", FakeSaver)
+    monkeypatch.setattr(store_aio, "AsyncPostgresStore", FakeStore)
+
+    from app.graph.memory import open_durable_backends
+
+    with pytest.raises(RuntimeError, match="role cannot CREATE TABLE"):
+        asyncio.run(
+            open_durable_backends(
+                "postgresql://x/db",
+                agent_run_setup_on_boot=True,
+            )
+        )
     assert closed["value"] is True
 
 
-def test_build_uses_strict_msgpack_serializer(monkeypatch):
-    """The durable saver must be built with a strict (allowlisted) serializer,
-    so tampered checkpoint rows can't trigger code execution on resume."""
-    # Skip on the light CI job, which omits requirements-rag.txt (no PG deps).
+def test_open_durable_backends_keeps_strict_msgpack_serializer(monkeypatch):
     pg_aio = pytest.importorskip("langgraph.checkpoint.postgres.aio")
+    store_aio = pytest.importorskip("langgraph.store.postgres.aio")
     psycopg_pool = pytest.importorskip("psycopg_pool")
-    from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 
     captured = {}
 
-    class _FakePool:
+    class FakePool:
         def __init__(self, *args, **kwargs):
             pass
 
@@ -129,24 +169,29 @@ def test_build_uses_strict_msgpack_serializer(monkeypatch):
         async def close(self):
             pass
 
-    class _FakeSaver:
+    class FakeSaver:
         def __init__(self, pool, serde=None):
             captured["serde"] = serde
 
         async def setup(self):
             pass
 
-    monkeypatch.setattr(main.settings, "database_url", "postgresql://x/db")
-    monkeypatch.setattr(psycopg_pool, "AsyncConnectionPool", _FakePool)
-    monkeypatch.setattr(pg_aio, "AsyncPostgresSaver", _FakeSaver)
-    # Bypass compile-time checkpointer validation (our fake saver isn't a real
-    # BaseCheckpointSaver); the serde is already captured at saver construction.
-    monkeypatch.setattr(main, "build_assistant_graph", lambda checkpointer=None: object())
+    class FakeStore:
+        def __init__(self, pool):
+            pass
 
-    asyncio.run(main._build_durable_assistant_graph())
+        async def setup(self):
+            pass
 
-    serde = captured["serde"]
-    assert isinstance(serde, JsonPlusSerializer)
-    # Permissive (default, unsafe) mode keeps the marker `True`; strict mode
-    # narrows it to a built-in allowlist (here, None == SAFE_MSGPACK_TYPES only).
-    assert serde._allowed_msgpack_modules is not True
+    monkeypatch.setattr(psycopg_pool, "AsyncConnectionPool", FakePool)
+    monkeypatch.setattr(pg_aio, "AsyncPostgresSaver", FakeSaver)
+    monkeypatch.setattr(store_aio, "AsyncPostgresStore", FakeStore)
+
+    from app.graph.memory import open_durable_backends
+
+    asyncio.run(open_durable_backends("postgresql://x/db"))
+
+    from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+    assert isinstance(captured["serde"], JsonPlusSerializer)
+    assert captured["serde"]._allowed_msgpack_modules is not True


### PR DESCRIPTION
Closes #254.

## What changed

- Added one lifespan-owned, pgbouncer-safe Postgres pool shared by the assistant checkpointer, all four specialist graphs, and `AsyncPostgresStore`.
- Added exact shared-profile/private-agent namespace helpers and retained strict checkpoint deserialization.
- Added `AGENT_RUN_SETUP_ON_BOOT` and `CHECKPOINT_RETENTION_DAYS` configuration, with local no-database fallback and fail-closed startup when a configured durable backend fails.
- Added authenticated `POST /maintenance/prune-checkpoints` with bounded 1,000-row deletion batches, server-side row counts, orphan cleanup, and saver-compatible lock ordering.
- Added restart/resume, Store round-trip, pruning safety, concurrent thread-deletion, lifespan, endpoint, serializer, and cleanup coverage.

## Review-driven fixes

- Removed unbounded `DELETE ... RETURNING` materialization during pruning.
- Aligned pruning locks with `AsyncPostgresSaver.adelete_thread` and added live concurrency coverage.
- Replaced private serializer-field assertions with public behavior tests.
- Ensured restart tests remove their checkpoint artifacts.

## Verification

- `python -m pytest tests/ -ra`: 282 passed, 9 skipped.
- PostgreSQL-focused memory/checkpointer suite: 23 passed.
- `python -m ruff check app tests`: clean.
- `npm test`: API 266 passed; web 108 passed.
- `npm run check`: lint, typecheck, and production builds exited 0; one pre-existing web lint warning remains outside this diff.
- `git diff --check`: clean.
- Task-scoped review: approved with no findings.
- Final review findings: fixed; scoped re-review confirmed all addressed with no new breakage.

## Scope boundaries

This PR does not add specialist business logic, profile writes, semantic indexing, or cron/ACA wiring. Agent image activation/drift issue #303 remains a separate operations task.