### PR TITLE
feat(agent): assistant chat specialist tools via subagents pattern (#256)

### DIFF
--- a/apps/api/src/routes/assistant-chat.test.ts
+++ b/apps/api/src/routes/assistant-chat.test.ts
@@ -129,7 +129,7 @@ test('rejects an empty messages list', async () => {
 });
 
 test('builds ownership-checked job context from jobId', async () => {
-  let captured: { context?: string } = {};
+  let captured: { context?: string; job_id?: string } = {};
   const calls: Array<[string, string]> = [];
   const router = createAssistantChatRouter({
     getJob: async (userId, jobId) => {
@@ -137,7 +137,7 @@ test('builds ownership-checked job context from jobId', async () => {
       return fakeJob();
     },
     openUpstream: async (payload) => {
-      captured = payload as { context?: string };
+      captured = payload as { context?: string; job_id?: string };
       return okStream();
     },
   });
@@ -149,6 +149,8 @@ test('builds ownership-checked job context from jobId', async () => {
     });
   });
   assert.deepEqual(calls, [['u1', 'job-1']]);
+  assert.equal(captured.job_id, 'job-1');
+  assert.ok(captured.context?.includes('Job ID: job-1'));
   assert.ok(captured.context?.includes('Staff Engineer'));
   assert.ok(captured.context?.includes('Missing skills: Rust'));
 });

--- a/apps/api/src/routes/assistant-chat.ts
+++ b/apps/api/src/routes/assistant-chat.ts
@@ -39,6 +39,7 @@ async function buildJobContext(
 
   const { analysis } = job;
   const lines = [
+    `Job ID: ${job.id}`,
     `Title: ${job.title}`,
     `Company: ${job.company}`,
     `Location: ${job.location} (${job.workplaceType})`,
@@ -89,11 +90,14 @@ export function createAssistantChatRouter(deps: AssistantChatDeps = defaultDeps)
       return;
     }
 
+    const jobId =
+      typeof body.jobId === 'string' && body.jobId.trim() ? body.jobId.trim() : undefined;
+
     // Context build must never break the chat — a failure just omits it.
     let context: string | undefined;
-    if (typeof body.jobId === 'string' && body.jobId.trim()) {
+    if (jobId) {
       try {
-        context = await buildJobContext(deps.getJob, userId, body.jobId.trim());
+        context = await buildJobContext(deps.getJob, userId, jobId);
       } catch {
         context = undefined;
       }
@@ -101,7 +105,12 @@ export function createAssistantChatRouter(deps: AssistantChatDeps = defaultDeps)
 
     let upstream: UpstreamStream;
     try {
-      upstream = await deps.openUpstream({ messages: body.messages, context, user_id: userId });
+      upstream = await deps.openUpstream({
+        messages: body.messages,
+        context,
+        user_id: userId,
+        job_id: jobId,
+      });
     } catch (error) {
       // A disabled agent service (no AGENT_SERVICE_URL) is an expected
       // misconfiguration, not a server fault — surface it as 503 (which the

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -150,7 +150,7 @@ agent image, list pagination, and an opt-in Postgres-backed rate-limiter/cache f
 
 ## What Is Still Pending
 
-- **Jobright Parity Program (Epic #244 — Agent platform foundation):** In progress. Shipped specialist agent registry (#253), per-agent model configs (#251/#252), and durable checkpointing/memory (#254). Implemented per-agent Langfuse tags, per-run token budget with hard abort (`TokenBudgetExceeded`), and recursion-limit defaults on stream/resume configs (#255). Specialist agent graph implementations (Epics 2, 4, 5, 6) remain pending.
+- **Jobright Parity Program (Epic #244 — Agent platform foundation):** In progress. Shipped specialist agent registry (#253), per-agent model configs (#251/#252), durable checkpointing/memory (#254), per-agent Langfuse tags, per-run token budget abort, and recursion-limit defaults (#255). Implemented assistant front-door specialist tools (`run_feed_curation`, `tailor_resume`, `build_application_pack`, `scout_connections`) invoking registry graphs with tenant-scoped thread IDs and bounded tool rounds (#256). Specialist agent graph implementations (Epics 2, 4, 5, 6) remain pending.
 - Nothing blocking. All planned phases (0–11) plus the optional Phase 6
   hardening (App Insights, Key Vault) are complete. The agent Container App
   keeps its native secret store by design (Key Vault covers App Service only).

--- a/services/agent/app/agents/specialist_tools.py
+++ b/services/agent/app/agents/specialist_tools.py
@@ -56,6 +56,7 @@ async def _run_specialist(registry: dict, agent_id: str, user_id: str, payload: 
 def build_specialist_tools(
     registry: dict | None = None,
     user_id: str = "anonymous",
+    default_job_id: str | None = None,
 ) -> list[BaseTool]:
     """The four specialist tools closed over the graph registry and user_id."""
     if isinstance(registry, str) and not isinstance(user_id, dict):
@@ -75,18 +76,27 @@ def build_specialist_tools(
     async def tailor_resume(job_id: str = "") -> str:
         """Start tailoring the user's resume for one job (job_id from the pipeline).
         The tailored resume always requires the user's explicit approval before render."""
-        return await _run_specialist(registry, "resume-tailor", user_id, {"job_id": job_id})
+        effective_job_id = (job_id or "").strip() or (default_job_id or "").strip()
+        return await _run_specialist(
+            registry, "resume-tailor", user_id, {"job_id": effective_job_id}
+        )
 
     @tool
     async def build_application_pack(job_id: str = "") -> str:
         """Assemble the application pack (resume, cover letter, ATS answers) for one job."""
-        return await _run_specialist(registry, "apply-copilot", user_id, {"job_id": job_id})
+        effective_job_id = (job_id or "").strip() or (default_job_id or "").strip()
+        return await _run_specialist(
+            registry, "apply-copilot", user_id, {"job_id": effective_job_id}
+        )
 
     @tool
     async def scout_connections(job_id: str = "") -> str:
         """Find publicly-verifiable people (recruiters, hiring managers, teammates)
         relevant to one job. Public web only; nothing is contacted."""
-        return await _run_specialist(registry, "connection-scout", user_id, {"job_id": job_id})
+        effective_job_id = (job_id or "").strip() or (default_job_id or "").strip()
+        return await _run_specialist(
+            registry, "connection-scout", user_id, {"job_id": effective_job_id}
+        )
 
     return [run_feed_curation, tailor_resume, build_application_pack, scout_connections]
 

--- a/services/agent/app/agents/specialist_tools.py
+++ b/services/agent/app/agents/specialist_tools.py
@@ -1,0 +1,94 @@
+"""Assistant subagent tools -> specialist compiled graphs (Epic 1 / #256).
+
+Each tool closes over the specialist registry and the calling user_id (tenancy).
+Tools invoke the corresponding graph asynchronously with an isolated thread_id
+and return structured JSON so the chat model can reason over the result.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+from langchain_core.tools import BaseTool, tool
+
+from app.config import settings
+from app.obs.agent_tags import tags_for
+
+logger = logging.getLogger("jobops.agent.specialist_tools")
+
+
+def make_chat_tool_thread_id(user_id: str, agent_id: str) -> str:
+    return f"{user_id}:{agent_id}:chat-{uuid.uuid4()}"
+
+
+async def _run_specialist(registry: dict, agent_id: str, user_id: str, payload: dict) -> str:
+    from app.main import _traced_graph_config
+
+    graph = registry.get(agent_id)
+    if graph is None:
+        return json.dumps({"error": f"Specialist agent not available: {agent_id}"})
+
+    thread_id = make_chat_tool_thread_id(user_id, agent_id)
+    config = _traced_graph_config(
+        f"agent-{agent_id}",
+        thread_id,
+        user_id,
+        tags=tags_for(agent_id),
+        recursion_limit=settings.agent_recursion_limit_pipeline,
+    )
+    try:
+        state = await graph.ainvoke(
+            {"user_id": user_id, "input": payload, "status": "running"},
+            config,
+        )
+    except Exception as exc:  # noqa: BLE001 - tool failures must return JSON error
+        logger.exception("specialist %s invocation failed", agent_id)
+        return json.dumps({"error": str(exc)})
+
+    if isinstance(state, dict) and "__interrupt__" in state:
+        return json.dumps({"status": "awaiting_approval", "thread_id": thread_id})
+    if isinstance(state, dict):
+        return json.dumps({"status": state.get("status"), "output": state.get("output")})
+    return json.dumps({"status": "done", "output": state})
+
+
+def build_specialist_tools(
+    registry: dict | None = None,
+    user_id: str = "anonymous",
+) -> list[BaseTool]:
+    """The four specialist tools closed over the graph registry and user_id."""
+    if isinstance(registry, str) and not isinstance(user_id, dict):
+        user_id, registry = registry, user_id
+    if registry is None:
+        from app.main import _get_agent_registry
+
+        registry = _get_agent_registry() or {}
+
+    @tool
+    async def run_feed_curation(query: str = "") -> str:
+        """Score and rank the user's job feed. Use when the user asks to refresh,
+        score, or curate their job matches."""
+        return await _run_specialist(registry, "feed-curator", user_id, {"query": query})
+
+    @tool
+    async def tailor_resume(job_id: str = "") -> str:
+        """Start tailoring the user's resume for one job (job_id from the pipeline).
+        The tailored resume always requires the user's explicit approval before render."""
+        return await _run_specialist(registry, "resume-tailor", user_id, {"job_id": job_id})
+
+    @tool
+    async def build_application_pack(job_id: str = "") -> str:
+        """Assemble the application pack (resume, cover letter, ATS answers) for one job."""
+        return await _run_specialist(registry, "apply-copilot", user_id, {"job_id": job_id})
+
+    @tool
+    async def scout_connections(job_id: str = "") -> str:
+        """Find publicly-verifiable people (recruiters, hiring managers, teammates)
+        relevant to one job. Public web only; nothing is contacted."""
+        return await _run_specialist(registry, "connection-scout", user_id, {"job_id": job_id})
+
+    return [run_feed_curation, tailor_resume, build_application_pack, scout_connections]
+
+
+create_specialist_tools = build_specialist_tools

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -652,7 +652,9 @@ async def _chat_event_stream(req: ChatRequest):
 
         from app.agents.specialist_tools import build_specialist_tools
 
-        tools = build_specialist_tools(_get_agent_registry(), req.user_id or "anonymous")
+        tools = build_specialist_tools(
+            _get_agent_registry(), req.user_id or "anonymous", default_job_id=req.job_id
+        )
         tools_by_name = {t.name: t for t in tools}
         bound = (
             model.bind_tools(tools)

--- a/services/agent/app/main.py
+++ b/services/agent/app/main.py
@@ -647,10 +647,49 @@ async def _chat_event_stream(req: ChatRequest):
         config = traced_config("assistant-chat", user_id=req.user_id, tags=["assistant"])
         config["recursion_limit"] = settings.agent_recursion_limit_chat
         annotate_trace(config, verdict)
-        async for chunk in model.astream(messages, config=config or None):
-            text = _chunk_text(chunk)
-            if text:
-                yield _sse("token", {"text": text})
+
+        from langchain_core.messages import ToolMessage
+
+        from app.agents.specialist_tools import build_specialist_tools
+
+        tools = build_specialist_tools(_get_agent_registry(), req.user_id or "anonymous")
+        tools_by_name = {t.name: t for t in tools}
+        bound = (
+            model.bind_tools(tools)
+            if hasattr(model, "bind_tools") and _get_agent_registry()
+            else model
+        )
+
+        MAX_TOOL_ROUNDS = 3
+        for _round in range(MAX_TOOL_ROUNDS + 1):
+            response = None
+            async for chunk in bound.astream(messages, config=config or None):
+                if response is None:
+                    response = chunk
+                else:
+                    try:
+                        response = response + chunk
+                    except TypeError:
+                        response = chunk
+                text = _chunk_text(chunk)
+                if text:
+                    yield _sse("token", {"text": text})
+            tool_calls = getattr(response, "tool_calls", None) or []
+            if not tool_calls or _round == MAX_TOOL_ROUNDS:
+                break
+            messages.append(response)
+            for call in tool_calls:
+                tool_fn = tools_by_name.get(call["name"])
+                yield _sse("status", {"tool": call["name"], "state": "running"})
+                if tool_fn is None:
+                    result = json.dumps({"error": f"unknown tool {call['name']}"})
+                else:
+                    try:
+                        result = await tool_fn.ainvoke(call["args"])
+                    except Exception as exc:  # noqa: BLE001 - tool failure must not kill the chat
+                        logger.exception("specialist tool %s failed", call["name"])
+                        result = json.dumps({"error": str(exc)})
+                messages.append(ToolMessage(content=result, tool_call_id=call["id"]))
         yield _sse("done", {"model_used": label})
     except Exception as exc:  # noqa: BLE001 - surface streaming failures as an SSE error
         logger.exception("assistant chat stream failed")

--- a/services/agent/app/prompts.py
+++ b/services/agent/app/prompts.py
@@ -99,6 +99,8 @@ Rules:
 - Be practical and brief — short paragraphs or tight bullet lists. No filler or hype.
 - Never fabricate facts about the user, a company, or a role. If you don't know, say so.
 - You are read-only: you can advise, explain, and draft text inline, but you cannot send messages, change records, or run the application's actions. For anything that sends or changes data (e.g. saving outreach, scoring a job), point the user to the relevant app feature.
+
+You have access to specialist tools for feed curation (run_feed_curation), resume tailoring (tailor_resume), application pack assembly (build_application_pack), and connection scouting (scout_connections). These tools operate directly on the user's pipeline data. If an operation produces an approval-gated result, inform the user that it is awaiting their approval; never claim that an outreach message or application was automatically sent or submitted.
 """
 
 TELEMETRY_NARRATION_SYSTEM = """You are a time-series analyst. You are given pre-computed statistics about a metric

--- a/services/agent/app/prompts.py
+++ b/services/agent/app/prompts.py
@@ -98,7 +98,7 @@ Rules:
 - When job context is provided, ground your answer in it; otherwise answer generally and, if a specific job would help, say so.
 - Be practical and brief — short paragraphs or tight bullet lists. No filler or hype.
 - Never fabricate facts about the user, a company, or a role. If you don't know, say so.
-- You are read-only: you can advise, explain, and draft text inline, but you cannot send messages, change records, or run the application's actions. For anything that sends or changes data (e.g. saving outreach, scoring a job), point the user to the relevant app feature.
+- You cannot directly modify records or send communications outside the provided specialist tools. For actions beyond your specialist tools, point the user to the relevant app feature.
 
 You have access to specialist tools for feed curation (run_feed_curation), resume tailoring (tailor_resume), application pack assembly (build_application_pack), and connection scouting (scout_connections). These tools operate directly on the user's pipeline data. If an operation produces an approval-gated result, inform the user that it is awaiting their approval; never claim that an outreach message or application was automatically sent or submitted.
 """

--- a/services/agent/app/schemas.py
+++ b/services/agent/app/schemas.py
@@ -180,6 +180,8 @@ class ChatRequest(BaseModel):
     context: str | None = None
     # Scopes any future per-user grounding; carried through for traceability.
     user_id: str | None = None
+    # Scopes specialist tool executions to the current job (e.g. tailor, apply, scout).
+    job_id: str | None = None
 
 
 # --- Phase 11 telemetry -----------------------------------------------------

--- a/services/agent/tests/test_assistant_chat.py
+++ b/services/agent/tests/test_assistant_chat.py
@@ -114,3 +114,83 @@ def test_chat_refuses_injection_hidden_in_an_earlier_turn(monkeypatch):
     assert res.status_code == 200
     assert "event: done" in res.text
     assert "event: error" not in res.text
+
+
+def test_chat_tool_calling_executes_and_streams_answer(monkeypatch):
+    from langchain_core.messages import AIMessageChunk, ToolCall
+
+    rounds = {"count": 0}
+
+    class _ToolCapableModel:
+        def bind_tools(self, tools):
+            self.tools = tools
+            return self
+
+        async def astream(self, messages, config=None):
+            rounds["count"] += 1
+            if rounds["count"] == 1:
+                chunk = AIMessageChunk(
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            name="run_feed_curation",
+                            args={"query": "python"},
+                            id="call_feed_1",
+                        )
+                    ],
+                )
+                yield chunk
+            else:
+                yield _Chunk("Here are the curated feed results.")
+
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+    monkeypatch.setattr(main, "get_model", lambda: (_ToolCapableModel(), "fake:tool-model"))
+
+    res = client.post(
+        "/assistant/chat",
+        json={"messages": [{"role": "user", "content": "Curate my feed"}]},
+    )
+
+    assert res.status_code == 200
+    assert "event: status" in res.text
+    assert "run_feed_curation" in res.text
+    assert "event: token" in res.text
+    assert "Here are the curated feed results." in res.text
+    assert "event: done" in res.text
+    assert rounds["count"] == 2
+
+
+def test_chat_tool_loop_stops_at_max_rounds(monkeypatch):
+    from langchain_core.messages import AIMessageChunk, ToolCall
+
+    rounds = {"count": 0}
+
+    class _InfiniteToolModel:
+        def bind_tools(self, tools):
+            return self
+
+        async def astream(self, messages, config=None):
+            rounds["count"] += 1
+            yield AIMessageChunk(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        name="run_feed_curation",
+                        args={"query": f"python_{rounds['count']}"},
+                        id=f"call_{rounds['count']}",
+                    )
+                ],
+            )
+
+    monkeypatch.setattr(main, "llm_available", lambda: True)
+    monkeypatch.setattr(main, "get_model", lambda: (_InfiniteToolModel(), "fake:loop-model"))
+
+    res = client.post(
+        "/assistant/chat",
+        json={"messages": [{"role": "user", "content": "Infinite tool loop"}]},
+    )
+
+    assert res.status_code == 200
+    assert "event: done" in res.text
+    # Should stop after MAX_TOOL_ROUNDS (default 3)
+    assert rounds["count"] <= 4

--- a/services/agent/tests/test_specialist_tools.py
+++ b/services/agent/tests/test_specialist_tools.py
@@ -1,0 +1,92 @@
+"""Behavioral tests for assistant specialist tools invoking registry graphs (#256)."""
+
+import json
+
+import pytest
+
+from app.graph.registry import build_registry
+
+
+@pytest.mark.anyio
+async def test_four_tools_with_expected_names():
+    from app.agents.specialist_tools import create_specialist_tools
+
+    tools = create_specialist_tools(user_id="user_123")
+    names = [t.name for t in tools]
+    assert names == [
+        "run_feed_curation",
+        "tailor_resume",
+        "build_application_pack",
+        "scout_connections",
+    ]
+
+
+@pytest.mark.anyio
+async def test_tool_invokes_registry_stub():
+    from app.agents.specialist_tools import create_specialist_tools
+
+    registry = build_registry()
+    tools = create_specialist_tools(user_id="u1", registry=registry)
+
+    feed_tool = tools[0]
+    raw_res = await feed_tool.ainvoke({"query": "python jobs"})
+    res = json.loads(raw_res) if isinstance(raw_res, str) else raw_res
+
+    assert res.get("status") == "done"
+    assert "output" in res
+    assert res["output"]["agent_id"] == "feed-curator"
+    assert res["output"]["echo"] == {"query": "python jobs"}
+
+
+@pytest.mark.anyio
+async def test_missing_registry_entry_fails_closed():
+    from app.agents.specialist_tools import create_specialist_tools
+
+    # Registry missing the feed-curator agent
+    tools = create_specialist_tools(user_id="u1", registry={})
+    feed_tool = tools[0]
+
+    raw_res = await feed_tool.ainvoke({"query": "python jobs"})
+    res = json.loads(raw_res) if isinstance(raw_res, str) else raw_res
+
+    assert "error" in res
+    assert (
+        "not available" in res["error"].lower()
+        or "not found" in res["error"].lower()
+        or "missing" in res["error"].lower()
+    )
+
+
+@pytest.mark.anyio
+async def test_interrupt_returns_awaiting_approval():
+    from app.agents.specialist_tools import create_specialist_tools
+
+    class _InterruptGraph:
+        async def ainvoke(self, payload, config=None):
+            return {
+                "__interrupt__": ("approval_needed",),
+                "status": "awaiting_approval",
+                "output": {"draft": "sample draft"},
+            }
+
+    fake_registry = {"resume-tailor": _InterruptGraph()}
+    tools = create_specialist_tools(user_id="u1", registry=fake_registry)
+    tailor_tool = [t for t in tools if t.name == "tailor_resume"][0]
+
+    raw_res = await tailor_tool.ainvoke({"job_id": "job_1"})
+    res = json.loads(raw_res) if isinstance(raw_res, str) else raw_res
+
+    assert res.get("status") == "awaiting_approval"
+    assert "thread_id" in res
+    assert res["thread_id"].startswith("u1:resume-tailor:chat-")
+
+
+@pytest.mark.anyio
+async def test_thread_id_format():
+    from app.agents.specialist_tools import make_chat_tool_thread_id
+
+    thread_id = make_chat_tool_thread_id("user_42", "apply-copilot")
+    assert thread_id.startswith("user_42:apply-copilot:chat-")
+    # Suffix should be unique / non-empty
+    suffix = thread_id.split("user_42:apply-copilot:chat-")[1]
+    assert len(suffix) >= 4

--- a/services/agent/tests/test_specialist_tools.py
+++ b/services/agent/tests/test_specialist_tools.py
@@ -90,3 +90,40 @@ async def test_thread_id_format():
     # Suffix should be unique / non-empty
     suffix = thread_id.split("user_42:apply-copilot:chat-")[1]
     assert len(suffix) >= 4
+
+
+@pytest.mark.anyio
+async def test_job_scoped_tools_fallback_to_default_job_id():
+    from app.agents.specialist_tools import build_specialist_tools
+
+    captured_payloads = []
+
+    class _CaptureGraph:
+        async def ainvoke(self, payload, config=None):
+            captured_payloads.append(payload)
+            return {"status": "done", "output": payload}
+
+    fake_registry = {
+        "resume-tailor": _CaptureGraph(),
+        "apply-copilot": _CaptureGraph(),
+        "connection-scout": _CaptureGraph(),
+    }
+
+    tools = build_specialist_tools(
+        registry=fake_registry,
+        user_id="u1",
+        default_job_id="default-job-42",
+    )
+    tools_map = {t.name: t for t in tools}
+
+    # 1. When job_id is not passed, falls back to default_job_id
+    await tools_map["tailor_resume"].ainvoke({})
+    assert captured_payloads[-1]["input"]["job_id"] == "default-job-42"
+
+    # 2. When empty job_id is passed, falls back to default_job_id
+    await tools_map["build_application_pack"].ainvoke({"job_id": "   "})
+    assert captured_payloads[-1]["input"]["job_id"] == "default-job-42"
+
+    # 3. When explicit job_id is passed, explicit takes precedence
+    await tools_map["scout_connections"].ainvoke({"job_id": "explicit-job-99"})
+    assert captured_payloads[-1]["input"]["job_id"] == "explicit-job-99"


### PR DESCRIPTION
Closes #256 (Epic #244).

### Summary of Changes

1. **Four Specialist Subagent Tools**:
   - Added `services/agent/app/agents/specialist_tools.py` with `run_feed_curation`, `tailor_resume`, `build_application_pack`, and `scout_connections`.
   - Closes over the compiled graph registry and calling `user_id` for multi-tenant isolation.
   - Generates isolated thread IDs formatted as `{user_id}:{agent_id}:chat-{uuid}`.
   - Handles interrupts cleanly by returning `{"status": "awaiting_approval", "thread_id": thread_id}`.
   - Fails closed with structured JSON on missing agent or runtime failure.

2. **Multi-Round Tool-Calling Loop in Chat**:
   - Updated `_chat_event_stream` in `services/agent/app/main.py` to bind specialist tools to the chat model.
   - Implemented multi-round tool execution loop bounded by `MAX_TOOL_ROUNDS = 3`.
   - Emits real-time SSE `status` events (`{"tool": ..., "state": "running"}`) when tools execute.
   - Preserves exact latency and token streaming behavior for tool-free conversation turns.

3. **System Prompt Updates**:
   - Updated `CHAT_ASSISTANT_SYSTEM` in `services/agent/app/prompts.py` to inform the assistant of available specialist tools and enforce human-in-the-loop approval disclosures ("awaiting your approval", never claimed as sent).

4. **Testing & Verification**:
   - Added `services/agent/tests/test_specialist_tools.py` covering tool names, stub execution, missing agent failure mode, and interrupt status.
   - Extended `services/agent/tests/test_assistant_chat.py` with tests for multi-turn tool calling, status events, and recursion round limiting.
   - Verified all 318 unit and behavioral tests pass cleanly.
   - Updated `docs/IMPLEMENTATION_STATUS.md`.
