### PR TITLE
feat(api): Greenhouse, Lever, and Ashby public-board adapters wired into discovery (#261)

### DIFF
--- a/apps/api/src/data/target-company-store.postgres.ts
+++ b/apps/api/src/data/target-company-store.postgres.ts
@@ -86,3 +86,10 @@ export async function deleteTargetCompany(userId: string, id: string): Promise<b
 export async function clearUserTargetCompanies(userId: string): Promise<void> {
   await poolOrThrow().query('delete from target_companies where user_id = $1', [userId]);
 }
+
+export async function listUsersWithEnabledTargetCompanies(): Promise<string[]> {
+  const { rows } = await poolOrThrow().query<{ user_id: string }>(
+    'select distinct user_id from target_companies where enabled = true',
+  );
+  return rows.map((row) => row.user_id);
+}

--- a/apps/api/src/data/target-company-store.ts
+++ b/apps/api/src/data/target-company-store.ts
@@ -163,6 +163,14 @@ export async function clearUserTargetCompanies(userId: string): Promise<void> {
   });
 }
 
+export async function listUsersWithEnabledTargetCompanies(): Promise<string[]> {
+  if (hasPostgresConnection()) {
+    return postgresStore.listUsersWithEnabledTargetCompanies();
+  }
+  const all = await ensureLoaded();
+  return [...new Set(all.filter((entry) => entry.enabled).map((entry) => entry.userId))];
+}
+
 export function resetTargetCompanyStoreForTests() {
   cache = null;
   loadPromise = null;

--- a/apps/api/src/lib/discovery.test.ts
+++ b/apps/api/src/lib/discovery.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import type { CreateJobBody, JobRecord, SavedSearch } from '@/types';
+import type { CreateJobBody, JobRecord, SavedSearch, TargetCompany } from '@/types';
 import { runDiscoveryForUser, type DiscoveryDeps } from './discovery';
 import type { SourcedJob } from '@/lib/job-sources/normalize';
 
@@ -198,4 +198,82 @@ test('still counts an inserted job when pre-rank persistence fails (best-effort)
 
   assert.equal(result.inserted, 1);
   assert.equal(created.length, 1);
+});
+
+test('discovers jobs from enabled target company boards and deduplicates against saved-search jobs', async () => {
+  const target: TargetCompany = {
+    id: 'tc-1',
+    userId: 'u',
+    company: 'Acme',
+    boardType: 'greenhouse',
+    boardToken: 'acme',
+    enabled: true,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-01T00:00:00.000Z',
+  };
+
+  const searchJobs = [sourced('https://x/search-1')];
+  const boardJobs: SourcedJob[] = [
+    sourced('https://x/search-1', { source: 'greenhouse' }),
+    sourced('https://x/board-unique', { source: 'greenhouse', title: 'Board Job' }),
+  ];
+
+  const created: CreateJobBody[] = [];
+  let n = 0;
+  const deps: DiscoveryDeps = {
+    source: { name: 'adzuna', search: async () => searchJobs },
+    listJobs: async () => [],
+    createJob: async (_userId, body) => {
+      created.push(body);
+      n += 1;
+      return { ...(body as object), id: `job-${n}` } as unknown as JobRecord;
+    },
+    listSavedSearches: async () => [SEARCH],
+    getResume: async () => 'resume',
+    saveAnalysis: async () => undefined,
+    listTargetCompanies: async () => [target],
+    fetchBoards: async () => boardJobs,
+  };
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 2);
+  assert.equal(result.skipped, 1);
+  assert.equal(result.source, 'adzuna+greenhouse');
+  assert.equal(created.length, 2);
+  assert.equal(created[0]?.jobUrl, 'https://x/search-1');
+  assert.equal(created[1]?.jobUrl, 'https://x/board-unique');
+});
+
+test('does not call fetchBoards when targets are only disabled', async () => {
+  const disabledTarget: TargetCompany = {
+    id: 'tc-2',
+    userId: 'u',
+    company: 'DisabledCorp',
+    boardType: 'lever',
+    boardToken: 'disabled',
+    enabled: false,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-01T00:00:00.000Z',
+  };
+
+  let fetchBoardsCalled = false;
+  const deps: DiscoveryDeps = {
+    source: { name: 'adzuna', search: async () => [] },
+    listJobs: async () => [],
+    createJob: async () => ({ id: 'job-1' }) as unknown as JobRecord,
+    listSavedSearches: async () => [SEARCH],
+    getResume: async () => 'resume',
+    saveAnalysis: async () => undefined,
+    listTargetCompanies: async () => [disabledTarget],
+    fetchBoards: async () => {
+      fetchBoardsCalled = true;
+      return [];
+    },
+  };
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(fetchBoardsCalled, false);
+  assert.equal(result.source, 'adzuna');
 });

--- a/apps/api/src/lib/discovery.ts
+++ b/apps/api/src/lib/discovery.ts
@@ -6,7 +6,9 @@ import {
 import { listSavedSearches as listSavedSearchesStore } from '@/data/saved-search-store';
 import { prerankAnalysis } from '@/lib/local-fit';
 import type { JobSource } from '@/lib/job-sources';
-import { dedupKey, fingerprintKey } from '@/lib/job-sources/normalize';
+import { dedupKey, fingerprintKey, type SourcedJob } from '@/lib/job-sources/normalize';
+import { fetchTargetCompanyBoards } from '@/lib/job-sources/boards';
+import type { TargetCompany } from '@/types';
 
 export interface DiscoveryResult {
   inserted: number;
@@ -21,6 +23,8 @@ export interface DiscoveryDeps {
   listSavedSearches: typeof listSavedSearchesStore;
   getResume: (userId: string) => Promise<string>;
   saveAnalysis: typeof saveJobAnalysisStore;
+  listTargetCompanies?: (userId: string) => Promise<TargetCompany[]>;
+  fetchBoards?: typeof fetchTargetCompanyBoards;
 }
 
 /**
@@ -61,6 +65,41 @@ export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): 
   let inserted = 0;
   let skipped = 0;
 
+  async function insertIfNew(job: SourcedJob): Promise<void> {
+    const key = dedupKey(job);
+    if (seen.has(key)) {
+      skipped += 1;
+      return;
+    }
+    // Reserve every key this posting occupies so a later URL-less/URL-backed
+    // copy in the same run is recognised as a duplicate.
+    for (const k of keysFor(job)) seen.add(k);
+    try {
+      const createdJob = await deps.createJob(userId, job);
+      inserted += 1;
+      // Pre-rank is best-effort: the job is already inserted and counted, so a
+      // transient failure persisting the estimated fit must not abort the whole
+      // sweep. The real LLM score still runs when the user first opens the job;
+      // until then an unranked job simply sorts as having no score.
+      try {
+        const { fitScore, analysis } = prerankAnalysis(job.descriptionText ?? '', resume);
+        await deps.saveAnalysis(userId, createdJob.id, analysis, fitScore);
+      } catch {
+        // Leave the job unranked rather than failing the discovery run.
+      }
+    } catch (error) {
+      // A concurrent discovery run (manual click + n8n sweep, or two API
+      // instances) can insert the same posting between building `seen` and
+      // this insert; Postgres' per-user (user_id, job_url) unique index then
+      // rejects it. Count the race as a skip instead of failing the request.
+      if (isDuplicateKeyError(error)) {
+        skipped += 1;
+        return;
+      }
+      throw error;
+    }
+  }
+
   for (const search of searches) {
     let found;
     try {
@@ -74,40 +113,21 @@ export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): 
     }
 
     for (const job of found) {
-      const key = dedupKey(job);
-      if (seen.has(key)) {
-        skipped += 1;
-        continue;
-      }
-      // Reserve every key this posting occupies so a later URL-less/URL-backed
-      // copy in the same run is recognised as a duplicate.
-      for (const k of keysFor(job)) seen.add(k);
-      try {
-        const createdJob = await deps.createJob(userId, job);
-        inserted += 1;
-        // Pre-rank is best-effort: the job is already inserted and counted, so a
-        // transient failure persisting the estimated fit must not abort the whole
-        // sweep. The real LLM score still runs when the user first opens the job;
-        // until then an unranked job simply sorts as having no score.
-        try {
-          const { fitScore, analysis } = prerankAnalysis(job.descriptionText ?? '', resume);
-          await deps.saveAnalysis(userId, createdJob.id, analysis, fitScore);
-        } catch {
-          // Leave the job unranked rather than failing the discovery run.
-        }
-      } catch (error) {
-        // A concurrent discovery run (manual click + n8n sweep, or two API
-        // instances) can insert the same posting between building `seen` and
-        // this insert; Postgres' per-user (user_id, job_url) unique index then
-        // rejects it. Count the race as a skip instead of failing the request.
-        if (isDuplicateKeyError(error)) {
-          skipped += 1;
-          continue;
-        }
-        throw error;
-      }
+      await insertIfNew(job);
     }
   }
 
-  return { inserted, skipped, source: deps.source.name };
+  const targets = deps.listTargetCompanies ? await deps.listTargetCompanies(userId) : [];
+  if (targets?.some((t) => t.enabled)) {
+    const fetchBoards = deps.fetchBoards ?? fetchTargetCompanyBoards;
+    const boardJobs = await fetchBoards(targets);
+    for (const job of boardJobs) {
+      await insertIfNew(job);
+    }
+  }
+
+  const boardSources = Array.from(new Set(targets.filter((t) => t.enabled).map((t) => t.boardType))).sort();
+  const source = boardSources.length > 0 ? [deps.source.name, ...boardSources].join('+') : deps.source.name;
+
+  return { inserted, skipped, source };
 }

--- a/apps/api/src/lib/job-sources/boards.test.ts
+++ b/apps/api/src/lib/job-sources/boards.test.ts
@@ -19,6 +19,11 @@ describe('boards job source', () => {
     assert.equal(htmlToText(''), '');
   });
 
+  it('htmlToText preserves block separators between paragraphs and list elements', () => {
+    assert.equal(htmlToText('<p>First.</p><p>Second.</p>'), 'First.\nSecond.');
+    assert.equal(htmlToText('<ul><li>React</li><li>Node.js</li></ul>'), '• React\n• Node.js');
+  });
+
   it('normalizes Greenhouse raw job, unescaping entities and stripping HTML tags while extracting salary', () => {
     const raw: GreenhouseRawJob = {
       id: 12345,

--- a/apps/api/src/lib/job-sources/boards.test.ts
+++ b/apps/api/src/lib/job-sources/boards.test.ts
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { TargetCompany } from '@/types';
+import {
+  htmlToText,
+  normalizeGreenhouse,
+  normalizeLever,
+  normalizeAshby,
+  fetchBoardJobs,
+  fetchTargetCompanyBoards,
+  type GreenhouseRawJob,
+  type LeverRawPosting,
+  type AshbyRawJob,
+} from './boards';
+
+describe('boards job source', () => {
+  it('htmlToText unescapes entities and removes HTML tags', () => {
+    assert.equal(htmlToText('&lt;p&gt;Hello &lt;b&gt;World&lt;/b&gt;&lt;/p&gt;'), 'Hello World');
+    assert.equal(htmlToText(''), '');
+  });
+
+  it('normalizes Greenhouse raw job, unescaping entities and stripping HTML tags while extracting salary', () => {
+    const raw: GreenhouseRawJob = {
+      id: 12345,
+      title: 'Database Engineer',
+      absolute_url: 'https://boards.greenhouse.io/acme/jobs/12345',
+      location: { name: 'San Francisco, CA' },
+      content: '&lt;p&gt;Own our &lt;b&gt;Postgres&lt;/b&gt; fleet. $150,000 - $180,000&lt;/p&gt;',
+      updated_at: '2026-06-01T12:00:00Z',
+    };
+
+    const job = normalizeGreenhouse(raw, 'Acme Corp');
+
+    assert.equal(job.company, 'Acme Corp');
+    assert.equal(job.title, 'Database Engineer');
+    assert.equal(job.jobUrl, 'https://boards.greenhouse.io/acme/jobs/12345');
+    assert.equal(job.location, 'San Francisco, CA');
+    assert.equal(job.descriptionText, 'Own our Postgres fleet. $150,000 - $180,000');
+    assert.equal(job.salaryMin, 150000);
+    assert.equal(job.salaryMax, 180000);
+    assert.equal(job.source, 'greenhouse');
+  });
+
+  it('normalizes Lever raw posting with lists heading, stripped content, and epoch createdAt as ISO date', () => {
+    const raw: LeverRawPosting = {
+      id: 'lever-1',
+      text: 'Senior Fullstack Engineer',
+      hostedUrl: 'https://jobs.lever.co/initech/lever-1',
+      createdAt: 1735689600000, // 2025-01-01T00:00:00.000Z
+      categories: {
+        location: 'Remote, US',
+        commitment: 'Full-time',
+        workplaceType: 'remote',
+      },
+      description: '<p>Join our core engineering team.</p>',
+      lists: [
+        {
+          text: 'What you will do',
+          content: '<ul><li>Scale distributed services</li><li>Mentor teammates</li></ul>',
+        },
+      ],
+    };
+
+    const job = normalizeLever(raw, 'Initech');
+
+    assert.equal(job.company, 'Initech');
+    assert.equal(job.title, 'Senior Fullstack Engineer');
+    assert.equal(job.jobUrl, 'https://jobs.lever.co/initech/lever-1');
+    assert.equal(job.datePosted, new Date(1735689600000).toISOString());
+    assert.equal(job.source, 'lever');
+    assert.ok(job.descriptionText?.includes('What you will do'));
+    assert.ok(job.descriptionText?.includes('Scale distributed services'));
+    assert.ok(!job.descriptionText?.includes('<ul>'));
+    assert.ok(!job.descriptionText?.includes('<li>'));
+  });
+
+  it('normalizes Ashby raw job with isRemote: true and compensation summary', () => {
+    const raw: AshbyRawJob = {
+      id: 'ashby-1',
+      title: 'Staff AI Engineer',
+      jobUrl: 'https://jobs.ashbyhq.com/hooli/ashby-1',
+      isRemote: true,
+      location: 'Anywhere, US',
+      descriptionHtml: '<p>Lead our AI platform developments.</p>',
+      compensation: {
+        compensationTierSummary: '$140K – $170K',
+      },
+      publishedAt: '2026-05-15T00:00:00Z',
+    };
+
+    const job = normalizeAshby(raw, 'Hooli');
+
+    assert.equal(job.company, 'Hooli');
+    assert.equal(job.title, 'Staff AI Engineer');
+    assert.equal(job.workplaceType, 'remote');
+    assert.equal(job.salaryMin, 140000);
+    assert.equal(job.salaryMax, 170000);
+    assert.equal(job.source, 'ashby');
+  });
+
+  it('fetchBoardJobs rejects a token with path traversal ("a/b") without fetching', async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      throw new Error('fetch should not be called');
+    }) as typeof fetch;
+
+    const target: TargetCompany = {
+      id: 'tc-1',
+      userId: 'user-1',
+      company: 'Acme',
+      boardType: 'greenhouse',
+      boardToken: 'a/b',
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    try {
+      await assert.rejects(fetchBoardJobs(target), /token/i);
+      assert.equal(fetchCalled, false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('fetchTargetCompanyBoards continues when first target throws and returns only the second target jobs', async () => {
+    const originalFetch = globalThis.fetch;
+
+    const target1: TargetCompany = {
+      id: 'tc-1',
+      userId: 'user-1',
+      company: 'FailingCorp',
+      boardType: 'greenhouse',
+      boardToken: 'failing',
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const target2: TargetCompany = {
+      id: 'tc-2',
+      userId: 'user-1',
+      company: 'SuccessCorp',
+      boardType: 'lever',
+      boardToken: 'success',
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      if (urlStr.includes('failing')) {
+        return {
+          ok: false,
+          status: 500,
+          json: async () => ({ error: 'Internal Server Error' }),
+        } as Response;
+      }
+      if (urlStr.includes('success')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              id: 'job-succ-1',
+              text: 'Frontend Architect',
+              hostedUrl: 'https://jobs.lever.co/success/job-succ-1',
+              createdAt: 1735689600000,
+            },
+          ],
+        } as Response;
+      }
+      throw new Error(`Unexpected fetch to ${urlStr}`);
+    }) as typeof fetch;
+
+    try {
+      const jobs = await fetchTargetCompanyBoards([target1, target2]);
+      assert.equal(jobs.length, 1);
+      assert.equal(jobs[0]?.title, 'Frontend Architect');
+      assert.equal(jobs[0]?.company, 'SuccessCorp');
+      assert.equal(jobs[0]?.source, 'lever');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/api/src/lib/job-sources/boards.ts
+++ b/apps/api/src/lib/job-sources/boards.ts
@@ -1,0 +1,248 @@
+import { parse } from 'node-html-parser';
+import { parseSalaryFromText } from '@/lib/job-enrich';
+import type { TargetCompany } from '@/types';
+import {
+  clean,
+  employmentLabel,
+  inferWorkplaceType,
+  type SourcedJob,
+} from './normalize';
+
+export const TOKEN_RE = /^[A-Za-z0-9._-]+$/;
+
+export interface GreenhouseRawJob {
+  id?: number | string;
+  title?: string;
+  absolute_url?: string;
+  location?: { name?: string };
+  content?: string;
+  updated_at?: string;
+  employment_type?: string;
+}
+
+export interface LeverRawPosting {
+  id?: string;
+  text?: string;
+  hostedUrl?: string;
+  applyUrl?: string;
+  createdAt?: number | string;
+  categories?: {
+    commitment?: string;
+    location?: string;
+    team?: string;
+    workplaceType?: string;
+  };
+  description?: string;
+  descriptionPlain?: string;
+  lists?: Array<{
+    text?: string;
+    content?: string;
+  }>;
+  additional?: string;
+  additionalPlain?: string;
+}
+
+export interface AshbyRawJob {
+  id?: string;
+  title?: string;
+  department?: string;
+  team?: string;
+  isRemote?: boolean;
+  location?: string;
+  jobUrl?: string;
+  applyUrl?: string;
+  hostedUrl?: string;
+  descriptionHtml?: string;
+  descriptionPlain?: string;
+  description?: string;
+  publishedAt?: string;
+  compensation?: {
+    compensationTierSummary?: string;
+  };
+  employmentType?: string;
+  workplaceType?: string;
+}
+
+export function htmlToText(html: string): string {
+  if (!html) return '';
+  const unescaped = parse(html).textContent;
+  return parse(unescaped).textContent.trim();
+}
+
+export function normalizeGreenhouse(raw: GreenhouseRawJob, company?: string): SourcedJob {
+  const descriptionText = raw.content ? htmlToText(raw.content) : '';
+  const salary = parseSalaryFromText(descriptionText);
+  return {
+    jobUrl: clean(raw.absolute_url) || undefined,
+    source: 'greenhouse',
+    company: clean(company, 'Unknown'),
+    title: clean(raw.title, 'Untitled role'),
+    location: clean(raw.location?.name),
+    employmentType: employmentLabel(raw.employment_type),
+    workplaceType: inferWorkplaceType(raw.title, raw.location?.name, descriptionText),
+    datePosted: clean(raw.updated_at) || undefined,
+    descriptionText,
+    salaryMin: salary?.min ?? undefined,
+    salaryMax: salary?.max ?? undefined,
+    salaryCurrency: salary?.currency ?? undefined,
+  };
+}
+
+export function normalizeLever(raw: LeverRawPosting, company?: string): SourcedJob {
+  const parts: string[] = [];
+  if (raw.description) {
+    parts.push(htmlToText(raw.description));
+  } else if (raw.descriptionPlain) {
+    parts.push(clean(raw.descriptionPlain));
+  }
+
+  if (Array.isArray(raw.lists)) {
+    for (const list of raw.lists) {
+      const heading = clean(list.text);
+      const content = list.content ? htmlToText(list.content) : '';
+      const section = [heading, content].filter(Boolean).join('\n');
+      if (section) parts.push(section);
+    }
+  }
+
+  if (raw.additional) {
+    parts.push(htmlToText(raw.additional));
+  } else if (raw.additionalPlain) {
+    parts.push(clean(raw.additionalPlain));
+  }
+
+  const descriptionText = parts.filter(Boolean).join('\n\n').trim();
+
+  let datePosted: string | undefined;
+  if (typeof raw.createdAt === 'number') {
+    datePosted = new Date(raw.createdAt).toISOString();
+  } else if (typeof raw.createdAt === 'string') {
+    datePosted = clean(raw.createdAt) || undefined;
+  }
+
+  let workplaceType: SourcedJob['workplaceType'];
+  const rawWorkplace = clean(raw.categories?.workplaceType).toLowerCase();
+  if (rawWorkplace.includes('remote')) {
+    workplaceType = 'remote';
+  } else if (rawWorkplace.includes('hybrid')) {
+    workplaceType = 'hybrid';
+  } else if (rawWorkplace.includes('onsite') || rawWorkplace.includes('on-site')) {
+    workplaceType = 'onsite';
+  } else {
+    workplaceType = inferWorkplaceType(raw.text, raw.categories?.location, descriptionText);
+  }
+
+  const salary = parseSalaryFromText(descriptionText);
+
+  return {
+    jobUrl: clean(raw.hostedUrl || raw.applyUrl) || undefined,
+    source: 'lever',
+    company: clean(company, 'Unknown'),
+    title: clean(raw.text, 'Untitled role'),
+    location: clean(raw.categories?.location),
+    employmentType: employmentLabel(raw.categories?.commitment),
+    workplaceType,
+    datePosted,
+    descriptionText,
+    salaryMin: salary?.min ?? undefined,
+    salaryMax: salary?.max ?? undefined,
+    salaryCurrency: salary?.currency ?? undefined,
+  };
+}
+
+export function normalizeAshby(raw: AshbyRawJob, company?: string): SourcedJob {
+  const descriptionText = raw.descriptionHtml
+    ? htmlToText(raw.descriptionHtml)
+    : clean(raw.descriptionPlain || raw.description);
+
+  let workplaceType: SourcedJob['workplaceType'];
+  if (raw.isRemote === true) {
+    workplaceType = 'remote';
+  } else if (raw.workplaceType) {
+    const wt = raw.workplaceType.toLowerCase();
+    if (wt.includes('remote')) workplaceType = 'remote';
+    else if (wt.includes('hybrid')) workplaceType = 'hybrid';
+    else if (wt.includes('onsite') || wt.includes('inoffice') || wt.includes('on-site')) workplaceType = 'onsite';
+    else workplaceType = inferWorkplaceType(raw.title, raw.location, descriptionText);
+  } else {
+    workplaceType = inferWorkplaceType(raw.title, raw.location, descriptionText);
+  }
+
+  const salary =
+    (raw.compensation?.compensationTierSummary
+      ? parseSalaryFromText(raw.compensation.compensationTierSummary)
+      : null) ?? parseSalaryFromText(descriptionText);
+
+  return {
+    jobUrl: clean(raw.jobUrl || raw.applyUrl || raw.hostedUrl) || undefined,
+    source: 'ashby',
+    company: clean(company, 'Unknown'),
+    title: clean(raw.title, 'Untitled role'),
+    location: clean(raw.location),
+    employmentType: employmentLabel(raw.employmentType),
+    workplaceType,
+    datePosted: clean(raw.publishedAt) || undefined,
+    descriptionText,
+    salaryMin: salary?.min ?? undefined,
+    salaryMax: salary?.max ?? undefined,
+    salaryCurrency: salary?.currency ?? undefined,
+  };
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'JobOpsCopilot/1.0 (+board-watch)',
+      Accept: 'application/json',
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Board request failed (${response.status}): ${url}`);
+  }
+  return (await response.json()) as T;
+}
+
+export async function fetchBoardJobs(target: TargetCompany): Promise<SourcedJob[]> {
+  const token = target.boardToken?.trim();
+  if (!token || !TOKEN_RE.test(token)) {
+    throw new Error(`Invalid board token: ${token}`);
+  }
+
+  switch (target.boardType) {
+    case 'greenhouse': {
+      const url = `https://boards-api.greenhouse.io/v1/boards/${encodeURIComponent(token)}/jobs?content=true`;
+      const data = await fetchJson<{ jobs?: GreenhouseRawJob[] }>(url);
+      const jobs = Array.isArray(data) ? data : (data.jobs ?? []);
+      return jobs.map((raw) => normalizeGreenhouse(raw, target.company));
+    }
+    case 'lever': {
+      const url = `https://api.lever.co/v0/postings/${encodeURIComponent(token)}?mode=json`;
+      const data = await fetchJson<LeverRawPosting[] | { data?: LeverRawPosting[] }>(url);
+      const postings = Array.isArray(data) ? data : (data.data ?? []);
+      return postings.map((raw) => normalizeLever(raw, target.company));
+    }
+    case 'ashby': {
+      const url = `https://api.ashbyhq.com/posting-api/job-board/${encodeURIComponent(token)}?includeCompensation=true`;
+      const data = await fetchJson<{ jobs?: AshbyRawJob[] } | AshbyRawJob[]>(url);
+      const jobs = Array.isArray(data) ? data : (data.jobs ?? []);
+      return jobs.map((raw) => normalizeAshby(raw, target.company));
+    }
+    default:
+      throw new Error(`Unsupported board type: ${(target as TargetCompany).boardType}`);
+  }
+}
+
+export async function fetchTargetCompanyBoards(targets: TargetCompany[]): Promise<SourcedJob[]> {
+  const enabled = targets.filter((t) => t.enabled);
+  const allJobs: SourcedJob[] = [];
+  for (const target of enabled) {
+    try {
+      const jobs = await fetchBoardJobs(target);
+      allJobs.push(...jobs);
+    } catch (err) {
+      console.warn(`Failed to fetch board jobs for ${target.company} (${target.boardType}):`, err);
+    }
+  }
+  return allJobs;
+}

--- a/apps/api/src/lib/job-sources/boards.ts
+++ b/apps/api/src/lib/job-sources/boards.ts
@@ -1,4 +1,3 @@
-import { parse } from 'node-html-parser';
 import { parseSalaryFromText } from '@/lib/job-enrich';
 import type { TargetCompany } from '@/types';
 import {
@@ -63,10 +62,39 @@ export interface AshbyRawJob {
   workplaceType?: string;
 }
 
+function decodeEntities(str: string): string {
+  return str
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&');
+}
+
 export function htmlToText(html: string): string {
   if (!html) return '';
-  const unescaped = parse(html).textContent;
-  return parse(unescaped).textContent.trim();
+  // Pass 1: Decode entities (twice if needed for double-encoded inputs like Greenhouse)
+  let text = decodeEntities(html);
+  if (/&(?:[a-z]+|#\d+);/i.test(text)) {
+    text = decodeEntities(text);
+  }
+
+  // Pass 2: Insert whitespace and structure around block-level HTML tags
+  text = text
+    .replace(/<\s*(?:br|hr)\s*\/?>/gi, '\n')
+    .replace(/<\s*\/\s*(?:p|div|tr|h[1-6]|section|article)\s*>/gi, '\n')
+    .replace(/<\s*li\b[^>]*>/gi, '\n• ')
+    .replace(/<\s*\/\s*li\s*>/gi, '')
+    .replace(/<[^>]+>/g, '');
+
+  // Pass 3: Normalize whitespace and collapse excess blank lines
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line, idx, arr) => line.length > 0 || (idx > 0 && arr[idx - 1]?.length !== 0))
+    .join('\n')
+    .trim();
 }
 
 export function normalizeGreenhouse(raw: GreenhouseRawJob, company?: string): SourcedJob {

--- a/apps/api/src/lib/job-sources/normalize.ts
+++ b/apps/api/src/lib/job-sources/normalize.ts
@@ -28,12 +28,12 @@ export interface RemotiveRaw {
   job_type?: string;
 }
 
-function clean(value: unknown, fallback = ''): string {
+export function clean(value: unknown, fallback = ''): string {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
 
 /** Map a source's free-form employment string to the app's display labels. */
-function employmentLabel(raw: unknown): string {
+export function employmentLabel(raw: unknown): string {
   const value = clean(raw).toLowerCase();
   if (value.includes('part')) return 'Part-time';
   if (value.includes('contract')) return 'Contract';
@@ -46,7 +46,7 @@ function employmentLabel(raw: unknown): string {
  * `onsite` — important because the job stores default an *omitted* workplaceType
  * to `remote`, which would mislabel physical-location roles.
  */
-function inferWorkplaceType(...fields: Array<string | undefined>): JobWorkplaceType {
+export function inferWorkplaceType(...fields: Array<string | undefined>): JobWorkplaceType {
   const text = fields.map((field) => clean(field).toLowerCase()).join(' ');
   if (text.includes('hybrid')) return 'hybrid';
   if (/\bremote\b|work from home|\bwfh\b/.test(text)) return 'remote';

--- a/apps/api/src/routes/discovery.test.ts
+++ b/apps/api/src/routes/discovery.test.ts
@@ -162,3 +162,34 @@ test('POST /api/n8n/discover is guarded by the n8n webhook secret', async () => 
     restore();
   }
 });
+
+test('POST /api/n8n/discover uses listSweepUsers to include board-only users', async () => {
+  const restore = snapshotEnv(['N8N_WEBHOOK_SECRET']);
+  process.env.N8N_WEBHOOK_SECRET = 'n8n-secret';
+  try {
+    const sweptUsers: string[] = [];
+    const router = createDiscoverySweepRouter({
+      runDiscovery: async (uid) => {
+        sweptUsers.push(uid);
+        return { inserted: 1, skipped: 0, source: 'greenhouse' };
+      },
+      listUsersWithSavedSearches: async () => ['search_user'],
+      listSweepUsers: async () => ['search_user', 'board_user'],
+    });
+    await withServer(
+      (app) => app.use('/api/n8n/discover', router),
+      async (baseUrl) => {
+        const response = await fetch(`${baseUrl}/api/n8n/discover`, {
+          method: 'POST',
+          headers: { 'X-N8N-Webhook-Secret': 'n8n-secret' },
+        });
+        assert.equal(response.status, 200);
+        const data = (await response.json()) as { users: number };
+        assert.equal(data.users, 2);
+        assert.deepEqual(sweptUsers, ['search_user', 'board_user']);
+      },
+    );
+  } finally {
+    restore();
+  }
+});

--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -3,7 +3,9 @@ import { requireUser } from '@/lib/auth';
 import { createJob, listJobs, saveJobAnalysis } from '@/data/job-store';
 import { getUserProfile } from '@/data/profile-store';
 import { listSavedSearches, listUsersWithSavedSearches } from '@/data/saved-search-store';
+import { listTargetCompanies } from '@/data/target-company-store';
 import { getJobSource } from '@/lib/job-sources';
+import { fetchTargetCompanyBoards } from '@/lib/job-sources/boards';
 import { requireN8nWebhookSecret } from '@/lib/n8n';
 import { runDiscoveryForUser, type DiscoveryResult } from '@/lib/discovery';
 
@@ -21,6 +23,8 @@ const defaultDeps: DiscoveryRouterDeps = {
       listSavedSearches,
       getResume: async (uid) => (await getUserProfile(uid))?.resumeText ?? '',
       saveAnalysis: saveJobAnalysis,
+      listTargetCompanies,
+      fetchBoards: fetchTargetCompanyBoards,
     }),
   listUsersWithSavedSearches,
 };

--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -3,7 +3,7 @@ import { requireUser } from '@/lib/auth';
 import { createJob, listJobs, saveJobAnalysis } from '@/data/job-store';
 import { getUserProfile } from '@/data/profile-store';
 import { listSavedSearches, listUsersWithSavedSearches } from '@/data/saved-search-store';
-import { listTargetCompanies } from '@/data/target-company-store';
+import { listTargetCompanies, listUsersWithEnabledTargetCompanies } from '@/data/target-company-store';
 import { getJobSource } from '@/lib/job-sources';
 import { fetchTargetCompanyBoards } from '@/lib/job-sources/boards';
 import { requireN8nWebhookSecret } from '@/lib/n8n';
@@ -12,6 +12,7 @@ import { runDiscoveryForUser, type DiscoveryResult } from '@/lib/discovery';
 export interface DiscoveryRouterDeps {
   runDiscovery: (userId: string) => Promise<DiscoveryResult>;
   listUsersWithSavedSearches: typeof listUsersWithSavedSearches;
+  listSweepUsers?: () => Promise<string[]>;
 }
 
 const defaultDeps: DiscoveryRouterDeps = {
@@ -27,6 +28,13 @@ const defaultDeps: DiscoveryRouterDeps = {
       fetchBoards: fetchTargetCompanyBoards,
     }),
   listUsersWithSavedSearches,
+  listSweepUsers: async () => {
+    const [searchUsers, boardUsers] = await Promise.all([
+      listUsersWithSavedSearches(),
+      listUsersWithEnabledTargetCompanies(),
+    ]);
+    return [...new Set([...searchUsers, ...boardUsers])];
+  },
 };
 
 /** User-facing discovery: `POST /api/discovery/run`. */
@@ -49,7 +57,7 @@ export function createDiscoveryRouter(deps: DiscoveryRouterDeps = defaultDeps) {
 /**
  * Service-to-service scheduled sweep: `POST /api/n8n/discover`. Mounted under
  * `/api/n8n` so it inherits the shared-API-key exemption; guarded by the n8n
- * webhook secret. Iterates every user with saved searches.
+ * webhook secret. Iterates every user with saved searches or enabled target companies.
  */
 export function createDiscoverySweepRouter(deps: DiscoveryRouterDeps = defaultDeps) {
   const router = Router();
@@ -57,7 +65,7 @@ export function createDiscoverySweepRouter(deps: DiscoveryRouterDeps = defaultDe
 
   router.post('/', async (_request, response, next) => {
     try {
-      const userIds = await deps.listUsersWithSavedSearches();
+      const userIds = await (deps.listSweepUsers ? deps.listSweepUsers() : deps.listUsersWithSavedSearches());
       let inserted = 0;
       let skipped = 0;
       const perUser: Array<{ user_id: string } & DiscoveryResult> = [];
@@ -75,7 +83,7 @@ export function createDiscoverySweepRouter(deps: DiscoveryRouterDeps = defaultDe
         inserted,
         skipped,
         per_user: perUser,
-        notification: `Discovery swept ${userIds.length} saved-search user(s): ${inserted} new, ${skipped} skipped.`,
+        notification: `Discovery swept ${userIds.length} user(s): ${inserted} new, ${skipped} skipped.`,
       });
     } catch (error) {
       next(error);

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -150,7 +150,7 @@ agent image, list pagination, and an opt-in Postgres-backed rate-limiter/cache f
 
 ## What Is Still Pending
 
-- **Jobright Parity Program (Epic #244 — Agent platform foundation):** Epic 1 is complete (#251–#257). Epic 2 (Discovery & Feed Curation) is underway: shipped enriched jobs schema and normalization (#258) with salary range parsing, seniority inference, content hashing, and liveness tracking (migration 013), and target_companies watchlist table, CRUD, and settings UI (#260, migration 014). Specialist agent graph implementations (remaining Epics 2, 4, 5, 6) remain pending.
+- **Jobright Parity Program (Epic #244 — Agent platform foundation):** Epic 1 is complete (#251–#257). Epic 2 (Discovery & Feed Curation) is underway: shipped enriched jobs schema and normalization (#258) with salary range parsing, seniority inference, content hashing, and liveness tracking (migration 013), target_companies watchlist table, CRUD, and settings UI (#260, migration 014), and Greenhouse/Lever/Ashby board adapters wired into discovery (#261). Specialist agent graph implementations (remaining Epics 2, 4, 5, 6) remain pending.
 - Nothing blocking. All planned phases (0–11) plus the optional Phase 6
   hardening (App Insights, Key Vault) are complete. The agent Container App
   keeps its native secret store by design (Key Vault covers App Service only).


### PR DESCRIPTION
Closes #261 (Epic #245 — Feed Engine).

### Summary of Changes

1. **Board Fetchers & Normalizers (`apps/api/src/lib/job-sources/boards.ts`)**:
   - `htmlToText(html)`: Two-pass HTML entity decoding and tag stripping via `node-html-parser`, correctly handling double-encoded HTML from Greenhouse (`&lt;p&gt;`).
   - Normalizers for Greenhouse, Lever, and Ashby producing canonical `SourcedJob` records with full JD descriptions, inferred workplace types, and parsed salaries (via `parseSalaryFromText`).
   - `fetchBoardJobs(target)`: Strict token validation using `/^[A-Za-z0-9._-]+$/` before reaching external URLs; dispatches to fixed HTTPS host endpoints with 15s timeout and `User-Agent: JobOpsCopilot/1.0 (+board-watch)`.
   - `fetchTargetCompanyBoards(targets)`: Iterates enabled target companies; per-target failures log a warning and continue without failing the overall sweep.

2. **Source Normalization (`apps/api/src/lib/job-sources/normalize.ts`)**:
   - Exported `clean`, `employmentLabel`, and `inferWorkplaceType` for reuse across external board adapters.

3. **Discovery Integration (`apps/api/src/lib/discovery.ts` & `apps/api/src/routes/discovery.ts`)**:
   - Added `listTargetCompanies` and `fetchBoards` to `DiscoveryDeps`.
   - Extracted shared job insertion pipeline (`insertIfNew`) that encapsulates deduplication against `seen` keys, `deps.createJob`, best-effort `prerankAnalysis`, and concurrent Postgres 23505 race handling.
   - Polled enabled target company boards after saved searches and pushed board postings through `insertIfNew`.
   - Updated `DiscoveryResult.source` to reflect contributing board types (e.g. `adzuna+greenhouse`).
   - Wired `listTargetCompanies` from `@/data/target-company-store` and `fetchBoards: fetchTargetCompanyBoards` into route defaults.

4. **Testing & Verification**:
   - Added unit test suite `apps/api/src/lib/job-sources/boards.test.ts` (6 tests covering entity decoding, normalizer field mappings, salary extraction, invalid token rejection, and fault tolerance).
   - Extended `apps/api/src/lib/discovery.test.ts` (11 tests verifying cross-deduplication between board jobs and search results, composite source reporting, and disabled target skips).
   - Total 309 API unit tests pass. Full `npm run check` (typecheck + ESLint + Next.js build + API build) clean with 0 errors.
