### PR TITLE
feat(api): USAJobs and The Muse source adapters, Remotive window fix, and multi-source discovery (#259)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,11 @@ N8N_WEBHOOK_SECRET=
 ADZUNA_APP_ID=
 ADZUNA_APP_KEY=
 ADZUNA_COUNTRY=us
+# Remotive fetch window override (default 200).
+REMOTIVE_FETCH_LIMIT=200
+# Optional USAJobs API integration: https://developer.usajobs.gov/
+USAJOBS_API_KEY=
+USAJOBS_USER_AGENT=
 # Cache identical job searches to cut redundant (rate-limited) Adzuna calls.
 # Milliseconds; default 300000 (5 min). Set to 0 to disable caching.
 JOB_SEARCH_CACHE_TTL_MS=300000

--- a/apps/api/src/lib/discovery.test.ts
+++ b/apps/api/src/lib/discovery.test.ts
@@ -277,3 +277,77 @@ test('does not call fetchBoards when targets are only disabled', async () => {
   assert.equal(fetchBoardsCalled, false);
   assert.equal(result.source, 'adzuna');
 });
+
+test('handles multiple sources when the second throws: completes, inserts first jobs, source reflects only contributing one', async () => {
+  const created: CreateJobBody[] = [];
+  let n = 0;
+  const src1 = {
+    name: 'adzuna',
+    search: async () => [sourced('https://x/1', { source: 'adzuna' })],
+  };
+  const src2 = {
+    name: 'usajobs',
+    search: async () => {
+      throw new Error('USAJobs upstream failure');
+    },
+  };
+
+  const deps: DiscoveryDeps = {
+    sources: [src1, src2],
+    listJobs: async () => [],
+    createJob: async (_userId, body) => {
+      created.push(body);
+      n += 1;
+      return { ...(body as object), id: `job-${n}` } as unknown as JobRecord;
+    },
+    listSavedSearches: async () => [SEARCH],
+    getResume: async () => 'resume',
+    saveAnalysis: async () => undefined,
+  };
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 1);
+  assert.equal(result.skipped, 0);
+  assert.equal(result.source, 'adzuna');
+  assert.equal(created.length, 1);
+  assert.equal(created[0]?.jobUrl, 'https://x/1');
+});
+
+test('deduplicates jobs across multiple sources by URL: duplicate URL inserts once', async () => {
+  const created: CreateJobBody[] = [];
+  let n = 0;
+  const src1 = {
+    name: 'adzuna',
+    search: async () => [sourced('https://shared/1', { source: 'adzuna', title: 'Adzuna Version' })],
+  };
+  const src2 = {
+    name: 'themuse',
+    search: async () => [
+      sourced('https://shared/1', { source: 'themuse', title: 'TheMuse Duplicate' }),
+      sourced('https://unique/2', { source: 'themuse', title: 'TheMuse Unique' }),
+    ],
+  };
+
+  const deps: DiscoveryDeps = {
+    sources: [src1, src2],
+    listJobs: async () => [],
+    createJob: async (_userId, body) => {
+      created.push(body);
+      n += 1;
+      return { ...(body as object), id: `job-${n}` } as unknown as JobRecord;
+    },
+    listSavedSearches: async () => [SEARCH],
+    getResume: async () => 'resume',
+    saveAnalysis: async () => undefined,
+  };
+
+  const result = await runDiscoveryForUser('u', deps);
+
+  assert.equal(result.inserted, 2);
+  assert.equal(result.skipped, 1);
+  assert.equal(result.source, 'adzuna+themuse');
+  assert.equal(created.length, 2);
+  assert.equal(created[0]?.jobUrl, 'https://shared/1');
+  assert.equal(created[1]?.jobUrl, 'https://unique/2');
+});

--- a/apps/api/src/lib/discovery.ts
+++ b/apps/api/src/lib/discovery.ts
@@ -17,7 +17,8 @@ export interface DiscoveryResult {
 }
 
 export interface DiscoveryDeps {
-  source: JobSource;
+  source?: JobSource;
+  sources?: JobSource[];
   listJobs: typeof listJobsStore;
   createJob: typeof createJobStore;
   listSavedSearches: typeof listSavedSearchesStore;
@@ -62,8 +63,15 @@ export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): 
   const seen = new Set((await deps.listJobs(userId)).flatMap(keysFor));
   const resume = await deps.getResume(userId);
 
+  const sources: JobSource[] = deps.sources && deps.sources.length > 0
+    ? deps.sources
+    : deps.source
+      ? [deps.source]
+      : [];
+
   let inserted = 0;
   let skipped = 0;
+  const contributingSources = new Set<string>();
 
   async function insertIfNew(job: SourcedJob): Promise<void> {
     const key = dedupKey(job);
@@ -101,19 +109,22 @@ export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): 
   }
 
   for (const search of searches) {
-    let found;
-    try {
-      found = await deps.source.search(search.query, {
-        location: search.location,
-        remoteOnly: search.remoteOnly,
-        limit: 20,
-      });
-    } catch {
-      continue;
-    }
+    for (const src of sources) {
+      let found: SourcedJob[];
+      try {
+        found = await src.search(search.query, {
+          location: search.location,
+          remoteOnly: search.remoteOnly,
+          limit: 20,
+        });
+        contributingSources.add(src.name);
+      } catch {
+        continue;
+      }
 
-    for (const job of found) {
-      await insertIfNew(job);
+      for (const job of found) {
+        await insertIfNew(job);
+      }
     }
   }
 
@@ -127,7 +138,11 @@ export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): 
   }
 
   const boardSources = Array.from(new Set(targets.filter((t) => t.enabled).map((t) => t.boardType))).sort();
-  const source = boardSources.length > 0 ? [deps.source.name, ...boardSources].join('+') : deps.source.name;
+  const searchSourceList = contributingSources.size > 0
+    ? Array.from(contributingSources)
+    : sources.map((s) => s.name);
+  const combined = [...searchSourceList, ...boardSources];
+  const source = combined.length > 0 ? combined.join('+') : 'unknown';
 
   return { inserted, skipped, source };
 }

--- a/apps/api/src/lib/job-sources/cache.test.ts
+++ b/apps/api/src/lib/job-sources/cache.test.ts
@@ -94,3 +94,12 @@ test('the same query in a different country is a distinct key', () => {
   // case/whitespace-insensitive on the query itself
   assert.equal(jobSearchCacheKey('  Python ', {}, 'us'), jobSearchCacheKey('python', {}, 'us'));
 });
+
+test('the same query for different sources produces distinct cache keys', () => {
+  const adzunaKey = jobSearchCacheKey('python', {}, 'us', 'adzuna');
+  const museKey = jobSearchCacheKey('python', {}, 'us', 'themuse');
+  const usajobsKey = jobSearchCacheKey('python', {}, 'us', 'usajobs');
+  assert.notEqual(adzunaKey, museKey);
+  assert.notEqual(museKey, usajobsKey);
+  assert.notEqual(adzunaKey, usajobsKey);
+});

--- a/apps/api/src/lib/job-sources/index.ts
+++ b/apps/api/src/lib/job-sources/index.ts
@@ -75,14 +75,16 @@ export function withCachedSearch(
   source: JobSource,
   cache: AsyncTtlCache<SourcedJob[]>,
   country: () => string,
+  cacheNamespace?: string,
 ): JobSource {
+  const namespace = cacheNamespace ?? source.name;
   return {
     get name() {
       return source.name;
     },
     async search(query, opts = {}) {
       const results = await cache.getOrCompute(
-        jobSearchCacheKey(query, opts, country(), source.name),
+        jobSearchCacheKey(query, opts, country(), namespace),
         () => source.search(query, opts),
       );
       // Copy so a caller mutating results in place can't poison the shared
@@ -101,11 +103,13 @@ export function withCachedSearch(
  * source); the authoritative per-job provider is each job's `source` field.
  */
 export function getJobSource(): JobSource {
-  const base = adzunaConfigured() ? createComposite() : createRemotiveSource();
+  const isAdzuna = adzunaConfigured();
+  const base = isAdzuna ? createComposite() : createRemotiveSource();
   return withCachedSearch(
     base,
     jobSearchCache,
     () => process.env.ADZUNA_COUNTRY?.trim() || 'us',
+    isAdzuna ? 'adzuna' : 'remotive',
   );
 }
 

--- a/apps/api/src/lib/job-sources/index.ts
+++ b/apps/api/src/lib/job-sources/index.ts
@@ -3,6 +3,8 @@ import { PostgresTtlCache } from '../cache.postgres';
 import { getPool } from '../postgres';
 import { createAdzunaSource } from './adzuna';
 import { createRemotiveSource } from './remotive';
+import { createUsaJobsSource, usaJobsConfigured } from './usajobs';
+import { createTheMuseSource } from './themuse';
 import type { SourcedJob } from './normalize';
 import type { JobSearchOptions, JobSource } from './types';
 
@@ -52,8 +54,10 @@ export function jobSearchCacheKey(
   query: string,
   opts: JobSearchOptions,
   country: string,
+  sourceName?: string,
 ): string {
   return JSON.stringify({
+    source: sourceName ?? null,
     q: query.trim().toLowerCase(),
     country,
     remoteOnly: Boolean(opts.remoteOnly),
@@ -77,8 +81,9 @@ export function withCachedSearch(
       return source.name;
     },
     async search(query, opts = {}) {
-      const results = await cache.getOrCompute(jobSearchCacheKey(query, opts, country()), () =>
-        source.search(query, opts),
+      const results = await cache.getOrCompute(
+        jobSearchCacheKey(query, opts, country(), source.name),
+        () => source.search(query, opts),
       );
       // Copy so a caller mutating results in place can't poison the shared
       // cached array (the cache is a process-local singleton across requests).
@@ -102,6 +107,24 @@ export function getJobSource(): JobSource {
     jobSearchCache,
     () => process.env.ADZUNA_COUNTRY?.trim() || 'us',
   );
+}
+
+/**
+ * Returns all available job sources: Adzuna/Remotive composite (or Remotive fallback),
+ * USAJobs (if configured), and The Muse.
+ */
+export function getJobSources(): JobSource[] {
+  const country = () => process.env.ADZUNA_COUNTRY?.trim() || 'us';
+  const primary = getJobSource();
+  const sources: JobSource[] = [primary];
+
+  if (usaJobsConfigured()) {
+    sources.push(withCachedSearch(createUsaJobsSource(), jobSearchCache, country));
+  }
+
+  sources.push(withCachedSearch(createTheMuseSource(), jobSearchCache, country));
+
+  return sources;
 }
 
 function createComposite(): JobSource {

--- a/apps/api/src/lib/job-sources/normalize.ts
+++ b/apps/api/src/lib/job-sources/normalize.ts
@@ -131,3 +131,15 @@ export function dedupKey(job: SourcedJob): string {
   if (job.jobUrl) return job.jobUrl.toLowerCase();
   return fingerprintKey(job);
 }
+
+/**
+ * Filter jobs using AND-terms matching across company, title, and descriptionText.
+ */
+export function filterByQueryTerms(jobs: SourcedJob[], query: string): SourcedJob[] {
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return jobs;
+  return jobs.filter((job) => {
+    const haystack = `${job.company} ${job.title} ${job.descriptionText}`.toLowerCase();
+    return terms.every((term) => haystack.includes(term));
+  });
+}

--- a/apps/api/src/lib/job-sources/remotive.test.ts
+++ b/apps/api/src/lib/job-sources/remotive.test.ts
@@ -11,6 +11,21 @@ function stubFetch(jobs: unknown[]): () => void {
   };
 }
 
+function stubFetchWithUrl(jobs: unknown[]): { restore: () => void; getUrls: () => string[] } {
+  const original = globalThis.fetch;
+  const urls: string[] = [];
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+    urls.push(String(input));
+    return { ok: true, status: 200, json: async () => ({ jobs }) } as unknown as Response;
+  }) as typeof fetch;
+  return {
+    restore: () => {
+      globalThis.fetch = original;
+    },
+    getUrls: () => urls,
+  };
+}
+
 test('Remotive filters the generic feed by query terms', async () => {
   const restore = stubFetch([
     { url: 'https://r/1', title: 'Python Developer', company_name: 'Acme', candidate_required_location: 'USA' },
@@ -49,6 +64,54 @@ test('Remotive filters by a real location but ignores remote-ish ones', async ()
     const all = await createRemotiveSource().search('engineer', { location: 'Remote' });
     assert.equal(all.length, 2);
   } finally {
+    restore();
+  }
+});
+
+test('the request URL carries limit=200 even when opts.limit is 10 and returned array is sliced to 10', async () => {
+  const fakeJobs = Array.from({ length: 15 }, (_, i) => ({
+    url: `https://r/${i}`,
+    title: `Python Developer ${i}`,
+    company_name: 'Acme',
+    description: 'Python job',
+  }));
+  const { restore, getUrls } = stubFetchWithUrl(fakeJobs);
+  try {
+    const jobs = await createRemotiveSource().search('python', { limit: 10 });
+    assert.equal(jobs.length, 10);
+    const calledUrl = new URL(getUrls()[0]!);
+    assert.equal(calledUrl.searchParams.get('limit'), '200');
+  } finally {
+    restore();
+  }
+});
+
+test('query "python developer" drops a job whose text contains only "developer"', async () => {
+  const feed = [
+    { url: 'https://r/1', title: 'Python Developer', company_name: 'Acme', description: 'Python dev' },
+    { url: 'https://r/2', title: 'Frontend Developer', company_name: 'Globex', description: 'React only' },
+  ];
+  const { restore } = stubFetchWithUrl(feed);
+  try {
+    const jobs = await createRemotiveSource().search('python developer');
+    assert.equal(jobs.length, 1);
+    assert.equal(jobs[0]?.title, 'Python Developer');
+  } finally {
+    restore();
+  }
+});
+
+test('REMOTIVE_FETCH_LIMIT=75 is honored in the request URL', async () => {
+  const prev = process.env.REMOTIVE_FETCH_LIMIT;
+  process.env.REMOTIVE_FETCH_LIMIT = '75';
+  const { restore, getUrls } = stubFetchWithUrl([]);
+  try {
+    await createRemotiveSource().search('python');
+    const calledUrl = new URL(getUrls()[0]!);
+    assert.equal(calledUrl.searchParams.get('limit'), '75');
+  } finally {
+    if (prev === undefined) delete process.env.REMOTIVE_FETCH_LIMIT;
+    else process.env.REMOTIVE_FETCH_LIMIT = prev;
     restore();
   }
 });

--- a/apps/api/src/lib/job-sources/remotive.ts
+++ b/apps/api/src/lib/job-sources/remotive.ts
@@ -1,7 +1,20 @@
-import { normalizeRemotive, type RemotiveRaw, type SourcedJob } from './normalize';
+import {
+  filterByQueryTerms,
+  normalizeRemotive,
+  type RemotiveRaw,
+  type SourcedJob,
+} from './normalize';
 import type { JobSearchOptions, JobSource } from './types';
 
 const NON_GEOGRAPHIC = new Set(['remote', 'anywhere', 'worldwide', 'global']);
+const DEFAULT_FETCH_WINDOW = 200;
+
+function fetchWindow(): number {
+  const raw = process.env.REMOTIVE_FETCH_LIMIT;
+  if (!raw) return DEFAULT_FETCH_WINDOW;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_FETCH_WINDOW;
+}
 
 /**
  * Remotive job source — no API key required. Used as the always-available
@@ -17,7 +30,7 @@ export function createRemotiveSource(): JobSource {
     async search(query: string, opts: JobSearchOptions = {}): Promise<SourcedJob[]> {
       const url = new URL('https://remotive.com/api/remote-jobs');
       if (query) url.searchParams.set('search', query);
-      url.searchParams.set('limit', String(opts.limit ?? 50));
+      url.searchParams.set('limit', String(fetchWindow()));
 
       const response = await fetch(url, { signal: AbortSignal.timeout(15_000) });
       if (!response.ok) {
@@ -26,12 +39,8 @@ export function createRemotiveSource(): JobSource {
       const data = (await response.json()) as { jobs?: RemotiveRaw[] };
       let jobs = (data.jobs ?? []).map(normalizeRemotive);
 
-      const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
-      if (terms.length > 0) {
-        jobs = jobs.filter((job) => {
-          const haystack = `${job.title} ${job.company} ${job.descriptionText}`.toLowerCase();
-          return terms.some((term) => haystack.includes(term));
-        });
+      if (query) {
+        jobs = filterByQueryTerms(jobs, query);
       }
 
       const location = opts.location?.trim().toLowerCase();
@@ -39,7 +48,7 @@ export function createRemotiveSource(): JobSource {
         jobs = jobs.filter((job) => (job.location ?? '').toLowerCase().includes(location));
       }
 
-      return jobs;
+      return jobs.slice(0, opts.limit ?? 50);
     },
   };
 }

--- a/apps/api/src/lib/job-sources/themuse.test.ts
+++ b/apps/api/src/lib/job-sources/themuse.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createTheMuseSource, normalizeTheMuse, type TheMuseRawJob } from './themuse';
+
+test('normalizeTheMuse strips HTML from contents, maps level to seniority, and sets source to themuse', () => {
+  const item: TheMuseRawJob = {
+    id: 101,
+    name: 'Staff Software Engineer',
+    contents: '<p>Join us to build <strong>amazing</strong> software.</p><ul><li>Write TypeScript</li></ul>',
+    publication_date: '2026-06-01T00:00:00Z',
+    company: { name: 'Acme Corp' },
+    locations: [{ name: 'San Francisco, CA' }],
+    levels: [{ name: 'Senior Level' }],
+    refs: { landing_page: 'https://www.themuse.com/jobs/acme/staff-swe' },
+  };
+
+  const job = normalizeTheMuse(item);
+  assert.equal(job.source, 'themuse');
+  assert.equal(job.company, 'Acme Corp');
+  assert.equal(job.title, 'Staff Software Engineer');
+  assert.equal(job.seniority, 'senior');
+  assert.equal(job.jobUrl, 'https://www.themuse.com/jobs/acme/staff-swe');
+  assert.ok(!job.descriptionText.includes('<p>'));
+  assert.ok(!job.descriptionText.includes('<strong>'));
+  assert.ok(job.descriptionText.includes('Join us to build amazing software.'));
+  assert.ok(job.descriptionText.includes('Write TypeScript'));
+
+  // Test seniority mappings
+  assert.equal(normalizeTheMuse({ ...item, levels: [{ name: 'Entry Level' }] }).seniority, 'junior');
+  assert.equal(normalizeTheMuse({ ...item, levels: [{ name: 'Mid Level' }] }).seniority, 'mid');
+  assert.equal(normalizeTheMuse({ ...item, levels: [{ name: 'Senior Level' }] }).seniority, 'senior');
+  assert.equal(normalizeTheMuse({ ...item, levels: [{ name: 'management' }] }).seniority, 'lead');
+  assert.equal(normalizeTheMuse({ ...item, levels: [{ name: 'Director' }] }).seniority, 'lead');
+  assert.equal(normalizeTheMuse({ ...item, levels: [{ name: 'Internship' }] }).seniority, 'unknown');
+});
+
+test('createTheMuseSource applies AND-filter across query terms', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+    const urlStr = String(input);
+    if (urlStr.includes('page=0')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          results: [
+            {
+              id: 1,
+              name: 'Python Developer',
+              contents: '<p>Backend Python developer</p>',
+              company: { name: 'Acme' },
+              levels: [{ name: 'Mid Level' }],
+              refs: { landing_page: 'https://themuse/1' },
+            },
+            {
+              id: 2,
+              name: 'Developer',
+              contents: '<p>Java developer only</p>',
+              company: { name: 'Globex' },
+              levels: [{ name: 'Mid Level' }],
+              refs: { landing_page: 'https://themuse/2' },
+            },
+          ],
+        }),
+      } as Response;
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ results: [] }),
+    } as Response;
+  }) as typeof fetch;
+
+  try {
+    const source = createTheMuseSource();
+    const results = await source.search('python developer');
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.title, 'Python Developer');
+    assert.equal(results[0]?.source, 'themuse');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/apps/api/src/lib/job-sources/themuse.test.ts
+++ b/apps/api/src/lib/job-sources/themuse.test.ts
@@ -81,3 +81,51 @@ test('createTheMuseSource applies AND-filter across query terms', async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+test('createTheMuseSource honors remoteOnly option', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+    const url = new URL(String(input));
+    if (url.searchParams.get('page') === '0') {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          results: [
+            {
+              id: 1,
+              name: 'Remote Engineer',
+              contents: '<p>Remote work from home</p>',
+              company: { name: 'Acme' },
+              locations: [{ name: 'Flexible / Remote' }],
+              refs: { landing_page: 'https://themuse/1' },
+            },
+            {
+              id: 2,
+              name: 'Onsite Engineer',
+              contents: '<p>In-office physical role</p>',
+              company: { name: 'Globex' },
+              locations: [{ name: 'New York, NY' }],
+              refs: { landing_page: 'https://themuse/2' },
+            },
+          ],
+        }),
+      } as Response;
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ results: [] }),
+    } as Response;
+  }) as typeof fetch;
+
+  try {
+    const source = createTheMuseSource();
+    const results = await source.search('', { remoteOnly: true });
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.title, 'Remote Engineer');
+    assert.equal(results[0]?.workplaceType, 'remote');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/apps/api/src/lib/job-sources/themuse.ts
+++ b/apps/api/src/lib/job-sources/themuse.ts
@@ -1,0 +1,95 @@
+import type { JobSeniority } from '@/types';
+import { htmlToText } from './boards';
+import {
+  clean,
+  employmentLabel,
+  filterByQueryTerms,
+  inferWorkplaceType,
+  type SourcedJob,
+} from './normalize';
+import type { JobSearchOptions, JobSource } from './types';
+
+const NON_GEOGRAPHIC = new Set(['remote', 'anywhere', 'worldwide', 'global']);
+
+export interface TheMuseRawJob {
+  id?: number | string;
+  name?: string;
+  type?: string;
+  contents?: string;
+  publication_date?: string;
+  company?: { id?: number; name?: string; short_name?: string };
+  locations?: Array<{ name?: string }>;
+  levels?: Array<{ name?: string; short_name?: string }>;
+  refs?: { landing_page?: string };
+}
+
+function mapSeniority(levelName?: string): JobSeniority {
+  const norm = clean(levelName).toLowerCase();
+  if (norm.includes('entry')) return 'junior';
+  if (norm.includes('mid')) return 'mid';
+  if (norm.includes('senior')) return 'senior';
+  if (norm.includes('management') || norm.includes('director')) return 'lead';
+  return 'unknown';
+}
+
+export function normalizeTheMuse(raw: TheMuseRawJob): SourcedJob {
+  const descriptionText = raw.contents ? htmlToText(raw.contents) : '';
+  const location = raw.locations?.[0]?.name ? clean(raw.locations[0].name) : undefined;
+  const levelName = raw.levels?.[0]?.name;
+
+  return {
+    jobUrl: clean(raw.refs?.landing_page) || undefined,
+    source: 'themuse',
+    company: clean(raw.company?.name, 'Unknown'),
+    title: clean(raw.name, 'Untitled role'),
+    location,
+    employmentType: employmentLabel(raw.type),
+    workplaceType: inferWorkplaceType(raw.name, location, descriptionText),
+    datePosted: clean(raw.publication_date) || undefined,
+    descriptionText,
+    seniority: mapSeniority(levelName),
+  };
+}
+
+export function createTheMuseSource(): JobSource {
+  return {
+    name: 'themuse',
+    async search(query: string, opts: JobSearchOptions = {}): Promise<SourcedJob[]> {
+      const fetchPage = async (page: number): Promise<TheMuseRawJob[]> => {
+        const url = new URL('https://www.themuse.com/api/public/jobs');
+        url.searchParams.set('page', String(page));
+        if (opts.location) {
+          url.searchParams.set('location', opts.location);
+        }
+        const res = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+        if (!res.ok) {
+          throw new Error(`The Muse request failed: ${res.status}`);
+        }
+        const data = (await res.json()) as { results?: TheMuseRawJob[] };
+        return data.results ?? [];
+      };
+
+      const [p0, p1] = await Promise.allSettled([fetchPage(0), fetchPage(1)]);
+      if (p0.status === 'rejected' && p1.status === 'rejected') {
+        throw p0.reason;
+      }
+      const rawJobs = [
+        ...(p0.status === 'fulfilled' ? p0.value : []),
+        ...(p1.status === 'fulfilled' ? p1.value : []),
+      ];
+
+      let jobs = rawJobs.map(normalizeTheMuse);
+
+      if (query) {
+        jobs = filterByQueryTerms(jobs, query);
+      }
+
+      const location = opts.location?.trim().toLowerCase();
+      if (location && !NON_GEOGRAPHIC.has(location)) {
+        jobs = jobs.filter((job) => (job.location ?? '').toLowerCase().includes(location));
+      }
+
+      return jobs.slice(0, opts.limit ?? 25);
+    },
+  };
+}

--- a/apps/api/src/lib/job-sources/themuse.ts
+++ b/apps/api/src/lib/job-sources/themuse.ts
@@ -85,7 +85,9 @@ export function createTheMuseSource(): JobSource {
       }
 
       const location = opts.location?.trim().toLowerCase();
-      if (location && !NON_GEOGRAPHIC.has(location)) {
+      if (opts.remoteOnly || (location && NON_GEOGRAPHIC.has(location))) {
+        jobs = jobs.filter((job) => job.workplaceType === 'remote');
+      } else if (location) {
         jobs = jobs.filter((job) => (job.location ?? '').toLowerCase().includes(location));
       }
 

--- a/apps/api/src/lib/job-sources/usajobs.test.ts
+++ b/apps/api/src/lib/job-sources/usajobs.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createUsaJobsSource, normalizeUsaJobs, usaJobsConfigured, type UsaJobsRaw } from './usajobs';
+import { getJobSources } from './index';
+
+test('normalizeUsaJobs normalizes SearchResultItems fixture and calculates hourly to annual salary', () => {
+  const rawItem: UsaJobsRaw = {
+    MatchedObjectId: '12345',
+    MatchedObjectDescriptor: {
+      PositionTitle: 'IT Specialist (Security)',
+      OrganizationName: 'Department of Veterans Affairs',
+      PositionLocationDisplay: 'Washington, DC',
+      PositionURI: 'https://www.usajobs.gov/job/12345',
+      PublicationStartDate: '2026-06-01T00:00:00.000Z',
+      PositionRemuneration: [
+        {
+          MinimumRange: '45',
+          MaximumRange: '55',
+          RateIntervalCode: 'PH',
+        },
+      ],
+      UserArea: {
+        Details: {
+          JobSummary: 'Summary of IT Specialist role.',
+          MajorDuties: ['Defend cyber systems.', 'Monitor networks.'],
+        },
+      },
+    },
+  };
+
+  const job = normalizeUsaJobs(rawItem);
+  assert.equal(job.source, 'usajobs');
+  assert.equal(job.salaryMin, 93600);
+  assert.equal(job.salaryMax, 114400);
+  assert.equal(job.title, 'IT Specialist (Security)');
+  assert.equal(job.company, 'Department of Veterans Affairs');
+  assert.equal(job.jobUrl, 'https://www.usajobs.gov/job/12345');
+});
+
+test('createUsaJobsSource sends Authorization-Key and User-Agent headers', async () => {
+  const prevKey = process.env.USAJOBS_API_KEY;
+  const prevAgent = process.env.USAJOBS_USER_AGENT;
+  process.env.USAJOBS_API_KEY = 'test-auth-key';
+  process.env.USAJOBS_USER_AGENT = 'myemail@example.com';
+
+  let capturedHeaders: unknown;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+    capturedHeaders = init?.headers;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        SearchResult: {
+          SearchResultItems: [
+            {
+              MatchedObjectId: '1',
+              MatchedObjectDescriptor: {
+                PositionTitle: 'Developer',
+                OrganizationName: 'GSA',
+                PositionURI: 'https://usajobs/1',
+                PositionRemuneration: [{ MinimumRange: '45', MaximumRange: '55', RateIntervalCode: 'PH' }],
+              },
+            },
+          ],
+        },
+      }),
+    } as Response;
+  }) as typeof fetch;
+
+  try {
+    const source = createUsaJobsSource();
+    const results = await source.search('developer');
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.source, 'usajobs');
+    const headers = new Headers(capturedHeaders as Record<string, string>);
+    assert.equal(headers.get('Authorization-Key'), 'test-auth-key');
+    assert.equal(headers.get('User-Agent'), 'myemail@example.com');
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (prevKey === undefined) delete process.env.USAJOBS_API_KEY;
+    else process.env.USAJOBS_API_KEY = prevKey;
+    if (prevAgent === undefined) delete process.env.USAJOBS_USER_AGENT;
+    else process.env.USAJOBS_USER_AGENT = prevAgent;
+  }
+});
+
+test('usaJobsConfigured() false without env and getJobSources() omits it', () => {
+  const prevKey = process.env.USAJOBS_API_KEY;
+  const prevAgent = process.env.USAJOBS_USER_AGENT;
+  delete process.env.USAJOBS_API_KEY;
+  delete process.env.USAJOBS_USER_AGENT;
+  try {
+    assert.equal(usaJobsConfigured(), false);
+    const sources = getJobSources();
+    assert.equal(sources.some((s) => s.name === 'usajobs'), false);
+  } finally {
+    if (prevKey !== undefined) process.env.USAJOBS_API_KEY = prevKey;
+    if (prevAgent !== undefined) process.env.USAJOBS_USER_AGENT = prevAgent;
+  }
+});

--- a/apps/api/src/lib/job-sources/usajobs.ts
+++ b/apps/api/src/lib/job-sources/usajobs.ts
@@ -1,0 +1,148 @@
+import type { JobWorkplaceType } from '@/types';
+import {
+  clean,
+  employmentLabel,
+  inferWorkplaceType,
+  type SourcedJob,
+} from './normalize';
+import type { JobSearchOptions, JobSource } from './types';
+
+export interface UsaJobsRemuneration {
+  MinimumRange?: string | number;
+  MaximumRange?: string | number;
+  RateIntervalCode?: string;
+  Description?: string;
+}
+
+export interface UsaJobsDescriptor {
+  PositionTitle?: string;
+  OrganizationName?: string;
+  DepartmentName?: string;
+  PositionLocationDisplay?: string;
+  PositionURI?: string;
+  PublicationStartDate?: string;
+  PositionRemuneration?: UsaJobsRemuneration[];
+  UserArea?: {
+    Details?: {
+      JobSummary?: string;
+      MajorDuties?: string[] | string;
+    };
+  };
+  QualificationSummary?: string;
+}
+
+export interface UsaJobsRaw {
+  MatchedObjectId?: string;
+  MatchedObjectDescriptor?: UsaJobsDescriptor;
+  PositionTitle?: string;
+  OrganizationName?: string;
+  PositionLocationDisplay?: string;
+  PositionURI?: string;
+  PublicationStartDate?: string;
+  PositionRemuneration?: UsaJobsRemuneration[];
+  UserArea?: {
+    Details?: {
+      JobSummary?: string;
+      MajorDuties?: string[] | string;
+    };
+  };
+}
+
+export function usaJobsConfigured(): boolean {
+  return Boolean(process.env.USAJOBS_API_KEY?.trim() && process.env.USAJOBS_USER_AGENT?.trim());
+}
+
+export function normalizeUsaJobs(raw: UsaJobsRaw): SourcedJob {
+  const desc = raw.MatchedObjectDescriptor ?? raw;
+
+  const summary = clean(desc.UserArea?.Details?.JobSummary);
+  const rawDuties = desc.UserArea?.Details?.MajorDuties;
+  const duties = Array.isArray(rawDuties)
+    ? rawDuties.map((d) => clean(d)).filter(Boolean).join('\n')
+    : clean(rawDuties);
+  const descriptionText = [summary, duties].filter(Boolean).join('\n\n');
+
+  const locDisplay = clean(desc.PositionLocationDisplay);
+  let workplaceType: JobWorkplaceType;
+  if (/anywhere in the u\.?s\.?/i.test(locDisplay)) {
+    workplaceType = 'remote';
+  } else {
+    workplaceType = inferWorkplaceType(desc.PositionTitle, desc.PositionLocationDisplay, descriptionText);
+  }
+
+  let salaryMin: number | undefined;
+  let salaryMax: number | undefined;
+  let salaryCurrency: string | undefined;
+
+  const rem = desc.PositionRemuneration?.[0];
+  if (rem) {
+    const minStr = clean(rem.MinimumRange);
+    const maxStr = clean(rem.MaximumRange);
+    const rawMin = minStr ? Number(minStr) : NaN;
+    const rawMax = maxStr ? Number(maxStr) : NaN;
+    const isHourly = rem.RateIntervalCode?.toUpperCase() === 'PH';
+    const multiplier = isHourly ? 2080 : 1;
+
+    if (Number.isFinite(rawMin)) {
+      salaryMin = Math.round(rawMin * multiplier);
+    }
+    if (Number.isFinite(rawMax)) {
+      salaryMax = Math.round(rawMax * multiplier);
+    }
+    if (salaryMin !== undefined || salaryMax !== undefined) {
+      salaryCurrency = 'USD';
+    }
+  }
+
+  return {
+    jobUrl: clean(desc.PositionURI) || undefined,
+    source: 'usajobs',
+    company: clean(desc.OrganizationName, 'Unknown'),
+    title: clean(desc.PositionTitle, 'Untitled role'),
+    location: locDisplay || undefined,
+    employmentType: employmentLabel('Full-time'),
+    workplaceType,
+    datePosted: clean(desc.PublicationStartDate) || undefined,
+    descriptionText,
+    salaryMin,
+    salaryMax,
+    salaryCurrency,
+  };
+}
+
+export function createUsaJobsSource(): JobSource {
+  return {
+    name: 'usajobs',
+    async search(query: string, opts: JobSearchOptions = {}): Promise<SourcedJob[]> {
+      const url = new URL('https://data.usajobs.gov/api/search');
+      if (query) url.searchParams.set('Keyword', query);
+      if (opts.location) url.searchParams.set('LocationName', opts.location);
+      if (opts.remoteOnly) url.searchParams.set('RemoteIndicator', 'True');
+      url.searchParams.set('ResultsPerPage', String(opts.limit ?? 25));
+
+      const headers: Record<string, string> = {
+        'Authorization-Key': process.env.USAJOBS_API_KEY ?? '',
+        'User-Agent': process.env.USAJOBS_USER_AGENT ?? '',
+        Host: 'data.usajobs.gov',
+      };
+
+      const response = await fetch(url, {
+        headers,
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (!response.ok) {
+        throw new Error(`USAJobs request failed: ${response.status}`);
+      }
+
+      const data = (await response.json()) as {
+        SearchResult?: {
+          SearchResultItems?: UsaJobsRaw[];
+        };
+      };
+
+      const items = data.SearchResult?.SearchResultItems ?? [];
+      return items.map(normalizeUsaJobs);
+    },
+  };
+}

--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -4,7 +4,7 @@ import { createJob, listJobs, saveJobAnalysis } from '@/data/job-store';
 import { getUserProfile } from '@/data/profile-store';
 import { listSavedSearches, listUsersWithSavedSearches } from '@/data/saved-search-store';
 import { listTargetCompanies, listUsersWithEnabledTargetCompanies } from '@/data/target-company-store';
-import { getJobSource } from '@/lib/job-sources';
+import { getJobSources } from '@/lib/job-sources';
 import { fetchTargetCompanyBoards } from '@/lib/job-sources/boards';
 import { requireN8nWebhookSecret } from '@/lib/n8n';
 import { runDiscoveryForUser, type DiscoveryResult } from '@/lib/discovery';
@@ -18,7 +18,7 @@ export interface DiscoveryRouterDeps {
 const defaultDeps: DiscoveryRouterDeps = {
   runDiscovery: (userId) =>
     runDiscoveryForUser(userId, {
-      source: getJobSource(),
+      sources: getJobSources(),
       listJobs,
       createJob,
       listSavedSearches,

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -150,7 +150,7 @@ agent image, list pagination, and an opt-in Postgres-backed rate-limiter/cache f
 
 ## What Is Still Pending
 
-- **Jobright Parity Program (Epic #244 — Agent platform foundation):** Epic 1 is complete (#251–#257). Epic 2 (Discovery & Feed Curation) is underway: shipped enriched jobs schema and normalization (#258) with salary range parsing, seniority inference, content hashing, and liveness tracking (migration 013), target_companies watchlist table, CRUD, and settings UI (#260, migration 014), and Greenhouse/Lever/Ashby board adapters wired into discovery (#261). Specialist agent graph implementations (remaining Epics 2, 4, 5, 6) remain pending.
+- **Jobright Parity Program (Epic #244 — Agent platform foundation):** Epic 1 is complete (#251–#257). Epic 2 (Discovery & Feed Curation) is underway: shipped enriched jobs schema and normalization (#258) with salary range parsing, seniority inference, content hashing, and liveness tracking (migration 013), target_companies watchlist table, CRUD, and settings UI (#260, migration 014), Greenhouse/Lever/Ashby board adapters wired into discovery (#261), and USAJobs + The Muse source adapters with Remotive fallback window fix and multi-source discovery (#259). Specialist agent graph implementations (remaining Epics 2, 4, 5, 6) remain pending.
 - Nothing blocking. All planned phases (0–11) plus the optional Phase 6
   hardening (App Insights, Key Vault) are complete. The agent Container App
   keeps its native secret store by design (Key Vault covers App Service only).


### PR DESCRIPTION
Closes #259 (Epic #245 — Feed Engine).

### Summary of Changes

1. **Remotive Fallback Window Fix (`apps/api/src/lib/job-sources/remotive.ts`)**:
   - Increased server fetch window to `DEFAULT_FETCH_WINDOW = 200` (configurable via `REMOTIVE_FETCH_LIMIT`).
   - Slices output to `opts.limit ?? 50` only *after* client-side filtering.
   - Enforces strict AND-matching across query terms via `filterByQueryTerms`.

2. **USAJobs Source Adapter (`apps/api/src/lib/job-sources/usajobs.ts`)**:
   - Integrates `https://data.usajobs.gov/api/search` with 15s timeout, sending required `Authorization-Key` and `User-Agent` headers.
   - Normalizes titles, organizations, locations, publication dates, and composite descriptions (summary + major duties).
   - Detects remote roles via "Anywhere in the U.S." location display.
   - Converts hourly remuneration rates (`RateIntervalCode === 'PH'`) to annual salary (`* 2080`) with USD currency.

3. **The Muse Source Adapter (`apps/api/src/lib/job-sources/themuse.ts`)**:
   - Queries `https://www.themuse.com/api/public/jobs` across pages 0 and 1 with 15s timeout and resilient `allSettled` handling.
   - Strips HTML tags and unescapes entities from job contents using `htmlToText`.
   - Maps seniority levels ("Entry Level"->junior, "Mid Level"->mid, "Senior Level"->senior, "management"/"director"->lead).
   - Performs client-side AND-terms filtering via `filterByQueryTerms`, slicing to `opts.limit ?? 25`.

4. **Multi-Source Discovery Registry & Caching (`apps/api/src/lib/job-sources/index.ts`)**:
   - Source-scoped `jobSearchCacheKey` using `source: source.name` to prevent cross-source cache collisions.
   - Implemented `getJobSources()` aggregating Adzuna/Remotive composite, USAJobs (when configured), and The Muse with TTL caching.
   - Preserved `getJobSource()` for backwards compatibility.

5. **Discovery Pipeline (`apps/api/src/lib/discovery.ts` & `apps/api/src/routes/discovery.ts`)**:
   - Supports `sources?: JobSource[]` with per-(search, source) error isolation.
   - Assembles composite source attribution strings (e.g. `adzuna+themuse+greenhouse`).
   - Wired `sources: getJobSources()` into default route dependencies.
   - Documented `USAJOBS_API_KEY`, `USAJOBS_USER_AGENT`, and `REMOTIVE_FETCH_LIMIT` in `.env.example`.

6. **Testing & Verification**:
   - Extended `remotive.test.ts`, created `usajobs.test.ts`, created `themuse.test.ts`, and extended `discovery.test.ts` and `cache.test.ts`.
   - All 322 API unit tests pass. Full `npm run check` (monorepo lint + typecheck + Next.js build + API build) clean.
