### PR TITLE
feat(api): USCIS H-1B Employer Data Hub import, h1b_sponsors table, and sponsor_likelihood matching (#262)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,6 +38,7 @@
     "@types/node": "^22.0.0",
     "@types/pdf-parse": "^1.1.4",
     "@types/pg": "^8.20.0",
+    "csv-parse": "^7.0.2",
     "eslint": "^9.0.0",
     "tsc-alias": "^1.9.1",
     "tsx": "^4.23.1",

--- a/apps/api/scripts/import-h1b.test.ts
+++ b/apps/api/scripts/import-h1b.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveHeaders, aggregateH1bRows } from './import-h1b';
+
+test('resolveHeaders maps standard USCIS headers case-insensitively', () => {
+  const headers = [
+    'Fiscal Year',
+    'Employer (Petitioner) Name',
+    'Petitioner State',
+    'Initial Approval',
+    'Initial Denial',
+    'Continuing Approval',
+    'Continuing Denial',
+  ];
+
+  const resolved = resolveHeaders(headers);
+  assert.equal(resolved.fiscalYear, 'Fiscal Year');
+  assert.equal(resolved.employer, 'Employer (Petitioner) Name');
+  assert.equal(resolved.initialApproval, 'Initial Approval');
+  assert.equal(resolved.initialDenial, 'Initial Denial');
+  assert.equal(resolved.continuingApproval, 'Continuing Approval');
+  assert.equal(resolved.continuingDenial, 'Continuing Denial');
+});
+
+test('resolveHeaders throws error naming the column when employer column is missing', () => {
+  const headers = [
+    'Fiscal Year',
+    'Petitioner State',
+    'Initial Approval',
+    'Initial Denial',
+  ];
+
+  assert.throws(
+    () => resolveHeaders(headers),
+    (err: Error) => {
+      return /employer/i.test(err.message);
+    },
+  );
+});
+
+test('aggregateH1bRows aggregates 4 rows (same employer, two states, two years, comma counts) to 2 upsert rows with summed counts', () => {
+  const fixture: Record<string, string>[] = [
+    {
+      'Fiscal Year': '2024',
+      'Employer (Petitioner) Name': 'Google, LLC',
+      'Petitioner State': 'CA',
+      'Initial Approval': '1,000',
+      'Continuing Approval': '2,000',
+      'Initial Denial': '10',
+      'Continuing Denial': '5',
+    },
+    {
+      'Fiscal Year': '2024',
+      'Employer (Petitioner) Name': 'Google Inc',
+      'Petitioner State': 'NY',
+      'Initial Approval': '500',
+      'Continuing Approval': '300',
+      'Initial Denial': '2',
+      'Continuing Denial': '1',
+    },
+    {
+      'Fiscal Year': '2023',
+      'Employer (Petitioner) Name': 'Google LLC',
+      'Petitioner State': 'CA',
+      'Initial Approval': '800',
+      'Continuing Approval': '1,200',
+      'Initial Denial': '20',
+      'Continuing Denial': '10',
+    },
+    {
+      'Fiscal Year': '2023',
+      'Employer (Petitioner) Name': 'Google',
+      'Petitioner State': 'WA',
+      'Initial Approval': '400',
+      'Continuing Approval': '100',
+      'Initial Denial': '5',
+      'Continuing Denial': '2',
+    },
+  ];
+
+  const aggregated = aggregateH1bRows(fixture);
+  assert.equal(aggregated.length, 2);
+
+  const row2024 = aggregated.find((r) => r.fiscalYear === 2024);
+  const row2023 = aggregated.find((r) => r.fiscalYear === 2023);
+
+  assert.ok(row2024, '2024 row should exist');
+  assert.ok(row2023, '2023 row should exist');
+
+  assert.equal(row2024.employerNameNormalized, 'google');
+  // 2024: (1000 + 2000) + (500 + 300) = 3800 approvals
+  assert.equal(row2024.approvals, 3800);
+  // 2024: (10 + 5) + (2 + 1) = 18 denials
+  assert.equal(row2024.denials, 18);
+
+  assert.equal(row2023.employerNameNormalized, 'google');
+  // 2023: (800 + 1200) + (400 + 100) = 2500 approvals
+  assert.equal(row2023.approvals, 2500);
+  // 2023: (20 + 10) + (5 + 2) = 37 denials
+  assert.equal(row2023.denials, 37);
+});

--- a/apps/api/scripts/import-h1b.ts
+++ b/apps/api/scripts/import-h1b.ts
@@ -1,0 +1,269 @@
+import 'dotenv/config';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'csv-parse/sync';
+import { Pool } from 'pg';
+import { normalizeEmployerName, lookupSponsorLikelihood } from '../src/lib/sponsorship';
+
+export interface ResolvedHeaders {
+  fiscalYear: string;
+  employer: string;
+  initialApproval?: string;
+  initialDenial?: string;
+  continuingApproval?: string;
+  continuingDenial?: string;
+}
+
+export interface AggregatedH1bRow {
+  employerName: string;
+  employerNameNormalized: string;
+  fiscalYear: number;
+  approvals: number;
+  denials: number;
+}
+
+export function resolveHeaders(headers: string[]): ResolvedHeaders {
+  let fiscalYear: string | undefined;
+  let employer: string | undefined;
+  let initialApproval: string | undefined;
+  let initialDenial: string | undefined;
+  let continuingApproval: string | undefined;
+  let continuingDenial: string | undefined;
+
+  for (const header of headers) {
+    const clean = header.toLowerCase().replace(/[^a-z0-9]/g, ' ').trim();
+    if (!fiscalYear && ((clean.includes('fiscal') && clean.includes('year')) || clean === 'year')) {
+      fiscalYear = header;
+    }
+    if (
+      !employer &&
+      (clean.includes('employer') || clean.includes('petitioner name') || clean === 'petitioner') &&
+      !clean.includes('state') &&
+      !clean.includes('city') &&
+      !clean.includes('zip')
+    ) {
+      employer = header;
+    }
+    if (!initialApproval && clean.includes('initial') && clean.includes('approval')) {
+      initialApproval = header;
+    }
+    if (!initialDenial && clean.includes('initial') && clean.includes('denial')) {
+      initialDenial = header;
+    }
+    if (!continuingApproval && clean.includes('continuing') && clean.includes('approval')) {
+      continuingApproval = header;
+    }
+    if (!continuingDenial && clean.includes('continuing') && clean.includes('denial')) {
+      continuingDenial = header;
+    }
+  }
+
+  if (!employer) {
+    throw new Error('Missing required column: employer name');
+  }
+
+  if (!fiscalYear) {
+    throw new Error('Missing required column: fiscal year');
+  }
+
+  return {
+    fiscalYear,
+    employer,
+    initialApproval,
+    initialDenial,
+    continuingApproval,
+    continuingDenial,
+  };
+}
+
+function parseCount(value: string | undefined | null): number {
+  if (!value) return 0;
+  const cleaned = String(value).replace(/,/g, '').trim();
+  const parsed = parseInt(cleaned, 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export function parseH1bCsv(csvContent: string): Record<string, string>[] {
+  return parse(csvContent, {
+    columns: true,
+    bom: true,
+    skip_empty_lines: true,
+    relax_column_count: true,
+  });
+}
+
+export function aggregateH1bRows(rows: Record<string, string>[]): AggregatedH1bRow[] {
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const sampleRow = rows[0]!;
+  const resolved = resolveHeaders(Object.keys(sampleRow));
+
+  const map = new Map<string, AggregatedH1bRow>();
+
+  for (const row of rows) {
+    const rawEmployer = row[resolved.employer]?.trim();
+    if (!rawEmployer) continue;
+
+    const normalized = normalizeEmployerName(rawEmployer);
+    if (!normalized) continue;
+
+    const rawYear = row[resolved.fiscalYear]?.trim();
+    if (!rawYear) continue;
+
+    const fiscalYear = parseInt(rawYear.replace(/[^0-9]/g, ''), 10);
+    if (Number.isNaN(fiscalYear) || fiscalYear <= 0) continue;
+
+    const initialApproval = parseCount(resolved.initialApproval ? row[resolved.initialApproval] : undefined);
+    const continuingApproval = parseCount(resolved.continuingApproval ? row[resolved.continuingApproval] : undefined);
+    const initialDenial = parseCount(resolved.initialDenial ? row[resolved.initialDenial] : undefined);
+    const continuingDenial = parseCount(resolved.continuingDenial ? row[resolved.continuingDenial] : undefined);
+
+    const approvals = initialApproval + continuingApproval;
+    const denials = initialDenial + continuingDenial;
+
+    const key = `${normalized}::${fiscalYear}`;
+    const existing = map.get(key);
+    if (existing) {
+      existing.approvals += approvals;
+      existing.denials += denials;
+    } else {
+      map.set(key, {
+        employerName: rawEmployer,
+        employerNameNormalized: normalized,
+        fiscalYear,
+        approvals,
+        denials,
+      });
+    }
+  }
+
+  return Array.from(map.values());
+}
+
+export async function upsertH1bRows(
+  pool: Pool,
+  rows: AggregatedH1bRow[],
+  batchSize = 500,
+): Promise<number> {
+  let totalUpserted = 0;
+
+  for (let i = 0; i < rows.length; i += batchSize) {
+    const batch = rows.slice(i, i + batchSize);
+    if (batch.length === 0) continue;
+
+    const values: unknown[] = [];
+    const valuePlaceholders: string[] = [];
+
+    batch.forEach((row, index) => {
+      const offset = index * 5;
+      valuePlaceholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5})`,
+      );
+      values.push(
+        row.employerName,
+        row.employerNameNormalized,
+        row.fiscalYear,
+        row.approvals,
+        row.denials,
+      );
+    });
+
+    const query = `
+      insert into h1b_sponsors (
+        employer_name,
+        employer_name_normalized,
+        fiscal_year,
+        approvals,
+        denials
+      ) values ${valuePlaceholders.join(', ')}
+      on conflict (employer_name_normalized, fiscal_year)
+      do update set
+        employer_name = excluded.employer_name,
+        approvals = excluded.approvals,
+        denials = excluded.denials;
+    `;
+
+    await pool.query(query, values);
+    totalUpserted += batch.length;
+  }
+
+  return totalUpserted;
+}
+
+export async function backfillExistingJobs(pool: Pool): Promise<number> {
+  const { rows } = await pool.query<{ company: string }>(
+    `select distinct company from jobs where company is not null and trim(company) != ''`,
+  );
+
+  let updatedCount = 0;
+  for (const { company } of rows) {
+    const sponsor = await lookupSponsorLikelihood(company, pool);
+    if (sponsor) {
+      const res = await pool.query(
+        `update jobs set sponsor_likelihood = $1 where company = $2 and (sponsor_likelihood is null or sponsor_likelihood != $1)`,
+        [JSON.stringify(sponsor), company],
+      );
+      updatedCount += res.rowCount ?? 0;
+    }
+  }
+
+  return updatedCount;
+}
+
+async function main() {
+  const csvPath = process.argv[2];
+  if (!csvPath) {
+    console.error('Usage: npx tsx apps/api/scripts/import-h1b.ts <csv-path>');
+    process.exit(1);
+  }
+
+  const databaseUrl = process.env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    console.error('DATABASE_URL is required to run import-h1b.');
+    process.exit(1);
+  }
+
+  console.log(`Reading CSV from ${csvPath}...`);
+  const content = readFileSync(csvPath, 'utf8');
+  const rows = parseH1bCsv(content);
+  console.log(`Parsed ${rows.length} raw rows from CSV.`);
+
+  console.log('Aggregating rows by employer and fiscal year...');
+  const aggregated = aggregateH1bRows(rows);
+  console.log(`Aggregated to ${aggregated.length} employer-year records.`);
+
+  const pool = new Pool({
+    connectionString: databaseUrl,
+    allowExitOnIdle: true,
+    max: 5,
+  });
+
+  try {
+    console.log('Upserting into h1b_sponsors...');
+    const upserted = await upsertH1bRows(pool, aggregated);
+    console.log(`Successfully upserted ${upserted} records into h1b_sponsors.`);
+
+    console.log('Backfilling existing jobs...');
+    const backfilled = await backfillExistingJobs(pool);
+    console.log(`Backfilled ${backfilled} existing job listings with sponsorship data.`);
+  } finally {
+    await pool.end();
+  }
+}
+
+const isMain =
+  Boolean(process.argv[1]) &&
+  !process.argv[1].includes('.test.') &&
+  (resolve(process.argv[1]) === fileURLToPath(import.meta.url) ||
+    process.argv[1].endsWith('import-h1b.ts') ||
+    process.argv[1].endsWith('import-h1b.js'));
+
+if (isMain) {
+  main().catch((error: unknown) => {
+    console.error('H1B import failed:', error);
+    process.exit(1);
+  });
+}

--- a/apps/api/src/data/job-store.postgres.ts
+++ b/apps/api/src/data/job-store.postgres.ts
@@ -150,11 +150,14 @@ function mapOutreach(row: OutreachRow): OutreachDraft {
 
 function parseSponsorLikelihood(raw: string | null): JobRecord['sponsorLikelihood'] {
   if (!raw) return null;
-  try {
-    return JSON.parse(raw) as JobRecord['sponsorLikelihood'];
-  } catch {
-    return raw as JobRecord['sponsorLikelihood'];
+  if (raw.startsWith('{')) {
+    try {
+      return JSON.parse(raw) as JobRecord['sponsorLikelihood'];
+    } catch {
+      return raw as JobRecord['sponsorLikelihood'];
+    }
   }
+  return raw as JobRecord['sponsorLikelihood'];
 }
 
 function mapJob(row: JobRow, analysisRow?: JobAnalysisRow, outreachRows: OutreachRow[] = []): JobRecord {
@@ -296,10 +299,10 @@ export async function createJob(userId: string, body: CreateJobBody): Promise<Jo
   const lastSeenAt = body.lastSeenAt ?? timestamp;
   const liveness = body.liveness ?? 'active';
   const sponsorLikelihood =
-    body.sponsorLikelihood !== undefined
-      ? body.sponsorLikelihood
+    body.sponsorLikelihood !== undefined && body.sponsorLikelihood !== null
+      ? typeof body.sponsorLikelihood === 'object'
         ? JSON.stringify(body.sponsorLikelihood)
-        : null
+        : body.sponsorLikelihood
       : null;
 
   try {

--- a/apps/api/src/data/job-store.postgres.ts
+++ b/apps/api/src/data/job-store.postgres.ts
@@ -148,6 +148,15 @@ function mapOutreach(row: OutreachRow): OutreachDraft {
   };
 }
 
+function parseSponsorLikelihood(raw: string | null): JobRecord['sponsorLikelihood'] {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as JobRecord['sponsorLikelihood'];
+  } catch {
+    return raw as JobRecord['sponsorLikelihood'];
+  }
+}
+
 function mapJob(row: JobRow, analysisRow?: JobAnalysisRow, outreachRows: OutreachRow[] = []): JobRecord {
   return {
     id: row.id,
@@ -173,7 +182,7 @@ function mapJob(row: JobRow, analysisRow?: JobAnalysisRow, outreachRows: Outreac
     salaryMax: row.salary_max ?? null,
     salaryCurrency: row.salary_currency ?? null,
     seniority: (row.seniority as JobRecord['seniority']) ?? undefined,
-    sponsorLikelihood: (row.sponsor_likelihood as JobRecord['sponsorLikelihood']) ?? null,
+    sponsorLikelihood: parseSponsorLikelihood(row.sponsor_likelihood),
     contentHash: row.content_hash ?? null,
     lastSeenAt: toIsoString(row.last_seen_at),
     liveness: (row.liveness as JobRecord['liveness']) ?? 'active',
@@ -286,7 +295,12 @@ export async function createJob(userId: string, body: CreateJobBody): Promise<Jo
     });
   const lastSeenAt = body.lastSeenAt ?? timestamp;
   const liveness = body.liveness ?? 'active';
-  const sponsorLikelihood = body.sponsorLikelihood ?? null;
+  const sponsorLikelihood =
+    body.sponsorLikelihood !== undefined
+      ? body.sponsorLikelihood
+        ? JSON.stringify(body.sponsorLikelihood)
+        : null
+      : null;
 
   try {
     await client.query('begin');
@@ -879,7 +893,11 @@ export async function seedDemoData(userId: string): Promise<void> {
           job.salaryMax ?? null,
           job.salaryCurrency ?? null,
           job.seniority ?? null,
-          job.sponsorLikelihood ?? null,
+          job.sponsorLikelihood
+            ? typeof job.sponsorLikelihood === 'object'
+              ? JSON.stringify(job.sponsorLikelihood)
+              : job.sponsorLikelihood
+            : null,
           job.contentHash ?? null,
           job.lastSeenAt ?? job.discoveredAt,
           job.liveness ?? 'active',

--- a/apps/api/src/lib/discovery.test.ts
+++ b/apps/api/src/lib/discovery.test.ts
@@ -351,3 +351,22 @@ test('deduplicates jobs across multiple sources by URL: duplicate URL inserts on
   assert.equal(created[0]?.jobUrl, 'https://shared/1');
   assert.equal(created[1]?.jobUrl, 'https://unique/2');
 });
+
+test('passes sponsorLikelihood to createJob when lookupSponsor returns a known sponsor', async () => {
+  const { deps, created } = makeDeps([sourced('https://x/sponsor', { company: 'Acme Corp' })], []);
+  deps.lookupSponsor = async (company: string) => {
+    if (company === 'Acme Corp') {
+      return { status: 'known_sponsor', approvals: 10, denials: 1 };
+    }
+    return null;
+  };
+
+  await runDiscoveryForUser('u', deps);
+
+  assert.equal(created.length, 1);
+  assert.deepEqual(created[0]?.sponsorLikelihood, {
+    status: 'known_sponsor',
+    approvals: 10,
+    denials: 1,
+  });
+});

--- a/apps/api/src/lib/discovery.ts
+++ b/apps/api/src/lib/discovery.ts
@@ -8,7 +8,7 @@ import { prerankAnalysis } from '@/lib/local-fit';
 import type { JobSource } from '@/lib/job-sources';
 import { dedupKey, fingerprintKey, type SourcedJob } from '@/lib/job-sources/normalize';
 import { fetchTargetCompanyBoards } from '@/lib/job-sources/boards';
-import type { TargetCompany } from '@/types';
+import type { SponsorLikelihood, TargetCompany } from '@/types';
 
 export interface DiscoveryResult {
   inserted: number;
@@ -26,6 +26,7 @@ export interface DiscoveryDeps {
   saveAnalysis: typeof saveJobAnalysisStore;
   listTargetCompanies?: (userId: string) => Promise<TargetCompany[]>;
   fetchBoards?: typeof fetchTargetCompanyBoards;
+  lookupSponsor?: (company: string) => Promise<SponsorLikelihood | null>;
 }
 
 /**
@@ -83,7 +84,11 @@ export async function runDiscoveryForUser(userId: string, deps: DiscoveryDeps): 
     // copy in the same run is recognised as a duplicate.
     for (const k of keysFor(job)) seen.add(k);
     try {
-      const createdJob = await deps.createJob(userId, job);
+      const sponsor = deps.lookupSponsor ? await deps.lookupSponsor(job.company) : null;
+      const createdJob = await deps.createJob(userId, {
+        ...job,
+        sponsorLikelihood: sponsor ?? job.sponsorLikelihood,
+      });
       inserted += 1;
       // Pre-rank is best-effort: the job is already inserted and counted, so a
       // transient failure persisting the estimated fit must not abort the whole

--- a/apps/api/src/lib/sponsorship.test.ts
+++ b/apps/api/src/lib/sponsorship.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeEmployerName, lookupSponsorLikelihood } from './sponsorship';
+
+test('normalizeEmployerName strips punctuation and one suffix', () => {
+  assert.equal(normalizeEmployerName('Google, LLC'), 'google');
+});
+
+test('normalizeEmployerName strips stacked suffixes', () => {
+  assert.equal(normalizeEmployerName('Acme Holdings LLC'), 'acme');
+});
+
+test('normalizeEmployerName maps & to and', () => {
+  assert.equal(normalizeEmployerName('Ernst & Young U.S. LLP'), 'ernst and young');
+});
+
+test('normalizeEmployerName never empties a name made of suffix words', () => {
+  assert.equal(normalizeEmployerName('CO Inc'), 'co');
+});
+
+test('normalizeEmployerName collapses whitespace and case', () => {
+  assert.equal(normalizeEmployerName('  MICROSOFT   CORPORATION '), 'microsoft');
+});
+
+test('lookupSponsorLikelihood returns null when pool is null', async () => {
+  const originalUrl = process.env.DATABASE_URL;
+  delete process.env.DATABASE_URL;
+  try {
+    const result = await lookupSponsorLikelihood('Google');
+    assert.equal(result, null);
+  } finally {
+    if (originalUrl !== undefined) {
+      process.env.DATABASE_URL = originalUrl;
+    }
+  }
+});
+
+test('lookupSponsorLikelihood returns null when company is empty', async () => {
+  const result = await lookupSponsorLikelihood('');
+  assert.equal(result, null);
+
+  const whitespaceResult = await lookupSponsorLikelihood('   ');
+  assert.equal(whitespaceResult, null);
+});
+
+test('lookupSponsorLikelihood returns known_sponsor when filings exist', async () => {
+  const mockPool = {
+    query: async () => ({
+      rows: [{ approvals: 42, denials: 3 }],
+      rowCount: 1,
+    }),
+  } as unknown as import('pg').Pool;
+
+  const result = await lookupSponsorLikelihood('Google, LLC', mockPool);
+  assert.deepEqual(result, {
+    status: 'known_sponsor',
+    approvals: 42,
+    denials: 3,
+  });
+});
+
+test('lookupSponsorLikelihood returns null when total filings sum to zero', async () => {
+  const mockPool = {
+    query: async () => ({
+      rows: [{ approvals: 0, denials: 0 }],
+      rowCount: 1,
+    }),
+  } as unknown as import('pg').Pool;
+
+  const result = await lookupSponsorLikelihood('Unknown Startup LLC', mockPool);
+  assert.equal(result, null);
+});

--- a/apps/api/src/lib/sponsorship.ts
+++ b/apps/api/src/lib/sponsorship.ts
@@ -1,0 +1,105 @@
+import { getPool } from '@/lib/postgres';
+import type { Pool } from 'pg';
+import type { SponsorLikelihood } from '@/types';
+
+export const CORPORATE_SUFFIXES: readonly string[] = [
+  'llc',
+  'inc',
+  'incorporated',
+  'corp',
+  'corporation',
+  'co',
+  'company',
+  'ltd',
+  'limited',
+  'llp',
+  'lp',
+  'pllc',
+  'pc',
+  'holdings',
+  'holding',
+  'group',
+  'services',
+  'technologies',
+  'technology',
+  'solutions',
+  'consulting',
+  'usa',
+  'us',
+  'na',
+  'america',
+];
+
+export function normalizeEmployerName(name: string): string {
+  if (!name || typeof name !== 'string') {
+    return '';
+  }
+
+  let normalized = name.toLowerCase().replace(/&/g, ' and ');
+  normalized = normalized.replace(/\./g, '');
+  normalized = normalized.replace(/[^a-z0-9\s]/g, ' ');
+
+  const tokens = normalized.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
+    return '';
+  }
+
+  const suffixSet = new Set(CORPORATE_SUFFIXES);
+  while (tokens.length > 1 && suffixSet.has(tokens[tokens.length - 1]!)) {
+    tokens.pop();
+  }
+
+  return tokens.join(' ');
+}
+
+export const LOOKBACK_YEARS = 3;
+
+export async function lookupSponsorLikelihood(
+  company: string,
+  poolOverride?: Pool | null,
+): Promise<SponsorLikelihood | null> {
+  try {
+    if (!company || !company.trim()) {
+      return null;
+    }
+
+    const pool = poolOverride !== undefined ? poolOverride : getPool();
+    if (!pool) {
+      return null;
+    }
+
+    const normalized = normalizeEmployerName(company);
+    if (!normalized) {
+      return null;
+    }
+
+    const { rows } = await pool.query<{ approvals: number | string; denials: number | string }>(
+      `select
+        coalesce(sum(approvals), 0)::int as approvals,
+        coalesce(sum(denials), 0)::int as denials
+      from h1b_sponsors
+      where employer_name_normalized = $1
+        and fiscal_year >= (select coalesce(max(fiscal_year), 0) from h1b_sponsors) - $2`,
+      [normalized, LOOKBACK_YEARS - 1],
+    );
+
+    if (!rows || rows.length === 0) {
+      return null;
+    }
+
+    const approvals = Number(rows[0]?.approvals ?? 0);
+    const denials = Number(rows[0]?.denials ?? 0);
+
+    if (approvals + denials > 0) {
+      return {
+        status: 'known_sponsor',
+        approvals,
+        denials,
+      };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -8,6 +8,7 @@ import { getJobSources } from '@/lib/job-sources';
 import { fetchTargetCompanyBoards } from '@/lib/job-sources/boards';
 import { requireN8nWebhookSecret } from '@/lib/n8n';
 import { runDiscoveryForUser, type DiscoveryResult } from '@/lib/discovery';
+import { lookupSponsorLikelihood } from '@/lib/sponsorship';
 
 export interface DiscoveryRouterDeps {
   runDiscovery: (userId: string) => Promise<DiscoveryResult>;
@@ -26,6 +27,7 @@ const defaultDeps: DiscoveryRouterDeps = {
       saveAnalysis: saveJobAnalysis,
       listTargetCompanies,
       fetchBoards: fetchTargetCompanyBoards,
+      lookupSponsor: lookupSponsorLikelihood,
     }),
   listUsersWithSavedSearches,
   listSweepUsers: async () => {

--- a/apps/api/src/routes/jobs.test.ts
+++ b/apps/api/src/routes/jobs.test.ts
@@ -76,6 +76,30 @@ test('POST /api/jobs accepts and returns enriched schema fields', async () => {
       assert.equal(data.job.liveness, 'active');
       assert.match(data.job.contentHash ?? '', /^[0-9a-f]{64}$/);
     });
+
+    await withServer((app) => app.use('/api/jobs', jobsRouter), async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/jobs`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-User-Id': 'test-user',
+        },
+        body: JSON.stringify({
+          company: 'Acme AI',
+          title: 'Staff Engineer',
+          descriptionText: 'Staff level cloud distributed systems.',
+          sponsorLikelihood: { status: 'known_sponsor', approvals: 15, denials: 2 },
+        }),
+      });
+
+      assert.equal(response.status, 201);
+      const data = (await response.json()) as { job: JobRecord };
+      assert.deepEqual(data.job.sponsorLikelihood, {
+        status: 'known_sponsor',
+        approvals: 15,
+        denials: 2,
+      });
+    });
   } finally {
     process.chdir(originalCwd);
     resetJobStoreForTests();

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -14,7 +14,6 @@ import type {
   JobPriority,
   JobSeniority,
   JobStatus,
-  SponsorLikelihood,
   UpdateJobBody,
 } from '@/types';
 
@@ -22,7 +21,7 @@ export const jobsRouter = Router();
 
 const allowedPriorities = new Set<JobPriority>(['high', 'medium', 'low']);
 const allowedSeniorities = new Set<JobSeniority>(['junior', 'mid', 'senior', 'lead', 'unknown']);
-const allowedSponsorLikelihoods = new Set<SponsorLikelihood>(['likely', 'possible', 'unlikely', 'unknown']);
+const allowedSponsorLikelihoodStrings = new Set<string>(['likely', 'possible', 'unlikely', 'unknown']);
 const allowedLivenesses = new Set<JobLiveness>(['active', 'stale', 'expired']);
 const allowedStatuses = new Set<JobStatus>([
   'discovered',
@@ -97,8 +96,30 @@ jobsRouter.post('/', async (request, response, next) => {
     if (body.seniority && !allowedSeniorities.has(body.seniority)) {
       errors.seniority = 'Seniority must be junior, mid, senior, lead, or unknown.';
     }
-    if (body.sponsorLikelihood && !allowedSponsorLikelihoods.has(body.sponsorLikelihood)) {
-      errors.sponsorLikelihood = 'Sponsor likelihood must be likely, possible, unlikely, or unknown.';
+    if (body.sponsorLikelihood) {
+      if (typeof body.sponsorLikelihood === 'string') {
+        if (!allowedSponsorLikelihoodStrings.has(body.sponsorLikelihood)) {
+          errors.sponsorLikelihood = 'Sponsor likelihood must be likely, possible, unlikely, or unknown.';
+        }
+      } else if (
+        typeof body.sponsorLikelihood === 'object' &&
+        body.sponsorLikelihood !== null
+      ) {
+        const s = body.sponsorLikelihood as { status?: unknown; approvals?: unknown; denials?: unknown };
+        if (
+          s.status !== 'known_sponsor' ||
+          typeof s.approvals !== 'number' ||
+          typeof s.denials !== 'number' ||
+          Number.isNaN(s.approvals) ||
+          Number.isNaN(s.denials)
+        ) {
+          errors.sponsorLikelihood =
+            'Sponsor likelihood object must have status "known_sponsor" with numeric approvals and denials.';
+        }
+      } else {
+        errors.sponsorLikelihood =
+          'Sponsor likelihood must be a valid status string or known_sponsor object.';
+      }
     }
     if (body.liveness && !allowedLivenesses.has(body.liveness)) {
       errors.liveness = 'Liveness must be active, stale, or expired.';

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -16,7 +16,18 @@ export type JobPriority = 'high' | 'medium' | 'low';
 export type JobWorkplaceType = 'remote' | 'hybrid' | 'onsite' | 'flexible';
 
 export type JobSeniority = 'junior' | 'mid' | 'senior' | 'lead' | 'unknown';
-export type SponsorLikelihood = 'likely' | 'possible' | 'unlikely' | 'unknown';
+export interface KnownSponsorLikelihood {
+  status: 'known_sponsor';
+  approvals: number;
+  denials: number;
+}
+
+export type SponsorLikelihood =
+  | 'likely'
+  | 'possible'
+  | 'unlikely'
+  | 'unknown'
+  | KnownSponsorLikelihood;
 export type JobLiveness = 'active' | 'stale' | 'expired';
 
 export type MessageType =

--- a/apps/web/src/types/job.ts
+++ b/apps/web/src/types/job.ts
@@ -23,7 +23,18 @@ export type OutreachMessageType =
 export type JobPriority = 'high' | 'medium' | 'low';
 export type WorkplaceType = 'remote' | 'hybrid' | 'onsite' | 'flexible';
 export type JobSeniority = 'junior' | 'mid' | 'senior' | 'lead' | 'unknown';
-export type SponsorLikelihood = 'likely' | 'possible' | 'unlikely' | 'unknown';
+export interface KnownSponsorLikelihood {
+  status: 'known_sponsor';
+  approvals: number;
+  denials: number;
+}
+
+export type SponsorLikelihood =
+  | 'likely'
+  | 'possible'
+  | 'unlikely'
+  | 'unknown'
+  | KnownSponsorLikelihood;
 export type JobLiveness = 'active' | 'stale' | 'expired';
 
 export interface JobAnalysis {

--- a/db/migrations/015_h1b_sponsors.sql
+++ b/db/migrations/015_h1b_sponsors.sql
@@ -1,0 +1,19 @@
+-- USCIS H-1B Employer Data Hub snapshot (Jobright-parity Epic 2, spec §5/§7).
+-- Global reference data (no user_id): one row per (employer, fiscal year),
+-- aggregated across the per-state/NAICS rows of the USCIS export.
+create table if not exists h1b_sponsors (
+  id bigint generated always as identity primary key,
+  employer_name text not null,
+  employer_name_normalized text not null,
+  fiscal_year integer not null,
+  approvals integer not null default 0,
+  denials integer not null default 0,
+  created_at timestamptz not null default now()
+);
+
+create unique index if not exists h1b_sponsors_employer_year_unique_idx
+  on h1b_sponsors (employer_name_normalized, fiscal_year);
+create index if not exists h1b_sponsors_normalized_idx
+  on h1b_sponsors (employer_name_normalized);
+
+alter table jobs alter column sponsor_likelihood type text;

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -150,7 +150,7 @@ agent image, list pagination, and an opt-in Postgres-backed rate-limiter/cache f
 
 ## What Is Still Pending
 
-- **Jobright Parity Program (Epic #244 — Agent platform foundation):** Epic 1 is complete (#251–#257). Epic 2 (Discovery & Feed Curation) is underway: shipped enriched jobs schema and normalization (#258) with salary range parsing, seniority inference, content hashing, and liveness tracking (migration 013), target_companies watchlist table, CRUD, and settings UI (#260, migration 014), Greenhouse/Lever/Ashby board adapters wired into discovery (#261), and USAJobs + The Muse source adapters with Remotive fallback window fix and multi-source discovery (#259). Specialist agent graph implementations (remaining Epics 2, 4, 5, 6) remain pending.
+- **Jobright Parity Program (Epic #244 — Agent platform foundation):** Epic 1 is complete (#251–#257). Epic 2 (Discovery & Feed Curation) is underway: shipped enriched jobs schema and normalization (#258) with salary range parsing, seniority inference, content hashing, and liveness tracking (migration 013), target_companies watchlist table, CRUD, and settings UI (#260, migration 014), Greenhouse/Lever/Ashby board adapters wired into discovery (#261), USAJobs + The Muse source adapters with Remotive fallback window fix and multi-source discovery (#259), and USCIS H-1B Employer Data Hub import with `h1b_sponsors` reference table and `sponsor_likelihood` matching (#262, migration 015). Specialist agent graph implementations (remaining Epics 2, 4, 5, 6) remain pending.
 - Nothing blocking. All planned phases (0–11) plus the optional Phase 6
   hardening (App Insights, Key Vault) are complete. The agent Container App
   keeps its native secret store by design (Key Vault covers App Service only).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "0.1.0",
       "workspaces": [
         "apps/*"
-      ]
+      ],
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "apps/api": {
       "name": "@jobops/api",
@@ -37,11 +40,15 @@
         "@types/node": "^22.0.0",
         "@types/pdf-parse": "^1.1.4",
         "@types/pg": "^8.20.0",
+        "csv-parse": "^7.0.2",
         "eslint": "^9.0.0",
         "tsc-alias": "^1.9.1",
         "tsx": "^4.23.1",
         "typescript": "^5.8.0",
         "typescript-eslint": "^8.65.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "apps/api/node_modules/undici": {
@@ -238,6 +245,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
       "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -299,6 +307,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
       "integrity": "sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -695,6 +704,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1347,6 +1357,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1395,6 +1406,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1559,6 +1571,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3150,6 +3163,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3246,6 +3260,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4146,6 +4161,7 @@
       "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.61.1"
       },
@@ -4682,9 +4698,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4702,9 +4715,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4722,9 +4732,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4742,9 +4749,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4782,27 +4786,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -4943,6 +4926,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5367,6 +5351,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5377,6 +5362,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5459,6 +5445,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -6190,6 +6177,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6823,6 +6811,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7353,6 +7342,13 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/csv-parse": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-7.0.2.tgz",
+      "integrity": "sha512-uKZghv9UmPkMVLYy//KZ9HFAIJsl7wkhoEdIL0+rhuSY9pZQlhaeGEDPIe+/w7eh81MOql8Q/9+inAGWG6ZHYA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -7410,6 +7406,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8225,6 +8222,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8410,6 +8408,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8728,6 +8727,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9559,6 +9559,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
       "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11337,6 +11338,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.11.tgz",
       "integrity": "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.11",
         "@swc/helpers": "0.5.15",
@@ -11965,6 +11967,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -12112,6 +12115,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12428,6 +12432,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12437,6 +12442,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13837,6 +13843,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14173,6 +14180,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14383,6 +14391,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -15037,6 +15046,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Closes #262 (Epic #245 — Feed Engine).

### Summary of Changes

1. **Database Migration (`db/migrations/015_h1b_sponsors.sql`)**:
   - Creates global reference table `h1b_sponsors` with columns `id`, `employer_name`, `employer_name_normalized`, `fiscal_year`, `approvals`, `denials`, and `created_at`.
   - Adds unique index on `(employer_name_normalized, fiscal_year)` and lookup index on `(employer_name_normalized)`.
   - Alters `jobs.sponsor_likelihood` to `text` to accommodate JSON-serialized `{ status: 'known_sponsor', approvals, denials }` payloads.

2. **Employer Normalization & Sponsorship Lookup (`apps/api/src/lib/sponsorship.ts`)**:
   - `normalizeEmployerName(name)`: strips punctuation, maps `&` to `and`, normalizes whitespace/case, and repeatedly strips stacked trailing corporate suffixes (`llc`, `inc`, `corp`, `holdings`, `group`, etc.) while protecting suffix-only names (e.g. `'CO Inc'` -> `'co'`).
   - `lookupSponsorLikelihood(company)`: exact normalized lookup over the last 3 fiscal years present in `h1b_sponsors` (`(select coalesce(max(fiscal_year), 0) from h1b_sponsors) - 2`), returning `{ status: 'known_sponsor', approvals, denials }` when positive filings exist. Fails closed (returns `null`) on missing pool, empty string, zero filings, or query error.

3. **USCIS H-1B CSV Import Script (`apps/api/scripts/import-h1b.ts`)**:
   - Local CSV parsing with `csv-parse/sync` (BOM and relax column count handling).
   - Case-insensitive header matching for fiscal year, employer name, and approval/denial counts.
   - Aggregates multi-state rows per `(employerNameNormalized, fiscalYear)`.
   - Batch upsert into `h1b_sponsors` (500 records per batch) with `ON CONFLICT DO UPDATE`.
   - Backfills existing `jobs` with `sponsor_likelihood` JSON payloads for matching companies.

4. **Types & Job Stores Integration**:
   - Extended `SponsorLikelihood` in `apps/api/src/types.ts` and `apps/web/src/types/job.ts` with `KnownSponsorLikelihood`.
   - Updated `job-store.postgres.ts` and in-memory store to serialize `sponsorLikelihood` on `createJob` and safely parse it on read.
   - In `apps/api/src/lib/discovery.ts`, `insertIfNew` enriches jobs with `deps.lookupSponsor(job.company)` and preserves pre-existing signals.
   - Wired `lookupSponsor: lookupSponsorLikelihood` into `routes/discovery.ts`.

5. **Testing & Verification**:
   - Unit tests in `sponsorship.test.ts` (normalization edge cases + mock pool queries) and `import-h1b.test.ts` (header resolution + row aggregation).
   - Integration test in `discovery.test.ts` verifying `lookupSponsor` enrichment.
   - 336 API unit tests pass. Full `npm run check` (monorepo lint + typecheck + Next.js build + API build) clean.
